### PR TITLE
Remove inline comments across CLI command files to improve code reada…

### DIFF
--- a/cli/commands/clone.ts
+++ b/cli/commands/clone.ts
@@ -16,7 +16,6 @@ export const cloneCommand = new Command('clone')
       let sourceName = source
       let targetName = target
 
-      // Interactive selection if no source provided
       if (!sourceName) {
         const containers = await containerManager.list()
         const stopped = containers.filter((c) => c.status !== 'running')
@@ -50,14 +49,12 @@ export const cloneCommand = new Command('clone')
         sourceName = selected
       }
 
-      // Check source exists
       const sourceConfig = await containerManager.getConfig(sourceName)
       if (!sourceConfig) {
         console.error(error(`Container "${sourceName}" not found`))
         process.exit(1)
       }
 
-      // Check source is stopped
       const running = await processManager.isRunning(sourceName, {
         engine: sourceConfig.engine,
       })
@@ -70,12 +67,10 @@ export const cloneCommand = new Command('clone')
         process.exit(1)
       }
 
-      // Get target name
       if (!targetName) {
         targetName = await promptContainerName(`${sourceName}-copy`)
       }
 
-      // Clone the container
       const cloneSpinner = createSpinner(
         `Cloning ${sourceName} to ${targetName}...`,
       )
@@ -85,7 +80,6 @@ export const cloneCommand = new Command('clone')
 
       cloneSpinner.succeed(`Cloned "${sourceName}" to "${targetName}"`)
 
-      // Get engine for connection string
       const engine = getEngine(newConfig.engine)
       const connectionString = engine.getConnectionString(newConfig)
 

