### PR TITLE
Add back navigation option to container selection prompts and bump ve…

### DIFF
--- a/cli/commands/menu/backup-handlers.ts
+++ b/cli/commands/menu/backup-handlers.ts
@@ -592,6 +592,7 @@ export async function handleBackup(): Promise<void> {
   const containerName = await promptContainerSelect(
     running,
     'Select container to backup:',
+    { includeBack: true },
   )
   if (!containerName) return
 
@@ -715,6 +716,7 @@ export async function handleClone(): Promise<void> {
   const sourceName = await promptContainerSelect(
     stopped,
     'Select container to clone:',
+    { includeBack: true },
   )
   if (!sourceName) return
 

--- a/cli/commands/menu/container-handlers.ts
+++ b/cli/commands/menu/container-handlers.ts
@@ -474,6 +474,7 @@ export async function handleStart(): Promise<void> {
   const containerName = await promptContainerSelect(
     stopped,
     'Select container to start:',
+    { includeBack: true },
   )
   if (!containerName) return
 
@@ -521,6 +522,7 @@ export async function handleStop(): Promise<void> {
   const containerName = await promptContainerSelect(
     running,
     'Select container to stop:',
+    { includeBack: true },
   )
   if (!containerName) return
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Spin up local database containers without Docker. A DBngin-like CLI for PostgreSQL and MySQL.",
   "type": "module",
   "bin": {
@@ -32,7 +32,8 @@
   "license": "PolyForm-Noncommercial-1.0.0",
   "packageManager": "pnpm@9.14.2",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "pnpm": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…rsion to 0.8.2

- Add `includeBack` option to `promptContainerSelect()` function with optional back navigation
- Add back option to backup, clone, start, and stop container selection prompts
- Return `null` when back option (`__back__`) is selected to exit prompt gracefully
- Add JSDoc parameter documentation for `options.includeBack` flag
- Add `pnpm>=8` engine requirement to `package.json`
- Bump package version from 0.8.1 to 0.8.2