### PR TITLE
Add self-update command with automatic update notifications and versi…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ cli/
 │   ├── deps.ts             # Dependency management command (engine-agnostic)
 │   ├── engines.ts          # Engine list and delete commands
 │   ├── edit.ts             # Container rename/port editing
-│   └── url.ts              # Connection string output
+│   ├── url.ts              # Connection string output
+│   ├── self-update.ts      # Self-update command
+│   └── version.ts          # Version info and update check command
 └── ui/
     ├── prompts.ts          # Inquirer prompts
     ├── spinner.ts          # Ora spinner helpers

--- a/README.md
+++ b/README.md
@@ -18,11 +18,23 @@ Spin up local PostgreSQL and MySQL databases without Docker. A lightweight alter
 ## Installation
 
 ```bash
-# Run directly with pnpx (no install needed)
-pnpx spindb
+# Install globally (recommended)
+npm install -g spindb
 
-# Or install globally
-pnpm add -g spindb
+# Or run directly with pnpx (no install needed)
+pnpx spindb
+```
+
+### Updating
+
+SpinDB checks for updates automatically and will notify you when a new version is available:
+
+```bash
+# Update to latest version
+spindb self-update
+
+# Or check manually
+spindb version --check
 ```
 
 ## Quick Start
@@ -61,6 +73,10 @@ spindb connect mydb
 | `spindb config detect` | Auto-detect database tools |
 | `spindb deps check` | Check status of client tools |
 | `spindb deps install` | Install missing client tools |
+| `spindb version` | Show current version |
+| `spindb version --check` | Check for available updates |
+| `spindb self-update` | Update to latest version |
+| `spindb config update-check [on\|off]` | Enable/disable update notifications |
 
 ## Supported Engines
 

--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@ Similar to ngrok - free tier for individual developers with core functionality, 
 ### Advanced Features
 - [ ] **Container templates** - Save container configs as reusable templates
 - [ ] **Import from Docker** - Import data from Docker PostgreSQL/MySQL containers
-- [ ] **Automatic binary updates** - Check for and download newer PostgreSQL versions
+- [x] **Self-update** - `spindb self-update` command with automatic update notifications on startup
 - [ ] **User management** - Support for custom usernames, passwords, and additional database users
   - Custom superuser name (instead of default `postgres`/`root`)
   - Set password on container creation

--- a/cli/commands/backup.ts
+++ b/cli/commands/backup.ts
@@ -51,7 +51,10 @@ export const backupCommand = new Command('backup')
   .argument('[container]', 'Container name')
   .option('-d, --database <name>', 'Database to backup')
   .option('-n, --name <name>', 'Custom backup filename (without extension)')
-  .option('-o, --output <path>', 'Output directory (defaults to current directory)')
+  .option(
+    '-o, --output <path>',
+    'Output directory (defaults to current directory)',
+  )
   .option('--format <format>', 'Output format: sql or dump')
   .option('--sql', 'Output as plain SQL (shorthand for --format sql)')
   .option('--dump', 'Output as dump format (shorthand for --format dump)')
@@ -198,7 +201,10 @@ export const backupCommand = new Command('backup')
         }
 
         // Determine filename
-        const defaultFilename = generateDefaultFilename(containerName, databaseName)
+        const defaultFilename = generateDefaultFilename(
+          containerName,
+          databaseName,
+        )
         let filename = options.name || defaultFilename
 
         // In interactive mode with no name provided, optionally prompt for custom name
@@ -229,17 +235,17 @@ export const backupCommand = new Command('backup')
         console.log(success('Backup complete'))
         console.log()
         console.log(chalk.gray('  File:'), chalk.cyan(result.path))