--- a/cli/commands/delete.ts
+++ b/cli/commands/delete.ts
@@ -20,7 +20,6 @@ export const deleteCommand = new Command('delete')
       try {
         let containerName = name
 
-        // Interactive selection if no name provided
         if (!containerName) {
           const containers = await containerManager.list()
 
@@ -37,14 +36,12 @@ export const deleteCommand = new Command('delete')
           containerName = selected
         }
 
-        // Get container config
         const config = await containerManager.getConfig(containerName)
         if (!config) {
           console.error(error(`Container "${containerName}" not found`))
           process.exit(1)
         }
 
-        // Confirm deletion
         if (!options.yes) {
           const confirmed = await promptConfirm(
             `Are you sure you want to delete "${containerName}"? This cannot be undone.`,
@@ -56,13 +53,11 @@ export const deleteCommand = new Command('delete')
           }
         }
 
-        // Check if running
         const running = await processManager.isRunning(containerName, {
           engine: config.engine,
         })
         if (running) {
           if (options.force) {
-            // Stop the container first
             const stopSpinner = createSpinner(`Stopping ${containerName}...`)
             stopSpinner.start()
 
@@ -80,7 +75,6 @@ export const deleteCommand = new Command('delete')
           }
         }
 
-        // Delete the container
         const deleteSpinner = createSpinner(`Deleting ${containerName}...`)
         deleteSpinner.start()
 

--- a/cli/commands/edit.ts
+++ b/cli/commands/edit.ts
@@ -8,16 +8,10 @@ import { promptContainerSelect } from '../ui/prompts'
 import { createSpinner } from '../ui/spinner'
 import { error, warning, success } from '../ui/theme'
 
-/**
- * Validate container name format
- */
 function isValidName(name: string): boolean {
   return /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(name)
 }
 
-/**
- * Prompt for what to edit when no options provided
- */
 async function promptEditAction(): Promise<'name' | 'port' | null> {
   const { action } = await inquirer.prompt<{ action: string }>([
     {
@@ -36,9 +30,6 @@ async function promptEditAction(): Promise<'name' | 'port' | null> {
   return action as 'name' | 'port'
 }
 
-/**
- * Prompt for new container name
- */
 async function promptNewName(currentName: string): Promise<string | null> {
   const { newName } = await inquirer.prompt<{ newName: string }>([
     {
@@ -64,9 +55,6 @@ async function promptNewName(currentName: string): Promise<string | null> {
   return newName
 }
 
-/**
- * Prompt for new port
- */
 async function promptNewPort(currentPort: number): Promise<number | null> {
   const { newPort } = await inquirer.prompt<{ newPort: number }>([
     {
@@ -90,7 +78,6 @@ async function promptNewPort(currentPort: number): Promise<number | null> {
     return null
   }
 
-  // Double-check availability and warn (user already confirmed via validation)
   const portAvailable = await portManager.isPortAvailable(newPort)
   if (!portAvailable) {
     console.log(
@@ -116,7 +103,6 @@ export const editCommand = new Command('edit')
       try {
         let containerName = name
 
-        // Interactive selection if no name provided
         if (!containerName) {
           const containers = await containerManager.list()
 
@@ -133,14 +119,12 @@ export const editCommand = new Command('edit')
           containerName = selected
         }
 
-        // Get container config
         const config = await containerManager.getConfig(containerName)
         if (!config) {
           console.error(error(`Container "${containerName}" not found`))
           process.exit(1)
         }
 
-        // If no options provided, prompt for what to edit
         if (options.name === undefined && options.port === undefined) {
           const action = await promptEditAction()
           if (!action) return
@@ -162,9 +146,7 @@ export const editCommand = new Command('edit')
           }
         }
 
-        // Handle rename
         if (options.name) {
-          // Validate new name
           if (!isValidName(options.name)) {
             console.error(
               error(
@@ -174,7 +156,6 @@ export const editCommand = new Command('edit')
             process.exit(1)
           }
 
-          // Check if new name already exists
           const exists = await containerManager.exists(options.name, {
             engine: config.engine,
           })
@@ -183,7 +164,6 @@ export const editCommand = new Command('edit')
             process.exit(1)
           }
 
-          // Check if container is running
           const running = await processManager.isRunning(containerName, {
             engine: config.engine,
           })
@@ -196,7 +176,6 @@ export const editCommand = new Command('edit')
             process.exit(1)
           }
 
-          // Rename the container
           const spinner = createSpinner(
             `Renaming "${containerName}" to "${options.name}"...`,
           )
@@ -206,19 +185,15 @@ export const editCommand = new Command('edit')
 
           spinner.succeed(`Renamed "${containerName}" to "${options.name}"`)
 
-          // Update containerName for subsequent operations
           containerName = options.name
         }
 
-        // Handle port change
         if (options.port !== undefined) {
-          // Validate port
           if (options.port < 1 || options.port > 65535) {
             console.error(error('Port must be between 1 and 65535'))
             process.exit(1)
           }
 
-          // Check port availability (warning only)
           const portAvailable = await portManager.isPortAvailable(options.port)
           if (!portAvailable) {
             console.log(
@@ -228,7 +203,6 @@ export const editCommand = new Command('edit')
             )
           }
 
-          // Update the config
           const spinner = createSpinner(`Changing port to ${options.port}...`)
           spinner.start()
 

--- a/cli/commands/info.ts
+++ b/cli/commands/info.ts
@@ -9,17 +9,11 @@ import { error, info, header } from '../ui/theme'
 import { getEngineIcon } from '../constants'
 import type { ContainerConfig } from '../../types'
 
-/**
- * Format a date for display
- */
 function formatDate(dateString: string): string {
   const date = new Date(dateString)
   return date.toLocaleString()
 }
 
-/**
- * Get actual running status (not just config status)
- */
 async function getActualStatus(
   config: ContainerConfig,
 ): Promise<'running' | 'stopped'> {
@@ -29,9 +23,6 @@ async function getActualStatus(
   return running ? 'running' : 'stopped'
 }
 
-/**
- * Display info for a single container
- */
 async function displayContainerInfo(
   config: ContainerConfig,
   options: { json?: boolean },
@@ -109,15 +100,11 @@ async function displayContainerInfo(
   console.log()
 }
 
-/**
- * Display summary info for all containers
- */
 async function displayAllContainersInfo(
   containers: ContainerConfig[],
   options: { json?: boolean },
 ): Promise<void> {
   if (options.json) {
-    // Get actual status for all containers
     const containersWithStatus = await Promise.all(
       containers.map(async (config) => {
         const actualStatus = await getActualStatus(config)
@@ -142,7 +129,6 @@ async function displayAllContainersInfo(
   console.log(header('All Containers'))
   console.log()
 
-  // Table header
   console.log(
     chalk.gray('  ') +
       chalk.bold.white('NAME'.padEnd(18)) +
@@ -154,7 +140,6 @@ async function displayAllContainersInfo(
   )
   console.log(chalk.gray('  ' + '─'.repeat(78)))
 
-  // Table rows
   for (const container of containers) {
     const actualStatus = await getActualStatus(container)
     const statusDisplay =
@@ -178,7 +163,6 @@ async function displayAllContainersInfo(
 
   console.log()
 
-  // Summary
   const statusChecks = await Promise.all(
     containers.map((c) => getActualStatus(c)),
   )
@@ -192,7 +176,6 @@ async function displayAllContainersInfo(
   )
   console.log()
 
-  // Connection strings
   console.log(chalk.bold.white('  Connection Strings:'))
   console.log(chalk.gray('  ' + '─'.repeat(78)))
   for (const container of containers) {
@@ -221,7 +204,6 @@ export const infoCommand = new Command('info')
         return
       }
 
-      // If name provided, show single container
       if (name) {
         const config = await containerManager.getConfig(name)
         if (!config) {
@@ -232,7 +214,6 @@ export const infoCommand = new Command('info')
         return
       }
 
-      // If running interactively without name, ask if they want all or specific
       if (!options.json && process.stdout.isTTY && containers.length > 1) {
         const { choice } = await inquirer.prompt<{
           choice: string
@@ -262,7 +243,6 @@ export const infoCommand = new Command('info')
         return
       }
 
-      // Non-interactive or only one container: show all
       await displayAllContainersInfo(containers, options)
     } catch (err) {
       const e = err as Error

--- a/cli/commands/list.ts
+++ b/cli/commands/list.ts
@@ -6,9 +6,6 @@ import { info, error, formatBytes } from '../ui/theme'
 import { getEngineIcon } from '../constants'
 import type { ContainerConfig } from '../../types'
 
-/**
- * Get database size for a container (only if running)
- */
 async function getContainerSize(
   container: ContainerConfig,
 ): Promise<number | null> {
@@ -32,7 +29,6 @@ export const listCommand = new Command('list')
       const containers = await containerManager.list()
 
       if (options.json) {
-        // Include sizes in JSON output
         const containersWithSize = await Promise.all(
           containers.map(async (container) => ({
             ...container,
@@ -48,10 +44,8 @@ export const listCommand = new Command('list')
         return
       }
 
-      // Fetch sizes for running containers in parallel
       const sizes = await Promise.all(containers.map(getContainerSize))
 
-      // Table header
       console.log()
       console.log(
         chalk.gray('  ') +
@@ -64,7 +58,6 @@ export const listCommand = new Command('list')
       )
       console.log(chalk.gray('  ' + '─'.repeat(73)))
 
-      // Table rows
       for (let i = 0; i < containers.length; i++) {
         const container = containers[i]
         const size = sizes[i]
@@ -77,7 +70,6 @@ export const listCommand = new Command('list')
         const engineIcon = getEngineIcon(container.engine)
         const engineDisplay = `${engineIcon} ${container.engine}`
 
-        // Format size: show value if running, dash if stopped
         const sizeDisplay = size !== null ? formatBytes(size) : chalk.gray('—')
 
         console.log(
@@ -93,7 +85,6 @@ export const listCommand = new Command('list')
 
       console.log()
 
-      // Summary
       const running = containers.filter((c) => c.status === 'running').length
       const stopped = containers.filter((c) => c.status !== 'running').length
       console.log(

--- a/cli/commands/logs.ts
+++ b/cli/commands/logs.ts
@@ -7,12 +7,8 @@ import { paths } from '../../config/paths'
 import { promptContainerSelect } from '../ui/prompts'
 import { error, warning, info } from '../ui/theme'
 
-/**
- * Get the last N lines from a file content
- */
 function getLastNLines(content: string, n: number): string {
   const lines = content.split('\n')
-  // Filter empty trailing line if present
   const nonEmptyLines =
     lines[lines.length - 1] === '' ? lines.slice(0, -1) : lines
   return nonEmptyLines.slice(-n).join('\n')
@@ -32,7 +28,6 @@ export const logsCommand = new Command('logs')
       try {
         let containerName = name
 
-        // Interactive selection if no name provided
         if (!containerName) {
           const containers = await containerManager.list()
 
@@ -49,19 +44,16 @@ export const logsCommand = new Command('logs')
           containerName = selected
         }
 
-        // Get container config
         const config = await containerManager.getConfig(containerName)
         if (!config) {
           console.error(error(`Container "${containerName}" not found`))
           process.exit(1)
         }
 
-        // Get log file path
         const logPath = paths.getContainerLogPath(config.name, {
           engine: config.engine,
         })
 
-        // Check if log file exists
         if (!existsSync(logPath)) {
           console.log(
             info(
@@ -71,7 +63,6 @@ export const logsCommand = new Command('logs')
           return
         }
 
-        // Open in editor if requested
         if (options.editor) {
           const editorCmd = process.env.EDITOR || 'vi'
           const child = spawn(editorCmd, [logPath], {
@@ -91,14 +82,12 @@ export const logsCommand = new Command('logs')
           return
         }
 
-        // Follow mode using tail -f
         if (options.follow) {
           const lineCount = parseInt(options.lines || '50', 10)
           const child = spawn('tail', ['-n', String(lineCount), '-f', logPath], {
             stdio: 'inherit',
           })
 
-          // Handle SIGINT gracefully
           process.on('SIGINT', () => {
             child.kill('SIGTERM')
             process.exit(0)
@@ -110,7 +99,6 @@ export const logsCommand = new Command('logs')
           return
         }
 
-        // Default: read and output last N lines
         const lineCount = parseInt(options.lines || '50', 10)
         const content = await readFile(logPath, 'utf-8')
 

--- a/cli/commands/menu/engine-handlers.ts
+++ b/cli/commands/menu/engine-handlers.ts
@@ -40,7 +40,6 @@ export async function handleEngines(): Promise<void> {
     return
   }
 
-  // Separate PostgreSQL and MySQL
   const pgEngines = engines.filter(
     (e): e is InstalledPostgresEngine => e.engine === 'postgresql',
   )
@@ -48,10 +47,8 @@ export async function handleEngines(): Promise<void> {
     (e): e is InstalledMysqlEngine => e.engine === 'mysql',
   )
 
-  // Calculate total size for PostgreSQL
   const totalPgSize = pgEngines.reduce((acc, e) => acc + e.sizeBytes, 0)
 
-  // Table header
   console.log()
   console.log(
     chalk.gray('  ') +
@@ -62,7 +59,6 @@ export async function handleEngines(): Promise<void> {
   )
   console.log(chalk.gray('  ' + '─'.repeat(55)))
 
-  // PostgreSQL rows
   for (const engine of pgEngines) {
     const icon = getEngineIcon(engine.engine)
     const platformInfo = `${engine.platform}-${engine.arch}`
@@ -76,7 +72,6 @@ export async function handleEngines(): Promise<void> {
     )
   }
 
-  // MySQL row
   if (mysqlEngine) {
     const icon = ENGINE_ICONS.mysql
     const displayName = mysqlEngine.isMariaDB ? 'mariadb' : 'mysql'
@@ -92,7 +87,6 @@ export async function handleEngines(): Promise<void> {
 
   console.log(chalk.gray('  ' + '─'.repeat(55)))
 
-  // Summary
   console.log()
   if (pgEngines.length > 0) {
     console.log(
@@ -106,7 +100,6 @@ export async function handleEngines(): Promise<void> {
   }
   console.log()
 
-  // Menu options - only allow deletion of PostgreSQL engines
   const choices: MenuChoice[] = []
 
   for (const e of pgEngines) {
@@ -116,7 +109,6 @@ export async function handleEngines(): Promise<void> {
     })
   }
 
-  // MySQL info option (not disabled, shows info icon)
   if (mysqlEngine) {
     const displayName = mysqlEngine.isMariaDB ? 'MariaDB' : 'MySQL'
     choices.push({
@@ -145,14 +137,12 @@ export async function handleEngines(): Promise<void> {
   if (action.startsWith('delete:')) {
     const [, enginePath, engineName, engineVersion] = action.split(':')
     await handleDeleteEngine(enginePath, engineName, engineVersion)
-    // Return to engines menu
     await handleEngines()
   }
 
   if (action.startsWith('mysql-info:')) {
     const mysqldPath = action.replace('mysql-info:', '')
     await handleMysqlInfo(mysqldPath)
-    // Return to engines menu
     await handleEngines()
   }
 }
@@ -162,7 +152,6 @@ async function handleDeleteEngine(
   engineName: string,
   engineVersion: string,
 ): Promise<void> {
-  // Check if any container is using this engine version
   const containers = await containerManager.list()
   const usingContainers = containers.filter(
     (c) => c.engine === engineName && c.version === engineVersion,
@@ -216,21 +205,17 @@ async function handleDeleteEngine(
 async function handleMysqlInfo(mysqldPath: string): Promise<void> {
   console.clear()
 
-  // Get install info
   const installInfo = await getMysqlInstallInfo(mysqldPath)
   const displayName = installInfo.isMariaDB ? 'MariaDB' : 'MySQL'
 
-  // Get version
   const version = await getMysqlVersion(mysqldPath)
 
   console.log(header(`${displayName} Information`))
   console.log()
 
-  // Check for containers using MySQL
   const containers = await containerManager.list()
   const mysqlContainers = containers.filter((c) => c.engine === 'mysql')
 
-  // Track running containers for uninstall instructions
   const runningContainers: string[] = []
 
   if (mysqlContainers.length > 0) {
@@ -261,7 +246,6 @@ async function handleMysqlInfo(mysqldPath: string): Promise<void> {
     console.log()
   }
 
-  // Show installation details
   console.log(chalk.white('  Installation Details:'))
   console.log(chalk.gray('  ' + '─'.repeat(50)))
   console.log(
@@ -286,13 +270,11 @@ async function handleMysqlInfo(mysqldPath: string): Promise<void> {
   )
   console.log()
 
-  // Uninstall instructions
   console.log(chalk.white('  To uninstall:'))
   console.log(chalk.gray('  ' + '─'.repeat(50)))
 
   let stepNum = 1
 
-  // Step: Stop running containers first
   if (runningContainers.length > 0) {
     console.log(chalk.gray(`  # ${stepNum}. Stop running SpinDB containers`))
     console.log(chalk.cyan('  spindb stop <container-name>'))
@@ -300,7 +282,6 @@ async function handleMysqlInfo(mysqldPath: string): Promise<void> {
     stepNum++
   }
 
-  // Step: Delete SpinDB containers
   if (mysqlContainers.length > 0) {
     console.log(chalk.gray(`  # ${stepNum}. Delete SpinDB containers`))
     console.log(chalk.cyan('  spindb delete <container-name>'))
@@ -371,7 +352,6 @@ async function handleMysqlInfo(mysqldPath: string): Promise<void> {
 
   console.log()
 
-  // Wait for user
   await inquirer.prompt([
     {
       type: 'input',

--- a/cli/commands/menu/index.ts
+++ b/cli/commands/menu/index.ts
@@ -5,20 +5,16 @@ import { containerManager } from '../../../core/container-manager'
 import { promptInstallDependencies } from '../../ui/prompts'
 import { header, error } from '../../ui/theme'
 import { getInstalledEngines } from '../../helpers'
-import { type MenuChoice } from './shared'
 import {
   handleCreate,
   handleList,
   handleStart,
   handleStop,
 } from './container-handlers'
-import {
-  handleBackup,
-  handleRestore,
-  handleClone,
-} from './backup-handlers'
+import { handleBackup, handleRestore, handleClone } from './backup-handlers'
 import { handleEngines } from './engine-handlers'
 import { handleCheckUpdate } from './update-handlers'
+import { type MenuChoice } from './shared'
 
 async function showMainMenu(): Promise<void> {
   console.clear()
@@ -148,7 +144,6 @@ async function showMainMenu(): Promise<void> {
       process.exit(0)
   }
 
-  // Return to menu after action
   await showMainMenu()
 }
 

--- a/cli/commands/menu/shell-handlers.ts
+++ b/cli/commands/menu/shell-handlers.ts
@@ -32,7 +32,6 @@ export async function handleCopyConnectionString(
   const engine = getEngine(config.engine)
   const connectionString = engine.getConnectionString(config)
 
-  // Copy to clipboard using platform service
   const copied = await platformService.copyToClipboard(connectionString)
 
   console.log()
@@ -64,7 +63,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
   const engine = getEngine(config.engine)
   const connectionString = engine.getConnectionString(config)
 
-  // Check which enhanced shells are installed (with loading indicator)
   const shellCheckSpinner = createSpinner('Checking available shells...')
   shellCheckSpinner.start()
 
@@ -100,7 +98,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     },
   ]
 
-  // Engine-specific enhanced CLI (pgcli for PostgreSQL, mycli for MySQL)
   if (engineSpecificInstalled) {
     choices.push({
       name: `⚡ Use ${engineSpecificCli} (enhanced features, recommended)`,
@@ -113,7 +110,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     })
   }
 
-  // usql - universal option
   if (usqlInstalled) {
     choices.push({
       name: '⚡ Use usql (universal SQL client)',
@@ -146,7 +142,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     return
   }
 
-  // Handle pgcli installation
   if (shellChoice === 'install-pgcli') {
     console.log()
     console.log(info('Installing pgcli for enhanced PostgreSQL shell...'))
@@ -180,7 +175,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     return
   }
 
-  // Handle mycli installation
   if (shellChoice === 'install-mycli') {
     console.log()
     console.log(info('Installing mycli for enhanced MySQL shell...'))
@@ -214,7 +208,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     return
   }
 
-  // Handle usql installation
   if (shellChoice === 'install-usql') {
     console.log()
     console.log(info('Installing usql for enhanced shell experience...'))
@@ -248,7 +241,6 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     return
   }
 
-  // Launch the selected shell
   await launchShell(containerName, config, connectionString, shellChoice)
 }
 
@@ -261,7 +253,6 @@ async function launchShell(
   console.log(info(`Connecting to ${containerName}...`))
   console.log()
 
-  // Determine shell command based on engine and shell type
   let shellCmd: string
   let shellArgs: string[]
   let installHint: string
@@ -291,7 +282,6 @@ async function launchShell(
     installHint = 'brew tap xo/xo && brew install xo/xo/usql'
   } else if (config.engine === 'mysql') {
     shellCmd = 'mysql'
-    // MySQL connection: mysql -u root -h 127.0.0.1 -P port database
     shellArgs = [
       '-u',
       'root',
@@ -303,7 +293,6 @@ async function launchShell(
     ]
     installHint = 'brew install mysql-client'
   } else {
-    // PostgreSQL (default)
     shellCmd = 'psql'
     shellArgs = [connectionString]
     installHint = 'brew install libpq && brew link --force libpq'

--- a/cli/commands/menu/sql-handlers.ts
+++ b/cli/commands/menu/sql-handlers.ts
@@ -20,7 +20,6 @@ export async function handleRunSql(containerName: string): Promise<void> {
 
   const engine = getEngine(config.engine)
 
-  // Check for required client tools
   let missingDeps = await getMissingDependencies(config.engine)
   if (missingDeps.length > 0) {
     console.log(
@@ -72,14 +71,12 @@ export async function handleRunSql(containerName: string): Promise<void> {
     },
   ])
 
-  // Empty input = go back to submenu
   if (!rawFilePath.trim()) {
     return
   }
 
   const filePath = stripQuotes(rawFilePath)
 
-  // Select database if container has multiple
   const databases = config.databases || [config.database]
   let databaseName: string
 

--- a/cli/commands/run.ts
+++ b/cli/commands/run.ts
@@ -23,7 +23,6 @@ export const runCommand = new Command('run')
       try {
         const containerName = name
 
-        // Get container config
         const config = await containerManager.getConfig(containerName)
         if (!config) {
           console.error(error(`Container "${containerName}" not found`))
@@ -32,7 +31,6 @@ export const runCommand = new Command('run')
 
         const { engine: engineName } = config
 
-        // Check if running
         const running = await processManager.isRunning(containerName, {
           engine: engineName,
         })
@@ -45,7 +43,6 @@ export const runCommand = new Command('run')
           process.exit(1)
         }
 
-        // Validate: must have either file or --sql, not both
         if (file && options.sql) {
           console.error(
             error('Cannot specify both a file and --sql option. Choose one.'),
@@ -64,16 +61,13 @@ export const runCommand = new Command('run')
           process.exit(1)
         }
 
-        // Validate file exists
         if (file && !existsSync(file)) {
           console.error(error(`SQL file not found: ${file}`))
           process.exit(1)
         }
 
-        // Get engine
         const engine = getEngine(engineName)
 
-        // Check for required client tools
         let missingDeps = await getMissingDependencies(engineName)
         if (missingDeps.length > 0) {
           console.log(
@@ -82,7 +76,6 @@ export const runCommand = new Command('run')
             ),
           )
 
-          // Offer to install
           const installed = await promptInstallDependencies(
             missingDeps[0].binary,
             engineName,
@@ -92,7 +85,6 @@ export const runCommand = new Command('run')
             process.exit(1)
           }
 
-          // Verify installation worked
           missingDeps = await getMissingDependencies(engineName)
           if (missingDeps.length > 0) {
             console.error(
@@ -107,10 +99,8 @@ export const runCommand = new Command('run')
           console.log()
         }
 
-        // Determine target database
         const database = options.database || config.database
 
-        // Run the SQL
         await engine.runScript(config, {
           file,
           sql: options.sql,
@@ -119,7 +109,6 @@ export const runCommand = new Command('run')
       } catch (err) {
         const e = err as Error
 
-        // Check if this is a missing tool error
         const missingToolPatterns = [
           'psql not found',
           'mysql not found',

--- a/cli/commands/stop.ts
+++ b/cli/commands/stop.ts
@@ -13,7 +13,6 @@ export const stopCommand = new Command('stop')
   .action(async (name: string | undefined, options: { all?: boolean }) => {
     try {
       if (options.all) {
-        // Stop all running containers
         const containers = await containerManager.list()
         const running = containers.filter((c) => c.status === 'running')
 
@@ -41,7 +40,6 @@ export const stopCommand = new Command('stop')
 
       let containerName = name
 
-      // Interactive selection if no name provided
       if (!containerName) {
         const containers = await containerManager.list()
         const running = containers.filter((c) => c.status === 'running')
@@ -59,14 +57,12 @@ export const stopCommand = new Command('stop')
         containerName = selected
       }
 
-      // Get container config
       const config = await containerManager.getConfig(containerName)
       if (!config) {
         console.error(error(`Container "${containerName}" not found`))
         process.exit(1)
       }
 
-      // Check if running
       const running = await processManager.isRunning(containerName, {
         engine: config.engine,
       })
@@ -75,7 +71,6 @@ export const stopCommand = new Command('stop')
         return
       }
 
-      // Get engine and stop
       const engine = getEngine(config.engine)
 
       const spinner = createSpinner(`Stopping ${containerName}...`)

--- a/cli/commands/url.ts
+++ b/cli/commands/url.ts
@@ -20,7 +20,6 @@ export const urlCommand = new Command('url')
       try {
         let containerName = name
 
-        // Interactive selection if no name provided
         if (!containerName) {
           const containers = await containerManager.list()
 
@@ -37,19 +36,16 @@ export const urlCommand = new Command('url')
           containerName = selected
         }
 
-        // Get container config
         const config = await containerManager.getConfig(containerName)
         if (!config) {
           console.error(error(`Container "${containerName}" not found`))
           process.exit(1)
         }
 
-        // Get connection string
         const engine = getEngine(config.engine)
         const databaseName = options.database || config.database
         const connectionString = engine.getConnectionString(config, databaseName)
 
-        // JSON output
         if (options.json) {
           const jsonOutput = {
             connectionString,
@@ -64,22 +60,17 @@ export const urlCommand = new Command('url')
           return
         }
 
-        // Copy to clipboard if requested
         if (options.copy) {
           const copied = await platformService.copyToClipboard(connectionString)
           if (copied) {
-            // Output the string AND confirmation
             console.log(connectionString)
             console.error(success('Copied to clipboard'))
           } else {
-            // Output the string but warn about clipboard
             console.log(connectionString)
             console.error(warning('Could not copy to clipboard'))
           }
         } else {
-          // Just output the connection string (no newline formatting for easy piping)
           process.stdout.write(connectionString)
-          // Add newline if stdout is a TTY (interactive terminal)
           if (process.stdout.isTTY) {
             console.log()
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.7.3",
+  "version": "0.7.5",
   "description": "Spin up local database containers without Docker. A DBngin-like CLI for PostgreSQL and MySQL.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
…bility

- Strip 200+ inline comments from command files: `backup.ts`, `clone.ts`, `connect.ts`, `create.ts`, `destroy.ts`, `info.ts`, `list.ts`, `logs.ts`, `menu/`, `rename.ts`, `restart.ts`, `restore.ts`, `shell.ts`, `start.ts`, `status.ts`, `stop.ts`, `update.ts`
- Remove redundant comments that restate obvious code intent ("Get container config", "Check if running", "Interactive selection if no container provided")
- Keep JS