### PR TITLE
Add Husky git hooks for pre-commit and pre-push linting and bump vers…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Spin up local database containers without Docker. A DBngin-like CLI for PostgreSQL and MySQL.",
   "type": "module",
   "bin": {
@@ -16,7 +16,8 @@
     "test:integration": "pnpm test:pg && pnpm test:mysql",
     "test:all": "pnpm test:unit && pnpm test:integration",
     "format": "prettier --write .",
-    "lint": "tsc --noEmit && eslint ."
+    "lint": "tsc --noEmit && eslint .",
+    "prepare": "husky"
   },
   "keywords": [
     "postgres",
@@ -54,6 +55,7 @@
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.10.0",
     "eslint": "^9.39.1",
+    "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "typescript": "^5.3.0",
     "typescript-eslint": "^8.48.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.1
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -579,6 +582,11 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
@@ -1418,6 +1426,8 @@ snapshots:
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.0:
     dependencies:

--- a/tests/unit/container-manager.test.ts
+++ b/tests/unit/container-manager.test.ts
@@ -217,7 +217,16 @@ describe('ContainerManager', () => {
 
     it('should migrate configs without databases array', async () => {
       // Test the concept of migration
-      const oldConfig = {
+      const oldConfig: {
+        name: string
+        engine: string
+        version: string
+        port: number
+        database: string
+        databases?: string[]
+        created: string
+        status: string
+      } = {
         name: 'testdb',
         engine: 'postgresql',
         version: '17',

--- a/tests/unit/dependency-manager.test.ts
+++ b/tests/unit/dependency-manager.test.ts
@@ -106,6 +106,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'List Command',
         binary: 'ls',
+        description: 'List directory contents',
         packages: {},
         manualInstall: { darwin: [], linux: [] },
       }
@@ -124,6 +125,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Fake Tool',
         binary: 'fake-tool-that-does-not-exist-xyz',
+        description: 'A fake tool for testing',
         packages: {},
         manualInstall: { darwin: [], linux: [] },
       }
@@ -140,6 +142,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {
           brew: { package: 'test-package' },
         },
@@ -154,6 +157,7 @@ describe('DependencyManager', () => {
           name: 'Homebrew',
           checkCommand: 'brew --version',
           installTemplate: 'brew install {package}',
+          updateTemplate: 'brew upgrade {package}',
           platforms: ['darwin'],
         },
       }
@@ -172,6 +176,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {
           brew: {
             package: 'test-package',
@@ -189,6 +194,7 @@ describe('DependencyManager', () => {
           name: 'Homebrew',
           checkCommand: 'brew --version',
           installTemplate: 'brew install {package}',
+          updateTemplate: 'brew upgrade {package}',
           platforms: ['darwin'],
         },
       }
@@ -204,6 +210,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {
           brew: {
             package: 'test-package',
@@ -221,6 +228,7 @@ describe('DependencyManager', () => {
           name: 'Homebrew',
           checkCommand: 'brew --version',
           installTemplate: 'brew install {package}',
+          updateTemplate: 'brew upgrade {package}',
           platforms: ['darwin'],
         },
       }
@@ -236,6 +244,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {}, // No package definitions
         manualInstall: { darwin: [], linux: [] },
       }
@@ -248,6 +257,7 @@ describe('DependencyManager', () => {
           name: 'Homebrew',
           checkCommand: 'brew --version',
           installTemplate: 'brew install {package}',
+          updateTemplate: 'brew upgrade {package}',
           platforms: ['darwin'],
         },
       }
@@ -270,6 +280,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {},
         manualInstall: {
           darwin: ['brew install test-package'],
@@ -298,6 +309,7 @@ describe('DependencyManager', () => {
       const mockDep = {
         name: 'Test Package',
         binary: 'test-bin',
+        description: 'A test package',
         packages: {},
         manualInstall: {
           darwin: ['brew install test-package'],
@@ -317,6 +329,7 @@ describe('DependencyManager', () => {
         dependency: {
           name: 'Test',
           binary: 'test',
+          description: 'A test tool',
           packages: {},
           manualInstall: {},
         },
@@ -340,11 +353,12 @@ describe('DependencyManager', () => {
 
   describe('InstallResult Shape', () => {
     it('should have correct success structure', () => {
-      const result = {
+      const result: { success: boolean; dependency: object; error?: string } = {
         success: true,
         dependency: {
           name: 'Test',
           binary: 'test',
+          description: 'A test tool',
           packages: {},
           manualInstall: {},
         },
@@ -361,6 +375,7 @@ describe('DependencyManager', () => {
         dependency: {
           name: 'Test',
           binary: 'test',
+          description: 'A test tool',
           packages: {},
           manualInstall: {},
         },
@@ -400,6 +415,7 @@ describe('Error Messages', () => {
     const mockDep = {
       name: 'PostgreSQL Client',
       binary: 'psql',
+      description: 'PostgreSQL interactive terminal',
       packages: {},
       manualInstall: { darwin: [], linux: [] },
     }
@@ -412,6 +428,7 @@ describe('Error Messages', () => {
         name: 'Homebrew',
         checkCommand: 'brew --version',
         installTemplate: 'brew install {package}',
+        updateTemplate: 'brew upgrade {package}',
         platforms: ['darwin'],
       },
     }

--- a/tests/unit/port-manager.test.ts
+++ b/tests/unit/port-manager.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for port-manager module
  */
 
-import { describe, it, mock } from 'node:test'
+import { describe, it } from 'node:test'
 import { PortManager } from '../../core/port-manager'
 import { assert, assertEqual } from '../integration/helpers'
 
@@ -42,12 +42,7 @@ describe('PortManager', () => {
     it('should throw error when no ports available in range', async () => {
       const portManager = new PortManager()
       // Create a mock that always returns false (all ports in use)
-      const originalIsPortAvailable = portManager.isPortAvailable.bind(portManager)
-      let callCount = 0
-      portManager.isPortAvailable = async () => {
-        callCount++
-        return false
-      }
+      portManager.isPortAvailable = async () => false
 
       try {
         await portManager.findAvailablePort({
@@ -65,8 +60,6 @@ describe('PortManager', () => {
           error.message.includes('59990-59992'),
           `Error message should include port range: ${error.message}`,
         )
-      } finally {
-        portManager.isPortAvailable = originalIsPortAvailable
       }
     })
 

--- a/tests/unit/start-with-retry.test.ts
+++ b/tests/unit/start-with-retry.test.ts
@@ -75,7 +75,7 @@ describe('StartWithRetryResult', () => {
     assert(successResult.success === true, 'success should be true')
     assertEqual(successResult.finalPort, 5432, 'finalPort should be set')
     assertEqual(successResult.retriesUsed, 0, 'retriesUsed should be 0 on first try')
-    assert(successResult.error === undefined, 'error should be undefined on success')
+    assert(!('error' in successResult), 'error should not be present on success')
   })
 
   it('should have correct failure result shape', () => {
@@ -174,15 +174,17 @@ describe('Port Change Callback', () => {
 
   it('should not call onPortChange if not provided', () => {
     // This tests that undefined callback doesn't crash
-    const onPortChange: ((oldPort: number, newPort: number) => void) | undefined = undefined
+    let callbackWasCalled = false
+    const maybeCallback = Math.random() > 2
+      ? ((_oldPort: number, _newPort: number) => { callbackWasCalled = true })
+      : undefined
 
     // Simulate the check that exists in start-with-retry
-    if (onPortChange) {
-      onPortChange(5432, 5433)
-      assert(false, 'Should not reach here')
+    if (maybeCallback) {
+      maybeCallback(5432, 5433)
     }
 
-    assert(true, 'Should handle undefined callback gracefully')
+    assert(!callbackWasCalled, 'Should handle undefined callback gracefully')
   })
 })
 
@@ -201,7 +203,7 @@ describe('Engine Port Range Resolution', () => {
 
 describe('Error Conversion', () => {
   it('should convert unknown errors to Error objects', () => {
-    const unknownError = 'string error'
+    const unknownError: unknown = 'string error'
     const converted = unknownError instanceof Error
       ? unknownError
       : new Error(String(unknownError))

--- a/tests/unit/update-manager.test.ts
+++ b/tests/unit/update-manager.test.ts
@@ -156,7 +156,7 @@ describe('UpdateManager', () => {
       assert(result.success === true, 'success should be true')
       assert(typeof result.previousVersion === 'string', 'Should have previousVersion')
       assert(typeof result.newVersion === 'string', 'Should have newVersion')
-      assert(result.error === undefined, 'error should be undefined on success')
+      assert(!('error' in result), 'error should not be present on success')
     })
 
     it('should have correct failure structure', () => {


### PR DESCRIPTION
…ion to 0.8.0

- Add Husky v9.1.7 as dev dependency with `prepare` script
- Create `.husky/pre-commit` and `.husky/pre-push` hooks running `pnpm run lint`
- Bump package version from 0.7.5 to 0.8.0
- Fix TypeScript type errors in test files: add explicit type annotations to mock objects in `container-manager.test.ts`, `dependency-manager.test.ts`, `port-manager.test.ts`, `start-with-retry.test.ts`, and `update-manager.test.ts`
- Replace