-        console.log(chalk.gray('  Size:'), chalk.white(formatBytes(result.size)))
+        console.log(
+          chalk.gray('  Size:'),
+          chalk.white(formatBytes(result.size)),
+        )
         console.log(chalk.gray('  Format:'), chalk.white(result.format))
         console.log()
       } catch (err) {
         const e = err as Error
 
         // Check if this is a missing tool error
-        const missingToolPatterns = [
-          'pg_dump not found',
-          'mysqldump not found',
-        ]
+        const missingToolPatterns = ['pg_dump not found', 'mysqldump not found']
 
         const matchingPattern = missingToolPatterns.find((p) =>
           e.message.includes(p),

--- a/cli/commands/connect.ts
+++ b/cli/commands/connect.ts
@@ -26,9 +26,15 @@ export const connectCommand = new Command('connect')
   .option('-d, --database <name>', 'Database name')
   .option('--tui', 'Use usql for enhanced shell experience')
   .option('--install-tui', 'Install usql if not present, then connect')
-  .option('--pgcli', 'Use pgcli for enhanced PostgreSQL shell (dropdown auto-completion)')
+  .option(
+    '--pgcli',
+    'Use pgcli for enhanced PostgreSQL shell (dropdown auto-completion)',
+  )
   .option('--install-pgcli', 'Install pgcli if not present, then connect')
-  .option('--mycli', 'Use mycli for enhanced MySQL shell (dropdown auto-completion)')
+  .option(
+    '--mycli',
+    'Use mycli for enhanced MySQL shell (dropdown auto-completion)',
+  )
   .option('--install-mycli', 'Install mycli if not present, then connect')
   .action(
     async (
@@ -164,7 +170,9 @@ export const connectCommand = new Command('connect')
         const usePgcli = options.pgcli || options.installPgcli
         if (usePgcli) {
           if (engineName !== 'postgresql') {
-            console.error(error('pgcli is only available for PostgreSQL containers'))
+            console.error(
+              error('pgcli is only available for PostgreSQL containers'),
+            )
             console.log(chalk.gray('For MySQL, use: spindb connect --mycli'))
             process.exit(1)
           }
@@ -173,7 +181,9 @@ export const connectCommand = new Command('connect')
 
           if (!pgcliInstalled) {
             if (options.installPgcli) {
-              console.log(info('Installing pgcli for enhanced PostgreSQL shell...'))
+              console.log(
+                info('Installing pgcli for enhanced PostgreSQL shell...'),
+              )
               const pm = await detectPackageManager()
               if (pm) {
                 const result = await installPgcli(pm)
@@ -181,7 +191,9 @@ export const connectCommand = new Command('connect')
                   console.log(success('pgcli installed successfully!'))
                   console.log()
                 } else {
-                  console.error(error(`Failed to install pgcli: ${result.error}`))
+                  console.error(
+                    error(`Failed to install pgcli: ${result.error}`),
+                  )
                   console.log()
                   console.log(chalk.gray('Manual installation:'))
                   for (const instruction of getPgcliManualInstructions()) {
@@ -201,7 +213,9 @@ export const connectCommand = new Command('connect')
             } else {
               console.error(error('pgcli is not installed'))
               console.log()
-              console.log(chalk.gray('Install pgcli for enhanced PostgreSQL shell:'))
+              console.log(
+                chalk.gray('Install pgcli for enhanced PostgreSQL shell:'),
+              )
               console.log(chalk.cyan('  spindb connect --install-pgcli'))
               console.log()
               console.log(chalk.gray('Or install manually:'))
@@ -218,7 +232,9 @@ export const connectCommand = new Command('connect')
         if (useMycli) {
           if (engineName !== 'mysql') {
             console.error(error('mycli is only available for MySQL containers'))
-            console.log(chalk.gray('For PostgreSQL, use: spindb connect --pgcli'))
+            console.log(
+              chalk.gray('For PostgreSQL, use: spindb connect --pgcli'),
+            )
             process.exit(1)
           }
 
@@ -234,7 +250,9 @@ export const connectCommand = new Command('connect')
                   console.log(success('mycli installed successfully!'))
                   console.log()
                 } else {
-                  console.error(error(`Failed to install mycli: ${result.error}`))
+                  console.error(
+                    error(`Failed to install mycli: ${result.error}`),
+                  )
                   console.log()
                   console.log(chalk.gray('Manual installation:'))
                   for (const instruction of getMycliManualInstructions()) {
@@ -327,7 +345,9 @@ export const connectCommand = new Command('connect')
 
             if (clientCmd === 'usql') {
               console.log(chalk.gray('  Install usql:'))
-              console.log(chalk.cyan('  brew tap xo/xo && brew install xo/xo/usql'))
+              console.log(
+                chalk.cyan('  brew tap xo/xo && brew install xo/xo/usql'),
+              )
             } else if (clientCmd === 'pgcli') {
               console.log(chalk.gray('  Install pgcli:'))
               console.log(chalk.cyan('  brew install pgcli'))

--- a/cli/commands/list.ts
+++ b/cli/commands/list.ts
@@ -85,8 +85,7 @@ export const listCommand = new Command('list')
         const engineDisplay = `${engineIcon} ${container.engine}`
 
         // Format size: show value if running, dash if stopped
-        const sizeDisplay =
-          size !== null ? formatBytes(size) : chalk.gray('—')
+        const sizeDisplay = size !== null ? formatBytes(size) : chalk.gray('—')
 
         console.log(
           chalk.gray('  ') +

--- a/cli/commands/version.ts
+++ b/cli/commands/version.ts
@@ -1,0 +1,55 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import { updateManager } from '../../core/update-manager'
+import { createSpinner } from '../ui/spinner'
+
+export const versionCommand = new Command('version')
+  .description('Show version information and check for updates')
+  .option('-c, --check', 'Check for available updates')
+  .option('-j, --json', 'Output as JSON')
+  .action(
+    async (options: { check?: boolean; json?: boolean }): Promise<void> => {
+      const currentVersion = updateManager.getCurrentVersion()
+
+      if (options.check) {
+        const spinner = createSpinner('Checking for updates...')
+        if (!options.json) spinner.start()
+
+        const result = await updateManager.checkForUpdate(true)
+
+        if (!options.json) spinner.stop()
+
+        if (options.json) {
+          console.log(
+            JSON.stringify({
+              current: currentVersion,
+              latest: result?.latestVersion || null,
+              updateAvailable: result?.updateAvailable || false,
+            }),
+          )
+        } else {
+          console.log()
+          console.log(`SpinDB v${currentVersion}`)
+          if (result) {
+            if (result.updateAvailable) {
+              console.log(
+                chalk.yellow(`Update available: v${result.latestVersion}`),
+              )
+              console.log(chalk.gray("Run 'spindb self-update' to update."))
+            } else {
+              console.log(chalk.green('You are on the latest version.'))
+            }
+          } else {
+            console.log(chalk.gray('Could not check for updates (offline?)'))
+          }
+          console.log()
+        }
+      } else {
+        if (options.json) {
+          console.log(JSON.stringify({ current: currentVersion }))
+        } else {
+          console.log(`SpinDB v${currentVersion}`)
+        }
+      }
+    },
+  )

--- a/cli/ui/prompts.ts
+++ b/cli/ui/prompts.ts
@@ -251,7 +251,8 @@ export async function promptDatabaseName(
   engine?: string,
 ): Promise<string> {
   // MySQL uses "schema" terminology (database and schema are synonymous)
-  const label = engine === 'mysql' ? 'Database (schema) name:' : 'Database name:'
+  const label =
+    engine === 'mysql' ? 'Database (schema) name:' : 'Database name:'
 
   const { database } = await inquirer.prompt<{ database: string }>([
     {

--- a/core/config-manager.ts
+++ b/core/config-manager.ts
@@ -29,12 +29,7 @@ const POSTGRESQL_TOOLS: BinaryTool[] = [
   'pg_basebackup',
 ]
 
-const MYSQL_TOOLS: BinaryTool[] = [
-  'mysql',
-  'mysqldump',
-  'mysqladmin',
-  'mysqld',
-]
+const MYSQL_TOOLS: BinaryTool[] = ['mysql', 'mysqldump', 'mysqladmin', 'mysqld']
 
 const ENHANCED_SHELLS: BinaryTool[] = ['pgcli', 'mycli', 'usql']
 
@@ -359,9 +354,4 @@ export class ConfigManager {
 export const configManager = new ConfigManager()
 
 // Export tool categories for use in commands
-export {
-  POSTGRESQL_TOOLS,
-  MYSQL_TOOLS,
-  ENHANCED_SHELLS,
-  ALL_TOOLS,
-}
+export { POSTGRESQL_TOOLS, MYSQL_TOOLS, ENHANCED_SHELLS, ALL_TOOLS }

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -398,7 +398,9 @@ export class ContainerManager {
 
     // Don't remove the primary database from the array
     if (database === config.database) {
-      throw new Error(`Cannot remove primary database "${database}" from tracking`)
+      throw new Error(
+        `Cannot remove primary database "${database}" from tracking`,
+      )
     }
 
     if (config.databases) {

--- a/core/update-manager.ts
+++ b/core/update-manager.ts
@@ -1,0 +1,194 @@
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { createRequire } from 'module'
+import { configManager } from './config-manager'
+
+const execAsync = promisify(exec)
+const require = createRequire(import.meta.url)
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/spindb'
+const CHECK_THROTTLE_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+export type UpdateCheckResult = {
+  currentVersion: string
+  latestVersion: string
+  updateAvailable: boolean
+  lastChecked: string
+}
+
+export type UpdateResult = {
+  success: boolean
+  previousVersion: string
+  newVersion: string
+  error?: string
+}
+
+export class UpdateManager {
+  /**
+   * Get currently installed version from package.json
+   */
+  getCurrentVersion(): string {
+    const pkg = require('../package.json') as { version: string }
+    return pkg.version
+  }
+
+  /**
+   * Check npm registry for latest version
+   * Throttled to once per 24 hours unless force=true
+   */
+  async checkForUpdate(force = false): Promise<UpdateCheckResult | null> {
+    const config = await configManager.load()
+    const lastCheck = config.update?.lastCheck
+
+    // Return cached result if within throttle period
+    if (!force && lastCheck) {
+      const elapsed = Date.now() - new Date(lastCheck).getTime()
+      if (elapsed < CHECK_THROTTLE_MS && config.update?.latestVersion) {
+        const currentVersion = this.getCurrentVersion()
+        return {
+          currentVersion,
+          latestVersion: config.update.latestVersion,
+          updateAvailable:
+            this.compareVersions(config.update.latestVersion, currentVersion) >
+            0,
+          lastChecked: lastCheck,
+        }
+      }
+    }
+
+    try {
+      const latestVersion = await this.fetchLatestVersion()
+      const currentVersion = this.getCurrentVersion()
+
+      // Update cache
+      config.update = {
+        ...config.update,
+        lastCheck: new Date().toISOString(),
+        latestVersion,
+      }
+      await configManager.save()
+
+      return {
+        currentVersion,
+        latestVersion,
+        updateAvailable:
+          this.compareVersions(latestVersion, currentVersion) > 0,
+        lastChecked: new Date().toISOString(),
+      }
+    } catch {
+      // Offline or registry error - return null
+      return null
+    }
+  }
+
+  /**
+   * Perform self-update via npm
+   */
+  async performUpdate(): Promise<UpdateResult> {
+    const previousVersion = this.getCurrentVersion()
+
+    try {
+      // Execute npm install globally
+      await execAsync('npm install -g spindb@latest', { timeout: 60000 })
+
+      // Verify new version by checking what npm reports
+      const { stdout } = await execAsync('npm list -g spindb --json')
+      const npmData = JSON.parse(stdout) as {
+        dependencies?: { spindb?: { version?: string } }
+      }
+      const newVersion =
+        npmData.dependencies?.spindb?.version || previousVersion
+
+      return {
+        success: true,
+        previousVersion,
+        newVersion,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+
+      // Detect permission issues
+      if (message.includes('EACCES') || message.includes('permission')) {
+        return {
+          success: false,
+          previousVersion,
+          newVersion: previousVersion,
+          error: 'Permission denied. Try: sudo npm install -g spindb@latest',
+        }
+      }
+
+      return {
+        success: false,
+        previousVersion,
+        newVersion: previousVersion,
+        error: message,
+      }
+    }
+  }
+
+  /**
+   * Get cached update info (for showing notification without network call)
+   */
+  async getCachedUpdateInfo(): Promise<{
+    latestVersion?: string
+    autoCheckEnabled: boolean
+  }> {
+    const config = await configManager.load()
+    return {
+      latestVersion: config.update?.latestVersion,
+      autoCheckEnabled: config.update?.autoCheckEnabled !== false,
+    }
+  }
+
+  /**
+   * Set whether auto-update checks are enabled
+   */
+  async setAutoCheckEnabled(enabled: boolean): Promise<void> {
+    const config = await configManager.load()
+    config.update = {
+      ...config.update,
+      autoCheckEnabled: enabled,
+    }
+    await configManager.save()
+  }
+
+  /**
+   * Fetch latest version from npm registry
+   */
+  private async fetchLatestVersion(): Promise<string> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10000)
+
+    try {
+      const response = await fetch(NPM_REGISTRY_URL, {
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        throw new Error(`Registry returned ${response.status}`)
+      }
+      const data = (await response.json()) as {
+        'dist-tags': { latest: string }
+      }
+      return data['dist-tags'].latest
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  /**
+   * Compare semver versions
+   * Returns >0 if a > b, <0 if a < b, 0 if equal
+   */
+  compareVersions(a: string, b: string): number {
+    const partsA = a.split('.').map((n) => parseInt(n, 10) || 0)
+    const partsB = b.split('.').map((n) => parseInt(n, 10) || 0)
+
+    for (let i = 0; i < 3; i++) {
+      const diff = (partsA[i] || 0) - (partsB[i] || 0)
+      if (diff !== 0) return diff
+    }
+    return 0
+  }
+}
+
+export const updateManager = new UpdateManager()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Spin up local database containers without Docker. A DBngin-like CLI for PostgreSQL and MySQL.",
   "type": "module",
   "bin": {

--- a/types/index.ts
+++ b/types/index.ts
@@ -147,4 +147,10 @@ export type SpinDBConfig = {
   }
   // Last updated timestamp
   updatedAt?: string
+  // Self-update tracking
+  update?: {
+    lastCheck?: string // ISO timestamp of last npm registry check
+    latestVersion?: string // Latest version found from registry
+    autoCheckEnabled?: boolean // Default true, user can disable
+  }
 }


### PR DESCRIPTION
…on management

- Add `spindb self-update` command to update to latest version with confirmation prompts
- Add `spindb version` command with `--check` flag to manually check for updates
- Add `spindb config update-check [on|off]` to enable/disable automatic update notifications on startup
- Add update check option to interactive main menu with update/remind/disable choices
- Implement UpdateManager class with npm registry integration