### PR TITLE
refactor: add FerretDB engine support with MongoDB-compatible API and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-01-23
+
+### Added
+- **FerretDB engine support** - MongoDB-compatible database using PostgreSQL as backend:
+  - First composite engine requiring two binaries: `ferretdb` proxy + `postgresql-documentdb` backend
+  - Two processes per container: PostgreSQL backend + FerretDB proxy
+  - Two ports per container: external (27017 for MongoDB) + internal (54320+ for PostgreSQL)
+  - Uses `mongodb://` connection scheme, compatible with mongosh
+  - Backup/restore via pg_dump/pg_restore on PostgreSQL backend (formats: `sql`, `custom`)
+  - Aliases: `ferretdb`, `ferret`
+  - macOS and Linux support (Windows not supported due to postgresql-documentdb build constraints)
+  - Version 2.7.0 with postgresql-documentdb 17-0.107.0 from hostdb
+  - **Note**: Requires fixed hostdb binaries with proper rpath settings (pending hostdb update)
+
+### Changed
+- **Port allocation for stopped containers** - Stopped containers no longer block port suggestions when creating new containers. Previously, a stopped MongoDB container on port 27017 would cause new containers to suggest 27018. Now only running containers are considered port conflicts, giving users more control over port management.
+
 ## [0.22.1] - 2026-01-23
 
 ### Changed

--- a/ENGINES.md
+++ b/ENGINES.md
@@ -9,6 +9,7 @@
 | 🦭 **MariaDB** | ✅ Complete | hostdb (all platforms) | ~120 MB | Versions 10.11, 11.4, 11.8 |
 | 🪶 **SQLite** | ✅ Complete | hostdb (all platforms) | ~5 MB | File-based, stores in project directories |
 | 🍃 **MongoDB** | ✅ Complete | hostdb (all platforms) | ~200 MB | Versions 7.0, 8.0, 8.2 |
+| 🦔 **FerretDB** | ✅ Complete | hostdb (macOS/Linux) | ~100 MB | MongoDB-compatible, PostgreSQL backend |
 | 🔴 **Redis** | ✅ Complete | hostdb (all platforms) | ~15 MB | Versions 7, 8 |
 | 🔷 **Valkey** | ✅ Complete | hostdb (all platforms) | ~15 MB | Versions 8, 9 (Redis fork) |
 | 🏠 **ClickHouse** | ✅ Complete | hostdb (macOS/Linux) | ~300 MB | Version 25.12 (column-oriented OLAP) |
@@ -71,6 +72,27 @@
   - Uses JavaScript for scripts instead of SQL
   - mongodump creates gzipped archive by default
   - Full cross-platform support (macOS, Linux, Windows)
+
+### 🦔 FerretDB
+
+- **Status:** ✅ Complete
+- **Versions:** 2
+- **Data location:** `~/.spindb/containers/ferretdb/{name}/`
+- **Process:** Two processes (PostgreSQL backend + FerretDB proxy)
+- **Binary source:** hostdb downloads (macOS/Linux only, no Windows)
+- **Enhanced CLI:** `mongosh` (MongoDB Shell - uses MongoDB protocol)
+- **Backup format:** `.sql` or `.dump` (PostgreSQL formats, via pg_dump)
+- **Multi-version support:** Yes (macOS/Linux)
+- **Bundled tools:** ferretdb, postgresql-documentdb (includes pg_ctl, initdb, pg_dump, etc.)
+- **Implementation notes:**
+  - Composite engine requiring two binaries from hostdb
+  - FerretDB is a stateless Go proxy (MongoDB wire protocol → PostgreSQL SQL)
+  - PostgreSQL backend uses DocumentDB extension for MongoDB compatibility
+  - Two ports per container: external (27017 for MongoDB) + internal (54320+ for PostgreSQL)
+  - Uses `mongodb://` connection scheme for clients
+  - Backups use pg_dump on the embedded PostgreSQL database
+  - Not available on Windows (postgresql-documentdb cannot be built)
+  - Apache-2.0 license
 
 ### 🔷 Valkey
 
@@ -162,6 +184,7 @@
 | Redis | `.redis` (text commands) | `.rdb` (RDB snapshot) | RDB for backups |
 | Valkey | `.valkey` (text commands) | `.rdb` (RDB snapshot) | RDB for backups |
 | MongoDB | `.json` (mongoexport) | `.bson` (mongodump) | BSON for backups |
+| FerretDB | `.sql` (pg_dump) | `.dump` (custom format) | SQL for portability |
 | ClickHouse | `.sql` (DDL + INSERT) | N/A | SQL for portability |
 | Qdrant | N/A | `.snapshot` (native) | Snapshot for backups |
 | Meilisearch | N/A | `.snapshot` (native) | Snapshot for backups |
@@ -178,6 +201,7 @@
 | Redis | `redis-cli` | `iredis` | Auto-completion, syntax highlighting |
 | Valkey | `valkey-cli` | `iredis` | Protocol-compatible with iredis |
 | MongoDB | `mongosh` | - | Built-in shell is already enhanced |
+| FerretDB | `mongosh` | - | Uses MongoDB shell (mongosh) |
 | Universal | - | `usql` | Works with all SQL databases |
 | Qdrant | REST API | - | Use curl or HTTP clients |
 | Meilisearch | REST API | - | Use curl or HTTP clients |
@@ -202,6 +226,7 @@ Both engines support multi-version side-by-side installations. Client tools are 
 | 🐬 | MySQL |
 | 🐘 | PostgreSQL |
 | 🍃 | MongoDB |
+| 🦔 | FerretDB |
 | 🔴 | Redis |
 | 🔷 | Valkey |
 | 🪶 | SQLite |

--- a/FEATURE.md
+++ b/FEATURE.md
@@ -38,9 +38,9 @@ SpinDB supports multiple database engines through an abstract `BaseEngine` class
 
 ## Engine Types
 
-SpinDB supports two types of database engines:
+SpinDB supports three types of database engines:
 
-### Server-Based Databases (PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Valkey, ClickHouse, Qdrant)
+### Server-Based Databases (PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Valkey, ClickHouse, Qdrant, Meilisearch)
 
 - Data stored in `~/.spindb/containers/{engine}/{name}/`
 - Require start/stop lifecycle management

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **One CLI for all your local databases.**
 
-SpinDB is a universal database management tool that combines a package manager, a unified API, and native client tooling for 11 different database engines—all from a single command-line interface. No Docker, no VMs, no platform-specific installers. Just databases, running natively on your machine.
+SpinDB is a universal database management tool that combines a package manager, a unified API, and native client tooling for 12 different database engines—all from a single command-line interface. No Docker, no VMs, no platform-specific installers. Just databases, running natively on your machine.
 
 ```bash
 npm install -g spindb
@@ -48,7 +48,7 @@ One consistent interface across SQL databases, document stores, key-value stores
 
 ```bash
 # Same commands work for ANY database
-spindb create mydb --engine [postgresql|mysql|mariadb|mongodb|redis|valkey|clickhouse|sqlite|duckdb|qdrant|meilisearch]
+spindb create mydb --engine [postgresql|mysql|mariadb|mongodb|ferretdb|redis|valkey|clickhouse|sqlite|duckdb|qdrant|meilisearch]
 spindb start mydb
 spindb connect mydb
 spindb backup mydb
@@ -70,7 +70,7 @@ spindb run mydb -c "SELECT * FROM system.tables"        # ClickHouse
 
 ## Platform Coverage
 
-SpinDB works across **11 database engines** and **5 platform architectures** with a **single, consistent API**.
+SpinDB works across **12 database engines** and **5 platform architectures** with a **single, consistent API**.
 
 | Database | macOS ARM64 | macOS Intel | Linux x64 | Linux ARM64 | Windows x64 |
 |----------|:-----------:|:-----------:|:---------:|:-----------:|:-----------:|
@@ -80,13 +80,14 @@ SpinDB works across **11 database engines** and **5 platform architectures** wit
 | 🪶 **SQLite** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 🦆 **DuckDB** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 🍃 **MongoDB** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 🦔 **FerretDB** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | 🔴 **Redis** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 🔷 **Valkey** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 🏠 **ClickHouse** | ✅ | ✅ | ✅ | ✅ | ❌ |
 | 🧭 **Qdrant** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 🔍 **Meilisearch** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-**54 combinations. One CLI. Zero configuration.**
+**58 combinations. One CLI. Zero configuration.**
 
 ---
 
@@ -165,7 +166,7 @@ SpinDB runs databases as **native processes** with **isolated data directories**
 | Feature | SpinDB | Docker | DBngin | Postgres.app | XAMPP |
 |---------|--------|--------|--------|--------------|-------|
 | No Docker required | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Multiple DB engines | ✅ 11 engines | ✅ Unlimited | ✅ 3 engines | ❌ PostgreSQL only | ⚠️ MySQL only |
+| Multiple DB engines | ✅ 12 engines | ✅ Unlimited | ✅ 3 engines | ❌ PostgreSQL only | ⚠️ MySQL only |
 | CLI-first | ✅ | ✅ | ❌ GUI-first | ❌ GUI-first | ❌ GUI-first |
 | Multiple versions | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Clone databases | ✅ | Manual | ✅ | ❌ | ❌ |
@@ -179,7 +180,7 @@ SpinDB runs databases as **native processes** with **isolated data directories**
 
 ## Supported Databases
 
-SpinDB supports **11 database engines** with **multiple versions** for each:
+SpinDB supports **12 database engines** with **multiple versions** for each:
 
 | Engine | Type | Versions | Default Port | Query Language |
 |--------|------|----------|--------------|----------------|
@@ -189,6 +190,7 @@ SpinDB supports **11 database engines** with **multiple versions** for each:
 | 🪶 **SQLite** | Embedded (SQL) | 3 | N/A (file-based) | SQL |
 | 🦆 **DuckDB** | Embedded OLAP | 1.4.3 | N/A (file-based) | SQL |
 | 🍃 **MongoDB** | Document Store | 7.0, 8.0, 8.2 | 27017 | JavaScript (mongosh) |
+| 🦔 **FerretDB** | Document Store | 2 | 27017 | JavaScript (mongosh) |
 | 🔴 **Redis** | Key-Value Store | 7, 8 | 6379 | Redis commands |
 | 🔷 **Valkey** | Key-Value Store | 8, 9 | 6379 | Redis commands |
 | 🏠 **ClickHouse** | Columnar OLAP | 25.12 | 9000 (TCP), 8123 (HTTP) | SQL (ClickHouse dialect) |
@@ -197,7 +199,7 @@ SpinDB supports **11 database engines** with **multiple versions** for each:
 
 ### Engine Categories
 
-**Server-Based Databases** (PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Valkey, ClickHouse, Qdrant, Meilisearch):
+**Server-Based Databases** (PostgreSQL, MySQL, MariaDB, MongoDB, FerretDB, Redis, Valkey, ClickHouse, Qdrant, Meilisearch):
 - Start/stop server processes
 - Bind to localhost ports
 - Data stored in `~/.spindb/containers/{engine}/{name}/`
@@ -481,6 +483,29 @@ spindb connect logs
 **Query language:** JavaScript (via `mongosh`)
 **Tools:** `mongod`, `mongosh`, `mongodump`, `mongorestore` (included)
 
+### FerretDB 🦔
+
+```bash
+# Create FerretDB database (MongoDB-compatible, PostgreSQL backend)
+spindb create docs --engine ferretdb
+
+# Same MongoDB queries work
+spindb run docs -c "db.users.insertOne({name: 'Alice'})"
+spindb run docs -c "db.users.find().pretty()"
+
+# Connect with mongosh
+spindb connect docs
+```
+
+**Version:** 2 (2.7.0)
+**Platforms:** macOS, Linux (no Windows - postgresql-documentdb unavailable)
+**Architecture:** FerretDB proxy + PostgreSQL with DocumentDB extension
+**Query language:** JavaScript (via `mongosh`)
+**Backups:** Uses `pg_dump` on embedded PostgreSQL backend
+**Tools:** `ferretdb`, `mongosh` (for client connections)
+
+FerretDB is a MongoDB-compatible database that stores data in PostgreSQL. It's useful when you want MongoDB's API but PostgreSQL's reliability and SQL access to your data.
+
 ### Redis 🔴 & Valkey 🔷
 
 ```bash
@@ -568,6 +593,7 @@ SpinDB supports enhanced database shells with auto-completion, syntax highlighti
 | SQLite | `sqlite3` | `litecli` | `usql` |
 | DuckDB | `duckdb` | - | `usql` |
 | MongoDB | `mongosh` | - | - |
+| FerretDB | `mongosh` | - | - |
 | Redis | `redis-cli` | `iredis` | - |
 | Valkey | `valkey-cli` | `iredis` (compatible) | - |
 | ClickHouse | `clickhouse-client` | - | `usql` |
@@ -779,7 +805,6 @@ See [TODO.md](TODO.md) for the complete roadmap.
 
 ### v1.2 - Additional Engines
 - **CockroachDB** - Distributed PostgreSQL-compatible database
-- **FerretDB** - MongoDB-compatible database built on PostgreSQL
 
 ### v1.3 - Advanced Features
 - Container templates for common configurations
@@ -803,6 +828,7 @@ The following engines may be added based on community interest:
 
 - **Local only** - Databases bind to `127.0.0.1`. Remote connection support planned for v1.1.
 - **ClickHouse Windows** - Not supported (hostdb doesn't build for Windows).
+- **FerretDB Windows** - Not supported (postgresql-documentdb unavailable for Windows).
 - **Qdrant & Meilisearch** - Use REST API instead of CLI shell. Access via HTTP at the configured port.
 
 ---

--- a/cli/commands/menu/shell-handlers.ts
+++ b/cli/commands/menu/shell-handlers.ts
@@ -167,9 +167,9 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     engineSpecificInstalled = mycliInstalled
     engineSpecificValue = 'mycli'
     engineSpecificInstallValue = 'install-mycli'
-  } else if (config.engine === 'mongodb') {
+  } else if (config.engine === 'mongodb' || config.engine === 'ferretdb') {
     defaultShellName = 'mongosh'
-    // mongosh IS the enhanced shell for MongoDB (no separate enhanced CLI like pgcli/mycli)
+    // mongosh IS the enhanced shell for MongoDB/FerretDB (no separate enhanced CLI like pgcli/mycli)
     engineSpecificCli = null
     engineSpecificInstalled = false
     engineSpecificValue = null
@@ -290,11 +290,12 @@ export async function handleOpenShell(containerName: string): Promise<void> {
     }
   }
 
-  // usql supports SQL databases (PostgreSQL, MySQL, SQLite) - skip for Redis, Valkey, MongoDB, Qdrant, and Meilisearch
+  // usql supports SQL databases (PostgreSQL, MySQL, SQLite) - skip for Redis, Valkey, MongoDB, FerretDB, Qdrant, and Meilisearch
   const isNonSqlEngine =
     config.engine === 'redis' ||
     config.engine === 'valkey' ||
     config.engine === 'mongodb' ||
+    config.engine === 'ferretdb' ||
     config.engine === 'qdrant' ||
     config.engine === 'meilisearch'
   if (!isNonSqlEngine) {
@@ -739,7 +740,7 @@ async function launchShell(
       config.database,
     ]
     installHint = 'spindb engines download mariadb'
-  } else if (config.engine === 'mongodb') {
+  } else if (config.engine === 'mongodb' || config.engine === 'ferretdb') {
     shellCmd = 'mongosh'
     shellArgs = [connectionString]
     installHint = 'brew install mongosh'

--- a/cli/constants.ts
+++ b/cli/constants.ts
@@ -7,6 +7,7 @@ export const ENGINE_ICONS: Record<string, string> = {
   sqlite: '🪶 ', // Extra space - feather emoji renders narrow
   duckdb: '🦆',
   mongodb: '🍃',
+  ferretdb: '🦔',
   redis: '🔴',
   valkey: '🔷',
   clickhouse: '🏠',

--- a/cli/ui/prompts.ts
+++ b/cli/ui/prompts.ts
@@ -247,11 +247,12 @@ export async function promptPort(
     ? getEngineDefaults(engine).portRange
     : defaults.portRange
 
-  // Get all existing container ports for conflict detection
+  // Get running container ports for conflict detection
+  // Stopped containers don't block ports - users can manage conflicts themselves
   const existingContainers = await containerManager.list()
   const containerPorts = new Map<number, string>()
   for (const c of existingContainers) {
-    if (c.port > 0) {
+    if (c.port > 0 && c.status === 'running') {
       containerPorts.set(c.port, c.name)
     }
   }

--- a/config/backup-formats.ts
+++ b/config/backup-formats.ts
@@ -16,6 +16,7 @@ import {
   type SQLiteFormat,
   type DuckDBFormat,
   type MongoDBFormat,
+  type FerretDBFormat,
   type RedisFormat,
   type ValkeyFormat,
   type ClickHouseFormat,
@@ -46,6 +47,7 @@ export const BACKUP_FORMATS: {
   [Engine.SQLite]: EngineBackupFormats<SQLiteFormat>
   [Engine.DuckDB]: EngineBackupFormats<DuckDBFormat>
   [Engine.MongoDB]: EngineBackupFormats<MongoDBFormat>
+  [Engine.FerretDB]: EngineBackupFormats<FerretDBFormat>
   [Engine.Redis]: EngineBackupFormats<RedisFormat>
   [Engine.Valkey]: EngineBackupFormats<ValkeyFormat>
   [Engine.ClickHouse]: EngineBackupFormats<ClickHouseFormat>
@@ -159,6 +161,24 @@ export const BACKUP_FORMATS: {
     },
     supportsFormatChoice: true,
     defaultFormat: 'archive',
+  },
+  [Engine.FerretDB]: {
+    formats: {
+      sql: {
+        extension: '.sql',
+        label: '.sql',
+        description: 'Plain SQL - human-readable, larger file',
+        spinnerLabel: 'SQL',
+      },
+      custom: {
+        extension: '.dump',
+        label: '.dump',
+        description: 'Custom format - smaller file, faster restore',
+        spinnerLabel: 'custom',
+      },
+    },
+    supportsFormatChoice: true,
+    defaultFormat: 'sql',
   },
   [Engine.Redis]: {
     formats: {

--- a/config/engine-defaults.ts
+++ b/config/engine-defaults.ts
@@ -174,6 +174,19 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     clientTools: [], // Meilisearch uses REST API, no separate CLI tools
     maxConnections: 0, // Not applicable for search engine
   },
+  [Engine.FerretDB]: {
+    defaultVersion: '2',
+    defaultPort: 27017, // MongoDB-compatible port
+    portRange: { start: 27017, end: 27100 },
+    latestVersion: '2',
+    superuser: '', // No auth by default for local dev
+    connectionScheme: 'mongodb', // MongoDB-compatible protocol
+    logFileName: 'ferretdb.log',
+    pidFileName: 'ferretdb.pid',
+    dataSubdir: 'pg_data', // PostgreSQL backend data directory
+    clientTools: ['mongosh', 'mongodump', 'mongorestore'], // Uses MongoDB client tools
+    maxConnections: 200, // PostgreSQL backend default
+  },
 }
 
 /**

--- a/config/engines.json
+++ b/config/engines.json
@@ -168,6 +168,22 @@
       "clientTools": ["meilisearch"],
       "licensing": "MIT",
       "notes": "Full-text search engine. REST API on port 7700. Uses indexes instead of databases."
+    },
+    "ferretdb": {
+      "displayName": "FerretDB",
+      "icon": "🦔",
+      "status": "integrated",
+      "binarySource": "hostdb",
+      "supportedVersions": ["2.7.0"],
+      "defaultVersion": "2.7.0",
+      "defaultPort": 27017,
+      "runtime": "server",
+      "queryLanguage": "javascript",
+      "connectionScheme": "mongodb",
+      "superuser": null,
+      "clientTools": ["ferretdb"],
+      "licensing": "Apache-2.0",
+      "notes": "MongoDB-compatible proxy using PostgreSQL as backend. Requires postgresql-documentdb. Not available on Windows."
     }
   }
 }

--- a/core/config-manager.ts
+++ b/core/config-manager.ts
@@ -64,6 +64,8 @@ const QDRANT_TOOLS: BinaryTool[] = ['qdrant']
 
 const MEILISEARCH_TOOLS: BinaryTool[] = ['meilisearch']
 
+const FERRETDB_TOOLS: BinaryTool[] = ['ferretdb']
+
 const SQLITE_TOOLS: BinaryTool[] = ['sqlite3']
 
 const DUCKDB_TOOLS: BinaryTool[] = ['duckdb']
@@ -81,6 +83,7 @@ const ALL_TOOLS: BinaryTool[] = [
   ...MYSQL_TOOLS,
   ...MARIADB_TOOLS,
   ...MONGODB_TOOLS,
+  ...FERRETDB_TOOLS,
   ...REDIS_TOOLS,
   ...VALKEY_TOOLS,
   ...QDRANT_TOOLS,
@@ -97,6 +100,7 @@ const ENGINE_BINARY_MAP: Partial<Record<Engine, BinaryTool[]>> = {
   [Engine.MySQL]: MYSQL_TOOLS,
   [Engine.MariaDB]: MARIADB_TOOLS,
   [Engine.MongoDB]: MONGODB_TOOLS,
+  [Engine.FerretDB]: FERRETDB_TOOLS,
   [Engine.Redis]: REDIS_TOOLS,
   [Engine.Valkey]: VALKEY_TOOLS,
   [Engine.Qdrant]: QDRANT_TOOLS,
@@ -567,6 +571,7 @@ export {
   MARIADB_SERVER_TOOLS,
   MARIADB_CLIENT_TOOLS,
   MONGODB_TOOLS,
+  FERRETDB_TOOLS,
   REDIS_TOOLS,
   VALKEY_TOOLS,
   QDRANT_TOOLS,

--- a/core/dependency-manager.ts
+++ b/core/dependency-manager.ts
@@ -59,6 +59,8 @@ const KNOWN_BINARY_TOOLS: readonly BinaryTool[] = [
   'mongosh',
   'mongodump',
   'mongorestore',
+  // FerretDB
+  'ferretdb',
   // Redis
   'redis-server',
   'redis-cli',

--- a/core/port-manager.ts
+++ b/core/port-manager.ts
@@ -106,7 +106,11 @@ export class PortManager {
             try {
               const content = await readFile(configPath, 'utf8')
               const config = JSON.parse(content) as ContainerConfig
-              ports.push(config.port)
+              // Only include ports from running containers
+              // Stopped containers don't block ports - users can manage conflicts themselves
+              if (config.status === 'running') {
+                ports.push(config.port)
+              }
             } catch (error) {
               logDebug('Skipping invalid container config', {
                 configPath,

--- a/engines/ferretdb/backup.ts
+++ b/engines/ferretdb/backup.ts
@@ -1,0 +1,152 @@
+/**
+ * FerretDB backup module
+ *
+ * Creates backups using pg_dump on the embedded PostgreSQL backend.
+ * This backs up the ferretdb database which contains all MongoDB-compatible data.
+ */
+
+import { spawn, type SpawnOptions } from 'child_process'
+import { stat } from 'fs/promises'
+import { existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { mkdir } from 'fs/promises'
+import { logDebug } from '../../core/error-handler'
+import { platformService } from '../../core/platform-service'
+import { ferretdbBinaryManager } from './binary-manager'
+import {
+  normalizeDocumentDBVersion,
+  DEFAULT_DOCUMENTDB_VERSION,
+} from './version-maps'
+import type { ContainerConfig, BackupOptions, BackupResult } from '../../types'
+
+/**
+ * Get the path to pg_dump from the postgresql-documentdb installation
+ */
+function getPgDumpPath(container: ContainerConfig): string {
+  const { backendVersion } = container
+  const { platform, arch } = platformService.getPlatformInfo()
+
+  const fullBackendVersion = normalizeDocumentDBVersion(
+    backendVersion || DEFAULT_DOCUMENTDB_VERSION,
+  )
+  const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+    fullBackendVersion,
+    platform,
+    arch,
+  )
+
+  return join(documentdbPath, 'bin', 'pg_dump')
+}
+
+/**
+ * Create a backup of a FerretDB database using pg_dump
+ *
+ * Supports two formats:
+ * - 'sql': Plain SQL text format
+ * - 'custom' (default): PostgreSQL custom format (.dump)
+ */
+export async function createBackup(
+  container: ContainerConfig,
+  outputPath: string,
+  options: BackupOptions,
+): Promise<BackupResult> {
+  const { backendPort } = container
+  const database = options.database || 'ferretdb'
+
+  if (!backendPort) {
+    throw new Error(
+      'Backend port not set. Make sure the container is running before creating a backup.',
+    )
+  }
+
+  const pgDump = getPgDumpPath(container)
+
+  if (!existsSync(pgDump)) {
+    throw new Error(
+      `pg_dump not found at ${pgDump}. Make sure postgresql-documentdb is installed.`,
+    )
+  }
+
+  // Ensure output directory exists
+  const outputDir = dirname(outputPath)
+  if (!existsSync(outputDir)) {
+    await mkdir(outputDir, { recursive: true })
+  }
+
+  const args: string[] = [
+    '-h',
+    '127.0.0.1',
+    '-p',
+    String(backendPort),
+    '-U',
+    'postgres',
+    '-d',
+    database,
+  ]
+
+  // Determine output format (default to 'sql' as per backup-formats.ts)
+  const format = options.format ?? 'sql'
+  if (format === 'custom') {
+    // Custom format: binary, compressed, supports parallel restore
+    args.push('-Fc', '-f', outputPath)
+  } else {
+    // SQL format: plain text, human-readable
+    args.push('-f', outputPath)
+  }
+
+  logDebug(`Running pg_dump with args: ${args.join(' ')}`)
+
+  const spawnOptions: SpawnOptions = {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(pgDump, args, spawnOptions)
+
+    let stderr = ''
+
+    proc.stdout?.on('data', () => {
+      // pg_dump outputs to file, stdout is typically empty
+    })
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    proc.on('error', reject)
+
+    proc.on('close', async (code) => {
+      if (code === 0) {
+        // Get backup size
+        let size = 0
+        try {
+          const stats = await stat(outputPath)
+          size = stats.size
+        } catch {
+          // Size calculation failed, use 0
+        }
+
+        resolve({
+          path: outputPath,
+          format: format === 'custom' ? 'custom' : 'plain',
+          size,
+        })
+      } else {
+        reject(new Error(stderr || `pg_dump exited with code ${code}`))
+      }
+    })
+  })
+}
+
+/**
+ * Create a backup for cloning purposes
+ * Uses custom format by default for reliability and smaller size
+ */
+export async function createCloneBackup(
+  container: ContainerConfig,
+  outputPath: string,
+): Promise<BackupResult> {
+  return createBackup(container, outputPath, {
+    database: 'ferretdb',
+    format: 'custom',
+  })
+}

--- a/engines/ferretdb/binary-manager.ts
+++ b/engines/ferretdb/binary-manager.ts
@@ -1,0 +1,628 @@
+/**
+ * FerretDB Composite Binary Manager
+ *
+ * Handles downloading and managing both FerretDB binaries:
+ * 1. ferretdb - The MongoDB-compatible Go proxy
+ * 2. postgresql-documentdb - PostgreSQL 17 with DocumentDB extension
+ *
+ * This is a composite manager that coordinates the installation of both
+ * binaries, which are required for FerretDB to function.
+ */
+
+import { createWriteStream, existsSync } from 'fs'
+import { mkdir, readdir, rm, chmod, rename, cp } from 'fs/promises'
+import { join } from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import { paths } from '../../config/paths'
+import { spawnAsync, extractWindowsArchive } from '../../core/spawn-utils'
+import { isRenameFallbackError } from '../../core/fs-error-utils'
+import { logDebug } from '../../core/error-handler'
+import {
+  Engine,
+  Platform,
+  type Arch,
+  type ProgressCallback,
+  type InstalledBinary,
+  isValidPlatform,
+  isValidArch,
+} from '../../types'
+import {
+  normalizeVersion,
+  normalizeDocumentDBVersion,
+  DEFAULT_DOCUMENTDB_VERSION,
+} from './version-maps'
+import {
+  isPlatformSupported,
+  getFerretDBBinaryUrl,
+  getDocumentDBBinaryUrl,
+} from './binary-urls'
+
+const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Result of ensuring both FerretDB binaries are installed
+ */
+export type FerretDBBinaryPaths = {
+  ferretdbPath: string // Path to ferretdb binary directory
+  documentdbPath: string // Path to postgresql-documentdb binary directory
+}
+
+/**
+ * FerretDB Composite Binary Manager
+ *
+ * Manages the installation of both required binaries for FerretDB.
+ */
+class FerretDBCompositeBinaryManager {
+  /**
+   * Check if the current platform supports FerretDB
+   */
+  isPlatformSupported(platform: Platform, arch: Arch): boolean {
+    return isPlatformSupported(platform, arch)
+  }
+
+  /**
+   * Get the full version string for a FerretDB version
+   */
+  getFullVersion(version: string): string {
+    return normalizeVersion(version)
+  }
+
+  /**
+   * Get the full version string for a postgresql-documentdb version
+   */
+  getFullDocumentDBVersion(version: string): string {
+    return normalizeDocumentDBVersion(version)
+  }
+
+  /**
+   * Check if FerretDB binaries are installed for a specific version
+   */
+  async isInstalled(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+    backendVersion: string = DEFAULT_DOCUMENTDB_VERSION,
+  ): Promise<boolean> {
+    const fullVersion = this.getFullVersion(version)
+    const fullBackendVersion = this.getFullDocumentDBVersion(backendVersion)
+
+    // Check FerretDB proxy
+    const ferretdbPath = this.getFerretDBBinaryPath(fullVersion, platform, arch)
+    const ext = platform === Platform.Win32 ? '.exe' : ''
+    const ferretdbBinary = join(ferretdbPath, 'bin', `ferretdb${ext}`)
+    if (!existsSync(ferretdbBinary)) {
+      return false
+    }
+
+    // Check postgresql-documentdb (not available on Windows)
+    if (platform !== Platform.Win32) {
+      const documentdbPath = this.getDocumentDBBinaryPath(
+        fullBackendVersion,
+        platform,
+        arch,
+      )
+      const pgCtl = join(documentdbPath, 'bin', 'pg_ctl')
+      if (!existsSync(pgCtl)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * Get the path where FerretDB binaries would be installed
+   */
+  getFerretDBBinaryPath(version: string, platform: Platform, arch: Arch): string {
+    const fullVersion = this.getFullVersion(version)
+    return join(
+      paths.bin,
+      `ferretdb-${fullVersion}-${platform}-${arch}`,
+    )
+  }
+
+  /**
+   * Get the path where postgresql-documentdb binaries would be installed
+   */
+  getDocumentDBBinaryPath(version: string, platform: Platform, arch: Arch): string {
+    const fullVersion = this.getFullDocumentDBVersion(version)
+    return join(
+      paths.bin,
+      `postgresql-documentdb-${fullVersion}-${platform}-${arch}`,
+    )
+  }
+
+  /**
+   * List all installed FerretDB versions
+   */
+  async listInstalled(): Promise<InstalledBinary[]> {
+    const binDir = paths.bin
+    if (!existsSync(binDir)) {
+      return []
+    }
+
+    const entries = await readdir(binDir, { withFileTypes: true })
+    const installed: InstalledBinary[] = []
+    const prefix = 'ferretdb-'
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (!entry.name.startsWith(prefix)) continue
+
+      // Split from end to handle versions with dashes
+      // Format: ferretdb-{version}-{platform}-{arch}
+      const rest = entry.name.slice(prefix.length)
+      const parts = rest.split('-')
+      if (parts.length < 3) continue
+
+      const arch = parts.pop()!
+      const platform = parts.pop()!
+      const version = parts.join('-')
+
+      if (version && isValidPlatform(platform) && isValidArch(arch)) {
+        installed.push({
+          engine: Engine.FerretDB,
+          version,
+          platform,
+          arch,
+        })
+      }
+    }
+
+    return installed
+  }
+
+  /**
+   * Ensure both FerretDB binaries are installed
+   *
+   * @param version - FerretDB version
+   * @param platform - Operating system
+   * @param arch - Architecture
+   * @param onProgress - Progress callback
+   * @param backendVersion - postgresql-documentdb version (optional)
+   * @returns Paths to both binary directories
+   */
+  async ensureInstalled(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+    onProgress?: ProgressCallback,
+    backendVersion: string = DEFAULT_DOCUMENTDB_VERSION,
+  ): Promise<FerretDBBinaryPaths> {
+    // Reject Windows early
+    if (platform === Platform.Win32) {
+      throw new Error(
+        'FerretDB is not available on Windows because postgresql-documentdb cannot be built.\n\n' +
+          'Options:\n' +
+          '  1. Use WSL (Windows Subsystem for Linux)\n' +
+          '  2. Use native MongoDB: spindb create mydb --engine mongodb',
+      )
+    }
+
+    const fullVersion = this.getFullVersion(version)
+    const fullBackendVersion = this.getFullDocumentDBVersion(backendVersion)
+
+    // Check if already installed
+    if (
+      await this.isInstalled(version, platform, arch, backendVersion)
+    ) {
+      onProgress?.({
+        stage: 'cached',
+        message: 'Using cached FerretDB binaries',
+      })
+      return {
+        ferretdbPath: this.getFerretDBBinaryPath(fullVersion, platform, arch),
+        documentdbPath: this.getDocumentDBBinaryPath(
+          fullBackendVersion,
+          platform,
+          arch,
+        ),
+      }
+    }
+
+    // Download both binaries
+    const ferretdbPath = await this.downloadFerretDB(
+      version,
+      platform,
+      arch,
+      onProgress,
+    )
+    const documentdbPath = await this.downloadDocumentDB(
+      backendVersion,
+      platform,
+      arch,
+      onProgress,
+    )
+
+    return { ferretdbPath, documentdbPath }
+  }
+
+  /**
+   * Download FerretDB proxy binary
+   */
+  private async downloadFerretDB(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+    onProgress?: ProgressCallback,
+  ): Promise<string> {
+    const fullVersion = this.getFullVersion(version)
+    const url = getFerretDBBinaryUrl(version, platform, arch)
+    const binPath = this.getFerretDBBinaryPath(fullVersion, platform, arch)
+    const tempDir = join(paths.bin, `temp-ferretdb-${fullVersion}-${platform}-${arch}`)
+    const ext = platform === Platform.Win32 ? 'zip' : 'tar.gz'
+    const archiveFile = join(tempDir, `ferretdb.${ext}`)
+
+    // Ensure directories exist
+    await mkdir(paths.bin, { recursive: true })
+    await mkdir(tempDir, { recursive: true })
+    await mkdir(binPath, { recursive: true })
+
+    let success = false
+    try {
+      onProgress?.({
+        stage: 'downloading',
+        message: 'Downloading FerretDB proxy...',
+      })
+
+      await this.downloadArchive(url, archiveFile, 'FerretDB')
+
+      if (platform === Platform.Win32) {
+        await this.extractWindowsBinaries(archiveFile, binPath, tempDir, onProgress)
+      } else {
+        await this.extractUnixBinaries(archiveFile, binPath, tempDir, onProgress)
+      }
+
+      // Make binaries executable (Unix only)
+      if (platform !== Platform.Win32) {
+        const binDir = join(binPath, 'bin')
+        if (existsSync(binDir)) {
+          const binaries = await readdir(binDir)
+          for (const binary of binaries) {
+            await chmod(join(binDir, binary), 0o755)
+          }
+        }
+      }
+
+      // Verify the installation
+      onProgress?.({ stage: 'verifying', message: 'Verifying FerretDB...' })
+      await this.verifyFerretDB(fullVersion, platform, arch)
+
+      success = true
+      return binPath
+    } finally {
+      // Clean up temp directory
+      await rm(tempDir, { recursive: true, force: true })
+      // Clean up binPath on failure
+      if (!success) {
+        await rm(binPath, { recursive: true, force: true })
+      }
+    }
+  }
+
+  /**
+   * Download postgresql-documentdb backend binary
+   */
+  private async downloadDocumentDB(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+    onProgress?: ProgressCallback,
+  ): Promise<string> {
+    const fullVersion = this.getFullDocumentDBVersion(version)
+    const url = getDocumentDBBinaryUrl(version, platform, arch)
+    const binPath = this.getDocumentDBBinaryPath(fullVersion, platform, arch)
+    const tempDir = join(
+      paths.bin,
+      `temp-postgresql-documentdb-${fullVersion}-${platform}-${arch}`,
+    )
+    const archiveFile = join(tempDir, 'postgresql-documentdb.tar.gz')
+
+    // Ensure directories exist
+    await mkdir(paths.bin, { recursive: true })
+    await mkdir(tempDir, { recursive: true })
+    await mkdir(binPath, { recursive: true })
+
+    let success = false
+    try {
+      onProgress?.({
+        stage: 'downloading',
+        message: 'Downloading postgresql-documentdb backend...',
+      })
+
+      await this.downloadArchive(url, archiveFile, 'postgresql-documentdb')
+
+      await this.extractUnixBinaries(archiveFile, binPath, tempDir, onProgress)
+
+      // Make binaries executable
+      const binaryDir = join(binPath, 'bin')
+      if (existsSync(binaryDir)) {
+        const binaries = await readdir(binaryDir)
+        for (const binary of binaries) {
+          await chmod(join(binaryDir, binary), 0o755)
+        }
+      }
+
+      // Verify the installation
+      onProgress?.({
+        stage: 'verifying',
+        message: 'Verifying postgresql-documentdb...',
+      })
+      await this.verifyDocumentDB(fullVersion, platform, arch)
+
+      success = true
+      return binPath
+    } finally {
+      // Clean up temp directory
+      await rm(tempDir, { recursive: true, force: true })
+      // Clean up binPath on failure
+      if (!success) {
+        await rm(binPath, { recursive: true, force: true })
+      }
+    }
+  }
+
+  /**
+   * Download an archive file
+   */
+  private async downloadArchive(
+    url: string,
+    archiveFile: string,
+    displayName: string,
+  ): Promise<void> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(url, { signal: controller.signal })
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error(
+            `${displayName} binaries not found (404). ` +
+              'This version may have been removed from hostdb. ' +
+              'Try a different version or check https://github.com/robertjbass/hostdb/releases',
+          )
+        }
+        throw new Error(
+          `Failed to download ${displayName} binaries: ${response.status} ${response.statusText}`,
+        )
+      }
+
+      if (!response.body) {
+        throw new Error(
+          `Download failed: response has no body (status ${response.status})`,
+        )
+      }
+
+      const fileStream = createWriteStream(archiveFile)
+      try {
+        const nodeStream = Readable.fromWeb(response.body)
+        await pipeline(nodeStream, fileStream)
+      } catch (pipelineError) {
+        fileStream.destroy()
+        throw pipelineError
+      }
+    } catch (error) {
+      const err = error as Error
+      if (err.name === 'AbortError') {
+        throw new Error(
+          `Download timed out after ${DOWNLOAD_TIMEOUT_MS / 1000 / 60} minutes. ` +
+            'Check your network connection and try again.',
+        )
+      }
+      throw error
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+
+  /**
+   * Extract Unix binaries from tar.gz file
+   */
+  private async extractUnixBinaries(
+    tarFile: string,
+    binPath: string,
+    tempDir: string,
+    onProgress?: ProgressCallback,
+  ): Promise<void> {
+    onProgress?.({
+      stage: 'extracting',
+      message: 'Extracting binaries...',
+    })
+
+    const extractDir = join(tempDir, 'extract')
+    await mkdir(extractDir, { recursive: true })
+
+    try {
+      await spawnAsync('tar', ['-xzf', tarFile, '-C', extractDir])
+    } catch (error) {
+      const err = error as Error & { code?: string | number }
+
+      // Check if extraction actually succeeded despite the error
+      const entries = await readdir(extractDir)
+      if (entries.length === 0) {
+        throw new Error(
+          `Extraction failed: ${err.message}${err.code ? ` (code: ${err.code})` : ''}`,
+        )
+      }
+
+      logDebug('FerretDB extraction recovered from tar error', {
+        tarFile,
+        entriesExtracted: entries.length,
+        errorMessage: err.message,
+        errorCode: err.code,
+      })
+    }
+
+    await this.moveExtractedEntries(extractDir, binPath)
+  }
+
+  /**
+   * Extract Windows binaries from ZIP file
+   */
+  private async extractWindowsBinaries(
+    zipFile: string,
+    binPath: string,
+    tempDir: string,
+    onProgress?: ProgressCallback,
+  ): Promise<void> {
+    onProgress?.({
+      stage: 'extracting',
+      message: 'Extracting binaries...',
+    })
+
+    await extractWindowsArchive(zipFile, tempDir)
+    await this.moveExtractedEntries(tempDir, binPath)
+  }
+
+  /**
+   * Move extracted entries from extractDir to binPath
+   */
+  private async moveExtractedEntries(
+    extractDir: string,
+    binPath: string,
+  ): Promise<void> {
+    const entries = await readdir(extractDir, { withFileTypes: true })
+
+    // Look for engine directory (ferretdb-* or postgresql-documentdb-*)
+    const engineDir = entries.find(
+      (e) =>
+        e.isDirectory() &&
+        (e.name === 'ferretdb' ||
+          e.name.startsWith('ferretdb-') ||
+          e.name === 'postgresql-documentdb' ||
+          e.name.startsWith('postgresql-documentdb-')),
+    )
+
+    const sourceDir = engineDir ? join(extractDir, engineDir.name) : extractDir
+    const sourceEntries = engineDir
+      ? await readdir(sourceDir, { withFileTypes: true })
+      : entries
+
+    for (const entry of sourceEntries) {
+      const sourcePath = join(sourceDir, entry.name)
+      const destPath = join(binPath, entry.name)
+      try {
+        await rename(sourcePath, destPath)
+      } catch (error) {
+        if (isRenameFallbackError(error)) {
+          await cp(sourcePath, destPath, { recursive: true })
+          await rm(sourcePath, { recursive: true, force: true })
+        } else {
+          throw error
+        }
+      }
+    }
+  }
+
+  /**
+   * Verify FerretDB binary installation
+   */
+  private async verifyFerretDB(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+  ): Promise<void> {
+    const binPath = this.getFerretDBBinaryPath(version, platform, arch)
+    const ext = platform === Platform.Win32 ? '.exe' : ''
+    const ferretdbBinary = join(binPath, 'bin', `ferretdb${ext}`)
+
+    if (!existsSync(ferretdbBinary)) {
+      throw new Error(`FerretDB binary not found at ${binPath}/bin/`)
+    }
+
+    try {
+      const { stdout } = await spawnAsync(ferretdbBinary, ['--version'])
+      const match = stdout.match(/(?:ferretdb\s+)?(?:version\s+)?v?(\d+\.\d+\.\d+)/)
+      if (!match) {
+        throw new Error(`Could not parse FerretDB version from: ${stdout.trim()}`)
+      }
+
+      const reportedVersion = match[1]
+      const expectedMajor = version.split('.')[0]
+      const reportedMajor = reportedVersion.split('.')[0]
+
+      if (expectedMajor !== reportedMajor) {
+        throw new Error(
+          `Version mismatch: expected ${version}, got ${reportedVersion}`,
+        )
+      }
+    } catch (error) {
+      const err = error as Error
+      throw new Error(`Failed to verify FerretDB binary: ${err.message}`)
+    }
+  }
+
+  /**
+   * Verify postgresql-documentdb binary installation
+   */
+  private async verifyDocumentDB(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+  ): Promise<void> {
+    const binPath = this.getDocumentDBBinaryPath(version, platform, arch)
+    const pgCtl = join(binPath, 'bin', 'pg_ctl')
+
+    if (!existsSync(pgCtl)) {
+      throw new Error(`postgresql-documentdb binary not found at ${binPath}/bin/`)
+    }
+
+    try {
+      const { stdout } = await spawnAsync(pgCtl, ['--version'])
+      // Expected output: "pg_ctl (PostgreSQL) 17.x.x"
+      const match = stdout.match(/PostgreSQL[)\s]+(\d+)/)
+      if (!match) {
+        throw new Error(
+          `Could not parse PostgreSQL version from: ${stdout.trim()}`,
+        )
+      }
+
+      // version is like "17-0.107.0", extract PostgreSQL major version
+      const expectedPgMajor = version.split('-')[0]
+      const reportedPgMajor = match[1]
+
+      if (expectedPgMajor !== reportedPgMajor) {
+        throw new Error(
+          `PostgreSQL version mismatch: expected ${expectedPgMajor}, got ${reportedPgMajor}`,
+        )
+      }
+    } catch (error) {
+      const err = error as Error
+      throw new Error(
+        `Failed to verify postgresql-documentdb binary: ${err.message}`,
+      )
+    }
+  }
+
+  /**
+   * Delete installed binaries for a specific version
+   */
+  async delete(
+    version: string,
+    platform: Platform,
+    arch: Arch,
+    backendVersion: string = DEFAULT_DOCUMENTDB_VERSION,
+  ): Promise<void> {
+    const fullVersion = this.getFullVersion(version)
+    const fullBackendVersion = this.getFullDocumentDBVersion(backendVersion)
+
+    const ferretdbPath = this.getFerretDBBinaryPath(fullVersion, platform, arch)
+    const documentdbPath = this.getDocumentDBBinaryPath(
+      fullBackendVersion,
+      platform,
+      arch,
+    )
+
+    if (existsSync(ferretdbPath)) {
+      await rm(ferretdbPath, { recursive: true, force: true })
+    }
+    if (existsSync(documentdbPath)) {
+      await rm(documentdbPath, { recursive: true, force: true })
+    }
+  }
+}
+
+export const ferretdbBinaryManager = new FerretDBCompositeBinaryManager()

--- a/engines/ferretdb/binary-urls.ts
+++ b/engines/ferretdb/binary-urls.ts
@@ -1,0 +1,149 @@
+/**
+ * FerretDB binary URL generation for hostdb
+ *
+ * Generates download URLs for FerretDB binaries from the hostdb GitHub releases.
+ * FerretDB requires two binaries:
+ * - ferretdb: MongoDB-compatible proxy (all platforms including Windows)
+ * - postgresql-documentdb: PostgreSQL 17 + DocumentDB extension (no Windows)
+ */
+
+import { normalizeVersion, normalizeDocumentDBVersion } from './version-maps'
+import { buildHostdbUrl } from '../../core/hostdb-client'
+import { Engine, Platform, type Arch } from '../../types'
+
+// Supported platforms for FerretDB proxy (Go binary, all platforms)
+export const FERRETDB_SUPPORTED_PLATFORMS = new Set([
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-x64',
+])
+
+// Supported platforms for postgresql-documentdb backend (no Windows)
+export const DOCUMENTDB_SUPPORTED_PLATFORMS = new Set([
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+])
+
+/**
+ * Map Node.js platform/arch to hostdb platform key
+ */
+export function getHostdbPlatform(
+  platform: Platform,
+  arch: Arch,
+): string | null {
+  const key = `${platform}-${arch}`
+  return FERRETDB_SUPPORTED_PLATFORMS.has(key) ? key : null
+}
+
+/**
+ * Check if the current platform supports FerretDB
+ * Windows is not supported because postgresql-documentdb cannot be built for Windows
+ */
+export function isPlatformSupported(platform: Platform, arch: Arch): boolean {
+  const key = `${platform}-${arch}`
+  // FerretDB requires postgresql-documentdb which is not available on Windows
+  return DOCUMENTDB_SUPPORTED_PLATFORMS.has(key)
+}
+
+/**
+ * Get the download URL for FerretDB proxy binary
+ *
+ * @param version - FerretDB version (major or full)
+ * @param platform - Operating system (darwin, linux, win32)
+ * @param arch - Architecture (arm64, x64)
+ * @returns Download URL
+ */
+export function getFerretDBBinaryUrl(
+  version: string,
+  platform: Platform,
+  arch: Arch,
+): string {
+  const fullVersion = normalizeVersion(version)
+  const hostdbPlatform = getHostdbPlatform(platform, arch)
+
+  if (!hostdbPlatform) {
+    throw new Error(
+      `Unsupported platform: ${platform}-${arch}. FerretDB hostdb binaries are available for: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-x64`,
+    )
+  }
+
+  const ext = platform === Platform.Win32 ? 'zip' : 'tar.gz'
+
+  return buildHostdbUrl(Engine.FerretDB, {
+    version: fullVersion,
+    hostdbPlatform,
+    extension: ext,
+  })
+}
+
+/**
+ * Get the download URL for postgresql-documentdb backend binary
+ *
+ * @param version - DocumentDB version (e.g., "17-0.107.0")
+ * @param platform - Operating system (darwin, linux - NOT win32)
+ * @param arch - Architecture (arm64, x64)
+ * @returns Download URL
+ */
+export function getDocumentDBBinaryUrl(
+  version: string,
+  platform: Platform,
+  arch: Arch,
+): string {
+  const fullVersion = normalizeDocumentDBVersion(version)
+  const key = `${platform}-${arch}`
+
+  if (!DOCUMENTDB_SUPPORTED_PLATFORMS.has(key)) {
+    throw new Error(
+      `Unsupported platform: ${platform}-${arch}. postgresql-documentdb binaries are only available for: darwin-arm64, darwin-x64, linux-arm64, linux-x64\n` +
+        'Windows is not supported because postgresql-documentdb cannot be built for Windows.',
+    )
+  }
+
+  // postgresql-documentdb uses a specific tag format: postgresql-documentdb-{version}
+  // e.g., postgresql-documentdb-17-0.107.0
+  const ext = 'tar.gz' // Always tar.gz (no Windows support)
+
+  // Build URL manually since it's a different engine name format
+  // Format: https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-{version}/postgresql-documentdb-{version}-{platform}-{arch}.tar.gz
+  const baseUrl = 'https://github.com/robertjbass/hostdb/releases/download'
+  const tag = `postgresql-documentdb-${fullVersion}`
+  const filename = `postgresql-documentdb-${fullVersion}-${key}.${ext}`
+
+  return `${baseUrl}/${tag}/${filename}`
+}
+
+/**
+ * Get the combined binary URLs for FerretDB (both proxy and backend)
+ *
+ * @param version - FerretDB version (major or full)
+ * @param backendVersion - postgresql-documentdb version (e.g., "17-0.107.0")
+ * @param platform - Operating system
+ * @param arch - Architecture
+ * @returns Object with ferretdb and documentdb URLs
+ */
+export function getBinaryUrls(
+  version: string,
+  backendVersion: string,
+  platform: Platform,
+  arch: Arch,
+): { ferretdb: string; documentdb: string } {
+  // Validate platform supports FerretDB (requires postgresql-documentdb)
+  if (!isPlatformSupported(platform, arch)) {
+    throw new Error(
+      `FerretDB is not available on ${platform}-${arch}.\n` +
+        'postgresql-documentdb cannot be built for Windows.\n\n' +
+        'Options:\n' +
+        '  1. Use WSL (Windows Subsystem for Linux)\n' +
+        '  2. Use native MongoDB: spindb create mydb --engine mongodb',
+    )
+  }
+
+  return {
+    ferretdb: getFerretDBBinaryUrl(version, platform, arch),
+    documentdb: getDocumentDBBinaryUrl(backendVersion, platform, arch),
+  }
+}

--- a/engines/ferretdb/index.ts
+++ b/engines/ferretdb/index.ts
@@ -1,0 +1,932 @@
+/**
+ * FerretDB Engine implementation
+ *
+ * FerretDB is a MongoDB-compatible proxy that stores data in PostgreSQL.
+ * This is a composite engine that manages two processes:
+ * 1. PostgreSQL backend (postgresql-documentdb)
+ * 2. FerretDB proxy
+ *
+ * The lifecycle is:
+ * - Start: Start PostgreSQL → Wait for ready → Start FerretDB
+ * - Stop: Stop FerretDB → Stop PostgreSQL
+ */
+
+import { spawn, exec, type SpawnOptions } from 'child_process'
+import { promisify } from 'util'
+import { existsSync } from 'fs'
+import net from 'net'
+import { mkdir, writeFile, readFile, unlink } from 'fs/promises'
+import { join, basename } from 'path'
+import { BaseEngine } from '../base-engine'
+import { paths } from '../../config/paths'
+import { getEngineDefaults } from '../../config/defaults'
+import { platformService, isWindows } from '../../core/platform-service'
+import { configManager } from '../../core/config-manager'
+import { logDebug, logWarning } from '../../core/error-handler'
+import { processManager } from '../../core/process-manager'
+import { spawnAsync } from '../../core/spawn-utils'
+import { ferretdbBinaryManager } from './binary-manager'
+import {
+  SUPPORTED_MAJOR_VERSIONS,
+  FALLBACK_VERSION_MAP,
+  DEFAULT_DOCUMENTDB_VERSION,
+  normalizeVersion,
+  normalizeDocumentDBVersion,
+} from './version-maps'
+import { getBinaryUrls, isPlatformSupported } from './binary-urls'
+import {
+  detectBackupFormat as detectBackupFormatImpl,
+  restoreBackup,
+} from './restore'
+import { createBackup } from './backup'
+import {
+  Platform,
+  type Arch,
+  type ContainerConfig,
+  type ProgressCallback,
+  type BackupFormat,
+  type BackupOptions,
+  type BackupResult,
+  type RestoreResult,
+  type DumpResult,
+  type StatusResult,
+} from '../../types'
+
+const execAsync = promisify(exec)
+
+const ENGINE = 'ferretdb'
+const engineDef = getEngineDefaults(ENGINE)
+
+// Default internal PostgreSQL port range for FerretDB backends
+const BACKEND_PORT_START = 54320
+const BACKEND_PORT_END = 54400
+
+/**
+ * Allocate a port for the PostgreSQL backend
+ */
+async function allocateBackendPort(): Promise<number> {
+  for (let port = BACKEND_PORT_START; port < BACKEND_PORT_END; port++) {
+    if (await isPortAvailable(port)) {
+      return port
+    }
+  }
+  throw new Error(
+    `No available ports in range ${BACKEND_PORT_START}-${BACKEND_PORT_END} for PostgreSQL backend`,
+  )
+}
+
+/**
+ * Check if a port is available
+ */
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.once('listening', () => {
+      server.close()
+      resolve(true)
+    })
+    server.listen(port, '127.0.0.1')
+  })
+}
+
+/**
+ * Wait for a TCP port to accept connections
+ */
+function waitForPort(port: number, timeoutMs = 30000): Promise<boolean> {
+  const startTime = Date.now()
+  const checkInterval = 500
+
+  return new Promise((resolve) => {
+    const check = () => {
+      const socket = new net.Socket()
+      socket.setTimeout(1000)
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => {
+        socket.destroy()
+        if (Date.now() - startTime < timeoutMs) {
+          setTimeout(check, checkInterval)
+        } else {
+          resolve(false)
+        }
+      })
+      socket.once('timeout', () => {
+        socket.destroy()
+        if (Date.now() - startTime < timeoutMs) {
+          setTimeout(check, checkInterval)
+        } else {
+          resolve(false)
+        }
+      })
+      socket.connect(port, '127.0.0.1')
+    }
+    check()
+  })
+}
+
+export class FerretDBEngine extends BaseEngine {
+  name = ENGINE
+  displayName = 'FerretDB'
+  defaultPort = engineDef.defaultPort
+  supportedVersions = SUPPORTED_MAJOR_VERSIONS
+
+  // Get the current platform and architecture
+  getPlatformInfo(): { platform: Platform; arch: Arch } {
+    return platformService.getPlatformInfo()
+  }
+
+  /**
+   * Check if the current platform supports FerretDB
+   */
+  isPlatformSupported(): boolean {
+    const { platform, arch } = this.getPlatformInfo()
+    return isPlatformSupported(platform, arch)
+  }
+
+  /**
+   * Returns available FerretDB versions from the fallback version map.
+   */
+  async fetchAvailableVersions(): Promise<Record<string, string[]>> {
+    const versions: Record<string, string[]> = {}
+
+    for (const [major, full] of Object.entries(FALLBACK_VERSION_MAP)) {
+      if (/^\d+$/.test(major)) {
+        versions[major] = [full]
+      }
+    }
+
+    return versions
+  }
+
+  // Get binary download URL from hostdb
+  getBinaryUrl(version: string, platform: Platform, arch: Arch): string {
+    const urls = getBinaryUrls(version, DEFAULT_DOCUMENTDB_VERSION, platform, arch)
+    return urls.ferretdb
+  }
+
+  // Resolves version string to full version
+  resolveFullVersion(version: string): string {
+    if (/^\d+\.\d+\.\d+$/.test(version)) {
+      return version
+    }
+    return FALLBACK_VERSION_MAP[version] || `${version}.0.0`
+  }
+
+  // Get the path where binaries for a version would be installed
+  getBinaryPath(version: string): string {
+    const fullVersion = this.resolveFullVersion(version)
+    const { platform: p, arch: a } = this.getPlatformInfo()
+    return ferretdbBinaryManager.getFerretDBBinaryPath(fullVersion, p, a)
+  }
+
+  /**
+   * Verify that FerretDB binaries are available and functional
+   */
+  async verifyBinary(binPath: string, version?: string): Promise<boolean> {
+    const { platform: p, arch: a } = this.getPlatformInfo()
+
+    if (version) {
+      return ferretdbBinaryManager.isInstalled(
+        version,
+        p,
+        a,
+        DEFAULT_DOCUMENTDB_VERSION,
+      )
+    }
+
+    // Fallback: extract version from directory name
+    const dirName = basename(binPath)
+    const match = dirName.match(/^ferretdb-([\d.]+)-/)
+    if (match) {
+      const extractedVersion = match[1]
+      return ferretdbBinaryManager.isInstalled(
+        extractedVersion,
+        p,
+        a,
+        DEFAULT_DOCUMENTDB_VERSION,
+      )
+    }
+
+    // Last resort: check file existence
+    const ext = platformService.getExecutableExtension()
+    const ferretdbPath = join(binPath, 'bin', `ferretdb${ext}`)
+    return existsSync(ferretdbPath)
+  }
+
+  // Check if a specific FerretDB version is installed
+  async isBinaryInstalled(version: string): Promise<boolean> {
+    const { platform, arch } = this.getPlatformInfo()
+    return ferretdbBinaryManager.isInstalled(
+      version,
+      platform,
+      arch,
+      DEFAULT_DOCUMENTDB_VERSION,
+    )
+  }
+
+  /**
+   * Ensure FerretDB binaries are available for a specific version
+   */
+  async ensureBinaries(
+    version: string,
+    onProgress?: ProgressCallback,
+  ): Promise<string> {
+    const { platform, arch } = this.getPlatformInfo()
+
+    // Check platform support
+    if (platform === Platform.Win32) {
+      throw new Error(
+        'FerretDB is not available on Windows because postgresql-documentdb cannot be built.\n\n' +
+          'Options:\n' +
+          '  1. Use WSL (Windows Subsystem for Linux)\n' +
+          '  2. Use native MongoDB: spindb create mydb --engine mongodb',
+      )
+    }
+
+    // Download both binaries
+    const { ferretdbPath } =
+      await ferretdbBinaryManager.ensureInstalled(
+        version,
+        platform,
+        arch,
+        onProgress,
+        DEFAULT_DOCUMENTDB_VERSION,
+      )
+
+    // Register ferretdb binary in config
+    const ext = platformService.getExecutableExtension()
+    const ferretdbBinary = join(ferretdbPath, 'bin', `ferretdb${ext}`)
+    if (existsSync(ferretdbBinary)) {
+      await configManager.setBinaryPath('ferretdb', ferretdbBinary, 'bundled')
+    }
+
+    return ferretdbPath
+  }
+
+  /**
+   * Initialize a new FerretDB container directory
+   * Creates both the PostgreSQL data directory and FerretDB config
+   */
+  async initDataDir(
+    containerName: string,
+    version: string,
+    options: Record<string, unknown> = {},
+  ): Promise<string> {
+    const { platform, arch } = this.getPlatformInfo()
+
+    // Get binary paths
+    const backendVersion =
+      (options.backendVersion as string) || DEFAULT_DOCUMENTDB_VERSION
+    const fullBackendVersion = normalizeDocumentDBVersion(backendVersion)
+
+    const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+      fullBackendVersion,
+      platform,
+      arch,
+    )
+
+    // Container directory structure
+    const containerDir = paths.getContainerPath(containerName, { engine: ENGINE })
+    const pgDataDir = join(containerDir, 'pg_data')
+    const logsDir = join(containerDir, 'logs')
+
+    // Create directories
+    await mkdir(containerDir, { recursive: true })
+    await mkdir(logsDir, { recursive: true })
+
+    // Initialize PostgreSQL data directory
+    // Check for PG_VERSION file to determine if already initialized
+    // (directory may exist but be empty if created by containerManager.create)
+    const pgVersionFile = join(pgDataDir, 'PG_VERSION')
+    if (!existsSync(pgVersionFile)) {
+      const initdb = join(documentdbPath, 'bin', 'initdb')
+
+      if (!existsSync(initdb)) {
+        throw new Error(`initdb not found at ${initdb}`)
+      }
+
+      try {
+        await spawnAsync(initdb, [
+          '-D',
+          pgDataDir,
+          '-U',
+          'postgres',
+          '--encoding=UTF8',
+          '--locale=C',
+        ])
+        logDebug(`Initialized PostgreSQL data directory: ${pgDataDir}`)
+      } catch (error) {
+        const err = error as Error
+        throw new Error(`Failed to initialize PostgreSQL: ${err.message}`)
+      }
+    }
+
+    return pgDataDir
+  }
+
+  /**
+   * Start FerretDB (two-process lifecycle)
+   *
+   * 1. Allocate/verify backend port
+   * 2. Start PostgreSQL
+   * 3. Wait for PostgreSQL ready
+   * 4. Create ferretdb database + extension (first start)
+   * 5. Start FerretDB proxy
+   * 6. Verify FerretDB connectivity
+   */
+  async start(
+    container: ContainerConfig,
+    onProgress?: ProgressCallback,
+  ): Promise<{ port: number; connectionString: string }> {
+    const { name, port, version, backendVersion, backendPort: existingBackendPort } = container
+
+    // Check if already running
+    const alreadyRunning = await processManager.isRunning(name, { engine: ENGINE })
+    if (alreadyRunning) {
+      return {
+        port,
+        connectionString: this.getConnectionString(container),
+      }
+    }
+
+    const { platform, arch } = this.getPlatformInfo()
+    const fullVersion = normalizeVersion(version)
+    const fullBackendVersion = normalizeDocumentDBVersion(
+      backendVersion || DEFAULT_DOCUMENTDB_VERSION,
+    )
+
+    // Get binary paths
+    const ferretdbPath = ferretdbBinaryManager.getFerretDBBinaryPath(
+      fullVersion,
+      platform,
+      arch,
+    )
+    const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+      fullBackendVersion,
+      platform,
+      arch,
+    )
+
+    const ferretdbBinary = join(ferretdbPath, 'bin', 'ferretdb')
+    const pgCtl = join(documentdbPath, 'bin', 'pg_ctl')
+    const psql = join(documentdbPath, 'bin', 'psql')
+
+    // Verify binaries exist
+    if (!existsSync(ferretdbBinary)) {
+      throw new Error(
+        `FerretDB binary not found. Run: spindb engines download ferretdb ${version}`,
+      )
+    }
+    if (!existsSync(pgCtl)) {
+      throw new Error(
+        `postgresql-documentdb not found. Run: spindb engines download ferretdb ${version}`,
+      )
+    }
+
+    // Container paths
+    const containerDir = paths.getContainerPath(name, { engine: ENGINE })
+    const pgDataDir = join(containerDir, 'pg_data')
+    const logsDir = join(containerDir, 'logs')
+    const pgLogFile = join(logsDir, 'postgres.log')
+    const ferretPidFile = join(containerDir, 'ferretdb.pid')
+
+    // Allocate backend port
+    const backendPort = existingBackendPort || await allocateBackendPort()
+
+    let pgStarted = false
+    let ferretStarted = false
+
+    try {
+      // 1. Start PostgreSQL
+      onProgress?.({ stage: 'starting', message: 'Starting PostgreSQL backend...' })
+
+      // Use pg_ctl to start PostgreSQL
+      await spawnAsync(pgCtl, [
+        'start',
+        '-D',
+        pgDataDir,
+        '-l',
+        pgLogFile,
+        '-o',
+        `-p ${backendPort} -h 127.0.0.1`,
+        '-w', // Wait for startup
+      ])
+
+      pgStarted = true
+      logDebug(`PostgreSQL started on port ${backendPort}`)
+
+      // 2. Wait for PostgreSQL to be ready
+      onProgress?.({ stage: 'starting', message: 'Waiting for PostgreSQL...' })
+      const pgReady = await waitForPort(backendPort, 30000)
+      if (!pgReady) {
+        throw new Error('PostgreSQL failed to start within timeout')
+      }
+
+      // 3. Create ferretdb database and extension (first start)
+      onProgress?.({ stage: 'starting', message: 'Initializing FerretDB database...' })
+      try {
+        // Create ferretdb database if it doesn't exist
+        await spawnAsync(psql, [
+          '-h',
+          '127.0.0.1',
+          '-p',
+          String(backendPort),
+          '-U',
+          'postgres',
+          '-c',
+          "SELECT 1 FROM pg_database WHERE datname='ferretdb'" +
+            " OR (SELECT count(*) FROM pg_database WHERE datname='ferretdb') = 0" +
+            " AND pg_catalog.pg_create_database('ferretdb', template := 'template0', encoding := 'UTF8') IS NOT NULL;",
+        ]).catch(async () => {
+          // Database might already exist, try creating it directly
+          await spawnAsync(psql, [
+            '-h',
+            '127.0.0.1',
+            '-p',
+            String(backendPort),
+            '-U',
+            'postgres',
+            '-c',
+            "CREATE DATABASE ferretdb WITH ENCODING 'UTF8';",
+          ]).catch(() => {
+            // Ignore error if database already exists
+          })
+        })
+
+        // Create DocumentDB extension
+        await spawnAsync(psql, [
+          '-h',
+          '127.0.0.1',
+          '-p',
+          String(backendPort),
+          '-U',
+          'postgres',
+          '-d',
+          'ferretdb',
+          '-c',
+          'CREATE EXTENSION IF NOT EXISTS documentdb;',
+        ]).catch((error) => {
+          logWarning(`Failed to create documentdb extension: ${error}`)
+          // Continue anyway - extension might already exist
+        })
+
+        logDebug('FerretDB database initialized')
+      } catch (error) {
+        logDebug(`Database initialization warning: ${error}`)
+        // Continue - might already be initialized
+      }
+
+      // 4. Start FerretDB proxy
+      onProgress?.({ stage: 'starting', message: 'Starting FerretDB proxy...' })
+
+      const ferretArgs = [
+        '--listen-addr',
+        `127.0.0.1:${port}`,
+        '--postgresql-url',
+        `postgres://postgres@127.0.0.1:${backendPort}/ferretdb`,
+      ]
+
+      logDebug(`Starting FerretDB with args: ${ferretArgs.join(' ')}`)
+
+      const spawnOpts: SpawnOptions = {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
+      }
+
+      const proc = spawn(ferretdbBinary, ferretArgs, spawnOpts)
+
+      // Log output
+      let stderrOutput = ''
+      proc.stdout?.on('data', (data: Buffer) => {
+        logDebug(`ferretdb stdout: ${data.toString()}`)
+      })
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderrOutput += data.toString()
+        logDebug(`ferretdb stderr: ${data.toString()}`)
+      })
+
+      proc.unref()
+
+      // Write PID file
+      if (proc.pid) {
+        await writeFile(ferretPidFile, String(proc.pid))
+        ferretStarted = true
+      }
+
+      // 5. Wait for FerretDB to be ready
+      const ferretReady = await waitForPort(port, 30000)
+      if (!ferretReady) {
+        throw new Error(
+          `FerretDB failed to start within timeout. Stderr: ${stderrOutput}`,
+        )
+      }
+
+      logDebug(`FerretDB started on port ${port}`)
+
+      return {
+        port,
+        connectionString: this.getConnectionString(container),
+      }
+    } catch (error) {
+      // Rollback: stop any started processes
+      if (ferretStarted) {
+        await this.stopFerretDBProcess(containerDir).catch(() => {})
+      }
+      if (pgStarted) {
+        await this.stopPostgreSQLProcess(pgCtl, pgDataDir).catch(() => {})
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Stop FerretDB (reverse order: FerretDB first, then PostgreSQL)
+   */
+  async stop(container: ContainerConfig): Promise<void> {
+    const { name, backendVersion } = container
+    const { platform, arch } = this.getPlatformInfo()
+
+    const fullBackendVersion = normalizeDocumentDBVersion(
+      backendVersion || DEFAULT_DOCUMENTDB_VERSION,
+    )
+
+    const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+      fullBackendVersion,
+      platform,
+      arch,
+    )
+    const pgCtl = join(documentdbPath, 'bin', 'pg_ctl')
+
+    const containerDir = paths.getContainerPath(name, { engine: ENGINE })
+    const pgDataDir = join(containerDir, 'pg_data')
+
+    logDebug(`Stopping FerretDB container "${name}"`)
+
+    // 1. Stop FerretDB proxy
+    await this.stopFerretDBProcess(containerDir)
+
+    // 2. Stop PostgreSQL
+    if (existsSync(pgCtl)) {
+      await this.stopPostgreSQLProcess(pgCtl, pgDataDir)
+    }
+
+    logDebug('FerretDB stopped')
+  }
+
+  /**
+   * Stop FerretDB proxy process
+   */
+  private async stopFerretDBProcess(containerDir: string): Promise<void> {
+    const pidFile = join(containerDir, 'ferretdb.pid')
+
+    if (existsSync(pidFile)) {
+      try {
+        const pidContent = await readFile(pidFile, 'utf8')
+        const pid = parseInt(pidContent.trim(), 10)
+
+        if (!isNaN(pid) && platformService.isProcessRunning(pid)) {
+          logDebug(`Killing FerretDB process ${pid}`)
+          await platformService.terminateProcess(pid, false)
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+
+          if (platformService.isProcessRunning(pid)) {
+            logWarning(`Graceful termination failed, force killing ${pid}`)
+            await platformService.terminateProcess(pid, true)
+          }
+        }
+
+        await unlink(pidFile).catch(() => {})
+      } catch (error) {
+        logDebug(`Error stopping FerretDB: ${error}`)
+      }
+    }
+  }
+
+  /**
+   * Stop PostgreSQL process
+   */
+  private async stopPostgreSQLProcess(
+    pgCtl: string,
+    pgDataDir: string,
+  ): Promise<void> {
+    try {
+      await spawnAsync(pgCtl, ['stop', '-D', pgDataDir, '-m', 'fast', '-w'])
+      logDebug('PostgreSQL stopped')
+    } catch (error) {
+      logDebug(`pg_ctl stop error: ${error}`)
+      // Try immediate mode if fast fails
+      try {
+        await spawnAsync(pgCtl, ['stop', '-D', pgDataDir, '-m', 'immediate', '-w'])
+      } catch {
+        logWarning('Failed to stop PostgreSQL gracefully')
+      }
+    }
+  }
+
+  // Get FerretDB server status
+  async status(container: ContainerConfig): Promise<StatusResult> {
+    const { name, port } = container
+    const containerDir = paths.getContainerPath(name, { engine: ENGINE })
+    const pidFile = join(containerDir, 'ferretdb.pid')
+
+    // Check if FerretDB is responding
+    const isOpen = await new Promise<boolean>((resolve) => {
+      const socket = new net.Socket()
+      socket.setTimeout(1000)
+      socket.once('connect', () => {
+        socket.destroy()
+        resolve(true)
+      })
+      socket.once('error', () => {
+        socket.destroy()
+        resolve(false)
+      })
+      socket.once('timeout', () => {
+        socket.destroy()
+        resolve(false)
+      })
+      socket.connect(port, '127.0.0.1')
+    })
+
+    if (isOpen) {
+      return { running: true, message: 'FerretDB is running' }
+    }
+
+    // Check PID file
+    if (existsSync(pidFile)) {
+      try {
+        const content = await readFile(pidFile, 'utf8')
+        const pid = parseInt(content.trim(), 10)
+        if (!isNaN(pid) && pid > 0 && platformService.isProcessRunning(pid)) {
+          return {
+            running: true,
+            message: `FerretDB is running (PID: ${pid})`,
+          }
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    return { running: false, message: 'FerretDB is not running' }
+  }
+
+  // Detect backup format
+  async detectBackupFormat(filePath: string): Promise<BackupFormat> {
+    return detectBackupFormatImpl(filePath)
+  }
+
+  // Restore a backup
+  async restore(
+    container: ContainerConfig,
+    backupPath: string,
+    options: Record<string, unknown> = {},
+  ): Promise<RestoreResult> {
+    const { backendPort } = container
+    const database = (options.database as string) || 'ferretdb'
+
+    if (!backendPort) {
+      throw new Error('Backend port not set - start the container first')
+    }
+
+    return restoreBackup(container, backupPath, {
+      database,
+      drop: options.drop !== false,
+    })
+  }
+
+  // Get connection string (MongoDB-compatible)
+  getConnectionString(container: ContainerConfig, database?: string): string {
+    const { port } = container
+    const db = database || 'test'
+    return `mongodb://127.0.0.1:${port}/${db}`
+  }
+
+  // Get PostgreSQL backend connection string (for debugging)
+  getBackendConnectionString(container: ContainerConfig): string {
+    const { backendPort } = container
+    return `postgresql://postgres@127.0.0.1:${backendPort || 54320}/ferretdb`
+  }
+
+  /**
+   * Get the path to mongosh (uses MongoDB's mongosh)
+   * FerretDB is MongoDB-compatible, so it uses the same shell
+   */
+  override async getMongoshPath(): Promise<string> {
+    const cached = await configManager.getBinaryPath('mongosh')
+    if (cached && existsSync(cached)) return cached
+
+    // Try to find in PATH as fallback
+    const detected = await platformService.findToolPath('mongosh')
+    if (detected) {
+      await configManager.setBinaryPath('mongosh', detected, 'system')
+      return detected
+    }
+
+    throw new Error(
+      'mongosh not found. To connect to FerretDB, install mongosh:\n' +
+        '  Download from: https://www.mongodb.com/try/download/shell\n' +
+        '  Or download MongoDB binaries: spindb engines download mongodb <version>',
+    )
+  }
+
+  // Open mongosh interactive shell
+  async connect(container: ContainerConfig, database?: string): Promise<void> {
+    const { port } = container
+    const db = database || 'test'
+
+    const mongosh = await this.getMongoshPath()
+
+    const spawnOptions: SpawnOptions = {
+      stdio: 'inherit',
+    }
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(
+        mongosh,
+        ['--host', '127.0.0.1', '--port', String(port), db],
+        spawnOptions,
+      )
+
+      proc.on('error', reject)
+      proc.on('close', () => resolve())
+    })
+  }
+
+  /**
+   * Create a new database
+   * FerretDB/MongoDB creates databases implicitly when you write to them
+   */
+  async createDatabase(
+    container: ContainerConfig,
+    database: string,
+  ): Promise<void> {
+    // MongoDB/FerretDB creates databases implicitly
+    // Just verify the connection works
+    logDebug(`Database "${database}" will be created when first accessed`)
+  }
+
+  // Drop a database
+  async dropDatabase(
+    container: ContainerConfig,
+    database: string,
+  ): Promise<void> {
+    const { port } = container
+
+    try {
+      const mongosh = await this.getMongoshPath()
+      const cmd = isWindows()
+        ? `"${mongosh}" --host 127.0.0.1 --port ${port} ${database} --eval "db.dropDatabase()"`
+        : `"${mongosh}" --host 127.0.0.1 --port ${port} ${database} --eval 'db.dropDatabase()'`
+
+      await execAsync(cmd, { timeout: 10000 })
+    } catch (error) {
+      logDebug(`dropDatabase result: ${error}`)
+    }
+  }
+
+  // Get the size of the database in bytes
+  async getDatabaseSize(container: ContainerConfig): Promise<number | null> {
+    const { port, database } = container
+    const db = database || 'test'
+
+    try {
+      const mongosh = await this.getMongoshPath()
+      const script = 'JSON.stringify(db.stats())'
+      const cmd = isWindows()
+        ? `"${mongosh}" --host 127.0.0.1 --port ${port} ${db} --quiet --eval "${script}"`
+        : `"${mongosh}" --host 127.0.0.1 --port ${port} ${db} --quiet --eval '${script}'`
+
+      const { stdout } = await execAsync(cmd, { timeout: 10000 })
+
+      // Extract JSON from output
+      const firstBrace = stdout.indexOf('{')
+      const lastBrace = stdout.lastIndexOf('}')
+      if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+        const stats = JSON.parse(stdout.substring(firstBrace, lastBrace + 1))
+        return stats?.dataSize || null
+      }
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  // Create a dump from a remote database
+  async dumpFromConnectionString(
+    connectionString: string,
+    outputPath: string,
+  ): Promise<DumpResult> {
+    // Use mongodump if available
+    const mongodump = await configManager.getBinaryPath('mongodump')
+    if (!mongodump) {
+      throw new Error(
+        'mongodump not found. Download MongoDB binaries:\n' +
+          '  Run: spindb engines download mongodb <version>',
+      )
+    }
+
+    const args = ['--uri', connectionString, '--archive=' + outputPath, '--gzip']
+
+    const spawnOptions: SpawnOptions = {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(mongodump, args, spawnOptions)
+
+      let stdout = ''
+      let stderr = ''
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString()
+      })
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString()
+      })
+
+      proc.on('error', reject)
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve({
+            filePath: outputPath,
+            stdout,
+            stderr,
+            code,
+          })
+        } else {
+          reject(new Error(stderr || `mongodump exited with code ${code}`))
+        }
+      })
+    })
+  }
+
+  // Create a backup
+  async backup(
+    container: ContainerConfig,
+    outputPath: string,
+    options: BackupOptions,
+  ): Promise<BackupResult> {
+    return createBackup(container, outputPath, options)
+  }
+
+  // Run a JavaScript file or inline script against the database
+  async runScript(
+    container: ContainerConfig,
+    options: { file?: string; sql?: string; database?: string },
+  ): Promise<void> {
+    const { port } = container
+    const db = options.database || container.database || 'test'
+
+    const mongosh = await this.getMongoshPath()
+
+    if (options.file) {
+      const spawnOptions: SpawnOptions = {
+        stdio: 'inherit',
+      }
+
+      return new Promise((resolve, reject) => {
+        const proc = spawn(
+          mongosh,
+          [
+            '--host',
+            '127.0.0.1',
+            '--port',
+            String(port),
+            db,
+            '--file',
+            options.file!,
+          ],
+          spawnOptions,
+        )
+
+        proc.on('error', reject)
+        proc.on('close', (code) => {
+          if (code === 0) {
+            resolve()
+          } else {
+            reject(new Error(`mongosh exited with code ${code}`))
+          }
+        })
+      })
+    } else if (options.sql) {
+      // sql field is actually JS for MongoDB-compatible databases
+      const script = options.sql
+      const cmd = isWindows()
+        ? `"${mongosh}" --host 127.0.0.1 --port ${port} ${db} --eval "${script.replace(/"/g, '\\"')}"`
+        : `"${mongosh}" --host 127.0.0.1 --port ${port} ${db} --eval '${script.replace(/'/g, "'\\''")}' `
+
+      const { stdout, stderr } = await execAsync(cmd, { timeout: 60000 })
+      if (stdout) process.stdout.write(stdout)
+      if (stderr) process.stderr.write(stderr)
+    } else {
+      throw new Error('Either file or sql option must be provided')
+    }
+  }
+}
+
+export const ferretdbEngine = new FerretDBEngine()

--- a/engines/ferretdb/restore.ts
+++ b/engines/ferretdb/restore.ts
@@ -1,0 +1,260 @@
+/**
+ * FerretDB restore module
+ *
+ * Restores backups using pg_restore or psql on the embedded PostgreSQL backend.
+ */
+
+import { spawn, type SpawnOptions } from 'child_process'
+import { existsSync, statSync } from 'fs'
+import { join } from 'path'
+import { logDebug, logWarning } from '../../core/error-handler'
+import { platformService } from '../../core/platform-service'
+import { ferretdbBinaryManager } from './binary-manager'
+import {
+  normalizeDocumentDBVersion,
+  DEFAULT_DOCUMENTDB_VERSION,
+} from './version-maps'
+import type { ContainerConfig, BackupFormat, RestoreResult } from '../../types'
+
+/**
+ * Get the path to pg_restore from the postgresql-documentdb installation
+ */
+function getPgRestorePath(container: ContainerConfig): string {
+  const { backendVersion } = container
+  const { platform, arch } = platformService.getPlatformInfo()
+
+  const fullBackendVersion = normalizeDocumentDBVersion(
+    backendVersion || DEFAULT_DOCUMENTDB_VERSION,
+  )
+  const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+    fullBackendVersion,
+    platform,
+    arch,
+  )
+
+  return join(documentdbPath, 'bin', 'pg_restore')
+}
+
+/**
+ * Get the path to psql from the postgresql-documentdb installation
+ */
+function getPsqlPath(container: ContainerConfig): string {
+  const { backendVersion } = container
+  const { platform, arch } = platformService.getPlatformInfo()
+
+  const fullBackendVersion = normalizeDocumentDBVersion(
+    backendVersion || DEFAULT_DOCUMENTDB_VERSION,
+  )
+  const documentdbPath = ferretdbBinaryManager.getDocumentDBBinaryPath(
+    fullBackendVersion,
+    platform,
+    arch,
+  )
+
+  return join(documentdbPath, 'bin', 'psql')
+}
+
+/**
+ * Detect the format of a backup file
+ */
+export async function detectBackupFormat(
+  filePath: string,
+): Promise<BackupFormat> {
+  if (!existsSync(filePath)) {
+    throw new Error(`Backup file not found: ${filePath}`)
+  }
+
+  const stats = statSync(filePath)
+
+  if (stats.isDirectory()) {
+    return {
+      format: 'directory',
+      description: 'PostgreSQL directory format backup',
+      restoreCommand: `pg_restore -h 127.0.0.1 -p PORT -U postgres -d DATABASE ${filePath}`,
+    }
+  }
+
+  // Check file header to determine format
+  try {
+    const buffer = Buffer.alloc(16)
+    const fd = await import('fs').then((fs) => fs.promises.open(filePath, 'r'))
+    try {
+      await fd.read(buffer, 0, 16, 0)
+    } finally {
+      await fd.close().catch(() => {})
+    }
+
+    // PostgreSQL custom format starts with "PGDMP"
+    const header = buffer.toString('ascii', 0, 5)
+    if (header === 'PGDMP') {
+      return {
+        format: 'custom',
+        description: 'PostgreSQL custom format backup',
+        restoreCommand: `pg_restore -h 127.0.0.1 -p PORT -U postgres -d DATABASE ${filePath}`,
+      }
+    }
+
+    // Check for SQL format (starts with common SQL patterns)
+    const textHeader = buffer.toString('utf8', 0, 16)
+    if (
+      textHeader.startsWith('--') ||
+      textHeader.startsWith('/*') ||
+      textHeader.includes('CREATE') ||
+      textHeader.includes('INSERT') ||
+      textHeader.includes('PGDUMP')
+    ) {
+      return {
+        format: 'sql',
+        description: 'Plain SQL backup',
+        restoreCommand: `psql -h 127.0.0.1 -p PORT -U postgres -d DATABASE -f ${filePath}`,
+      }
+    }
+
+    // Check file extension as fallback
+    if (filePath.endsWith('.dump')) {
+      return {
+        format: 'custom',
+        description: 'PostgreSQL custom format backup (by extension)',
+        restoreCommand: `pg_restore -h 127.0.0.1 -p PORT -U postgres -d DATABASE ${filePath}`,
+      }
+    }
+
+    if (filePath.endsWith('.sql')) {
+      return {
+        format: 'sql',
+        description: 'Plain SQL backup (by extension)',
+        restoreCommand: `psql -h 127.0.0.1 -p PORT -U postgres -d DATABASE -f ${filePath}`,
+      }
+    }
+
+    return {
+      format: 'unknown',
+      description: 'Unknown format - attempting as custom format',
+      restoreCommand: `pg_restore -h 127.0.0.1 -p PORT -U postgres -d DATABASE ${filePath}`,
+    }
+  } catch {
+    return {
+      format: 'unknown',
+      description: 'Could not detect format',
+      restoreCommand: `pg_restore -h 127.0.0.1 -p PORT -U postgres -d DATABASE ${filePath}`,
+    }
+  }
+}
+
+// Restore options
+export type RestoreOptions = {
+  database: string
+  drop?: boolean
+}
+
+/**
+ * Restore a backup to a FerretDB container
+ *
+ * Uses pg_restore for custom format backups, psql for SQL format
+ */
+export async function restoreBackup(
+  container: ContainerConfig,
+  backupPath: string,
+  options: RestoreOptions,
+): Promise<RestoreResult> {
+  const { backendPort } = container
+  const { database, drop = true } = options
+
+  if (!backendPort) {
+    throw new Error(
+      'Backend port not set. Make sure the container is running before restoring.',
+    )
+  }
+
+  // Detect backup format
+  const format = await detectBackupFormat(backupPath)
+  logDebug(`Detected backup format: ${format.format}`)
+
+  // Choose restore tool based on format
+  const isSqlFormat = format.format === 'sql'
+  const toolPath = isSqlFormat
+    ? getPsqlPath(container)
+    : getPgRestorePath(container)
+
+  if (!existsSync(toolPath)) {
+    const toolName = isSqlFormat ? 'psql' : 'pg_restore'
+    throw new Error(
+      `${toolName} not found at ${toolPath}. Make sure postgresql-documentdb is installed.`,
+    )
+  }
+
+  const args: string[] = [
+    '-h',
+    '127.0.0.1',
+    '-p',
+    String(backendPort),
+    '-U',
+    'postgres',
+    '-d',
+    database,
+  ]
+
+  if (isSqlFormat) {
+    // psql: use -f flag for file input
+    args.push('-f', backupPath)
+  } else {
+    // pg_restore: add options for custom/directory format
+    if (drop) {
+      args.push('--clean', '--if-exists')
+    }
+    args.push(backupPath)
+  }
+
+  logDebug(
+    `Running ${isSqlFormat ? 'psql' : 'pg_restore'} with args: ${args.join(' ')}`,
+  )
+
+  const spawnOptions: SpawnOptions = {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(toolPath, args, spawnOptions)
+
+    let stdout = ''
+    let stderr = ''
+
+    proc.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString()
+    })
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    proc.on('error', reject)
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve({
+          format: format.format,
+          stdout,
+          stderr,
+          code,
+        })
+      } else {
+        // pg_restore may exit with non-zero but still restore some data
+        if (stderr.includes('already exists') || stderr.includes('WARNING')) {
+          logWarning(`Restore completed with warnings: ${stderr}`)
+          resolve({
+            format: format.format,
+            stdout,
+            stderr,
+            code: code ?? undefined,
+          })
+        } else {
+          reject(
+            new Error(
+              stderr ||
+                `${isSqlFormat ? 'psql' : 'pg_restore'} exited with code ${code}`,
+            ),
+          )
+        }
+      }
+    })
+  })
+}

--- a/engines/ferretdb/version-maps.ts
+++ b/engines/ferretdb/version-maps.ts
@@ -1,0 +1,120 @@
+/**
+ * FerretDB version mapping
+ *
+ * TEMPORARY: This version map will be replaced by the hostdb npm package once published.
+ * Until then, manually keep this in sync with robertjbass/hostdb releases.json:
+ * https://github.com/robertjbass/hostdb/blob/main/releases.json
+ *
+ * FerretDB requires two binaries:
+ * - ferretdb: The MongoDB-compatible proxy
+ * - postgresql-documentdb: PostgreSQL 17 with DocumentDB extension
+ *
+ * To update: Check releases.json, find databases.ferretdb, copy all version strings.
+ */
+
+import { logDebug } from '../../core/error-handler'
+
+/**
+ * Map major versions to full versions for FerretDB proxy
+ * Keys are major versions (e.g., "2")
+ * Values are full versions from hostdb releases.json
+ */
+export const FERRETDB_VERSION_MAP: Record<string, string> = {
+  // 1-part: major version -> latest
+  '2': '2.7.0',
+  // 2-part: major.minor -> latest patch
+  '2.7': '2.7.0',
+  // 3-part: exact version (identity mapping)
+  '2.7.0': '2.7.0',
+}
+
+/**
+ * Map for postgresql-documentdb backend versions
+ * Format: postgresql-{pg_version}-{documentdb_version}
+ * e.g., "17-0.107.0" means PostgreSQL 17 with DocumentDB extension 0.107.0
+ */
+export const DOCUMENTDB_VERSION_MAP: Record<string, string> = {
+  // Default backend version
+  '17': '17-0.107.0',
+  // Full version (identity)
+  '17-0.107.0': '17-0.107.0',
+}
+
+/**
+ * Supported major FerretDB versions (1-part format).
+ * Used for grouping and display purposes.
+ */
+export const SUPPORTED_MAJOR_VERSIONS = ['2']
+
+/**
+ * Default postgresql-documentdb version to use with FerretDB
+ */
+export const DEFAULT_DOCUMENTDB_VERSION = '17-0.107.0'
+
+/**
+ * Fallback map of major versions to stable patch versions
+ * Used when hostdb repository is unreachable
+ */
+export const FALLBACK_VERSION_MAP: Record<string, string> = FERRETDB_VERSION_MAP
+
+/**
+ * Get the full version for a FerretDB version string
+ * @param version - Version string (e.g., "2", "2.7", "2.7.0")
+ * @returns Full version or null if not found
+ */
+export function getFullVersion(version: string): string | null {
+  // Try exact match first
+  if (FERRETDB_VERSION_MAP[version]) {
+    return FERRETDB_VERSION_MAP[version]
+  }
+
+  // Try matching major only (e.g., "2" -> highest 2.x version)
+  const majorOnly = version.split('.')[0]
+  const matchingVersions = Object.entries(FERRETDB_VERSION_MAP)
+    .filter(([key]) => key.split('.')[0] === majorOnly)
+    .sort(([a], [b]) => b.localeCompare(a, undefined, { numeric: true }))
+
+  if (matchingVersions.length > 0) {
+    return matchingVersions[0][1]
+  }
+
+  return null
+}
+
+/**
+ * Normalize a version string to a full version
+ * @param version - Version string (major, major.minor, or full)
+ * @returns Full version string
+ */
+export function normalizeVersion(version: string): string {
+  // If already a full version (x.y.z), return as-is
+  if (/^\d+\.\d+\.\d+$/.test(version)) {
+    return version
+  }
+
+  // Delegate to getFullVersion for major/major.minor lookup
+  const fullVersion = getFullVersion(version)
+  if (fullVersion) {
+    return fullVersion
+  }
+
+  // Unknown version format - log debug and return as-is
+  // This may cause download failures if the version doesn't exist in hostdb
+  logDebug(
+    `FerretDB version '${version}' not in version map, may not be available in hostdb`,
+  )
+  return version
+}
+
+/**
+ * Normalize a postgresql-documentdb version string
+ * @param version - Version string (e.g., "17", "17-0.107.0")
+ * @returns Full version string (e.g., "17-0.107.0")
+ */
+export function normalizeDocumentDBVersion(version: string): string {
+  if (DOCUMENTDB_VERSION_MAP[version]) {
+    return DOCUMENTDB_VERSION_MAP[version]
+  }
+  // Return as-is if not found
+  return version
+}

--- a/engines/index.ts
+++ b/engines/index.ts
@@ -4,6 +4,7 @@ import { mariadbEngine } from './mariadb'
 import { sqliteEngine } from './sqlite'
 import { duckdbEngine } from './duckdb'
 import { mongodbEngine } from './mongodb'
+import { ferretdbEngine } from './ferretdb'
 import { redisEngine } from './redis'
 import { valkeyEngine } from './valkey'
 import { clickhouseEngine } from './clickhouse'
@@ -32,6 +33,9 @@ export const engines: Record<string, BaseEngine> = {
   // MongoDB and aliases
   mongodb: mongodbEngine,
   mongo: mongodbEngine,
+  // FerretDB and aliases
+  ferretdb: ferretdbEngine,
+  ferret: ferretdbEngine,
   // Redis and aliases
   redis: redisEngine,
   // Valkey and aliases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
   "type": "module",
   "bin": {

--- a/plans/FERRETDB.md
+++ b/plans/FERRETDB.md
@@ -780,6 +780,7 @@ This section contains implementation details from the hostdb project about how t
 All binaries are available from the [hostdb releases page](https://github.com/robertjbass/hostdb/releases).
 
 **postgresql-documentdb** (PostgreSQL 17 with DocumentDB extension):
+
 | Platform | Download |
 |----------|----------|
 | linux-x64 | [postgresql-documentdb-17-0.107.0-linux-x64.tar.gz](https://github.com/robertjbass/hostdb/releases/download/postgresql-documentdb-17-0.107.0/postgresql-documentdb-17-0.107.0-linux-x64.tar.gz) |
@@ -789,6 +790,7 @@ All binaries are available from the [hostdb releases page](https://github.com/ro
 | win32-x64 | Not available (see [Windows Limitations](#windows-limitations)) |
 
 **ferretdb** (MongoDB-compatible proxy):
+
 | Platform | Download |
 |----------|----------|
 | linux-x64 | [ferretdb-2.7.0-linux-x64.tar.gz](https://github.com/robertjbass/hostdb/releases/download/ferretdb-2.7.0/ferretdb-2.7.0-linux-x64.tar.gz) |
@@ -798,6 +800,7 @@ All binaries are available from the [hostdb releases page](https://github.com/ro
 | win32-x64 | [ferretdb-2.7.0-win32-x64.zip](https://github.com/robertjbass/hostdb/releases/download/ferretdb-2.7.0/ferretdb-2.7.0-win32-x64.zip) (requires WSL for backend) |
 
 **SHA256 Checksums (postgresql-documentdb-17-0.107.0):**
+
 | Platform | SHA256 |
 |----------|--------|
 | darwin-arm64 | `2a3892c1fb5fc91ba6cfcaf883b8deff89d11be3c7fa9e8ab3820290f6cc26a6` |
@@ -809,7 +812,7 @@ All binaries are available from the [hostdb releases page](https://github.com/ro
 
 FerretDB is a **stateless proxy** that translates MongoDB wire protocol to PostgreSQL SQL:
 
-```
+```text
 ┌─────────────────┐         ┌─────────────────┐         ┌─────────────────────────┐
 │  MongoDB Client │   TCP   │    FerretDB     │   TCP   │  PostgreSQL+DocumentDB  │
 │   (mongosh,     │ ──────► │     Proxy       │ ──────► │      Backend            │
@@ -847,7 +850,7 @@ The backend port is stored in `container.json` as `backendPort` and is allocated
 
 The `postgresql-documentdb` tarball extracts to a self-contained PostgreSQL installation with all required extensions pre-built:
 
-```
+```text
 postgresql-documentdb-17-0.107.0-darwin-arm64/
 ├── postgresql-documentdb/
 │   ├── bin/
@@ -884,7 +887,7 @@ postgresql-documentdb-17-0.107.0-darwin-arm64/
 
 The `ferretdb` tarball is simpler - a single Go binary with optional bundled tools:
 
-```
+```text
 ferretdb-2.7.0-darwin-arm64/
 ├── bin/
 │   └── ferretdb                       # Main FerretDB binary (~30MB)

--- a/tests/fixtures/ferretdb/seeds/README.md
+++ b/tests/fixtures/ferretdb/seeds/README.md
@@ -1,0 +1,27 @@
+# FerretDB Test Fixtures
+
+FerretDB is a MongoDB-compatible proxy that stores data in PostgreSQL.
+
+## Seed Data
+
+The `sample-db.js` file contains test data that can be run with mongosh:
+
+```bash
+mongosh mongodb://localhost:27017/test --file sample-db.js
+```
+
+This creates:
+- `test_users` collection with 5 user documents
+- `test_products` collection with 3 product documents
+
+## Testing Approach
+
+FerretDB uses MongoDB client tools (mongosh, mongodump, mongorestore) for
+interaction. Since backups use pg_dump/pg_restore on the PostgreSQL backend,
+testing follows the same patterns as PostgreSQL with MongoDB-compatible
+connection strings.
+
+## Docker E2E Tests
+
+For Docker E2E tests, use mongosh (when available) or curl against the
+MongoDB wire protocol (FerretDB listens on port 27017 by default).

--- a/tests/fixtures/ferretdb/seeds/sample-db.js
+++ b/tests/fixtures/ferretdb/seeds/sample-db.js
@@ -1,0 +1,25 @@
+// FerretDB test seed data
+// This file can be run with: mongosh mongodb://localhost:27017/test --file sample-db.js
+
+// Create test_users collection with sample data
+db.test_users.drop()
+db.test_users.insertMany([
+  { name: 'Alice', email: 'alice@example.com', age: 30 },
+  { name: 'Bob', email: 'bob@example.com', age: 25 },
+  { name: 'Charlie', email: 'charlie@example.com', age: 35 },
+  { name: 'Diana', email: 'diana@example.com', age: 28 },
+  { name: 'Eve', email: 'eve@example.com', age: 32 },
+])
+
+// Create test_products collection
+db.test_products.drop()
+db.test_products.insertMany([
+  { name: 'Widget', price: 9.99, category: 'electronics' },
+  { name: 'Gadget', price: 19.99, category: 'electronics' },
+  { name: 'Book', price: 14.99, category: 'books' },
+])
+
+// Print confirmation
+print('Seed data inserted successfully')
+print('test_users count: ' + db.test_users.countDocuments())
+print('test_products count: ' + db.test_products.countDocuments())

--- a/tests/unit/config-manager.test.ts
+++ b/tests/unit/config-manager.test.ts
@@ -89,6 +89,7 @@ describe('ConfigManager', () => {
         MYSQL_TOOLS,
         MARIADB_TOOLS,
         MONGODB_TOOLS,
+        FERRETDB_TOOLS,
         REDIS_TOOLS,
         VALKEY_TOOLS,
         QDRANT_TOOLS,
@@ -103,6 +104,7 @@ describe('ConfigManager', () => {
         MYSQL_TOOLS.length +
         MARIADB_TOOLS.length +
         MONGODB_TOOLS.length +
+        FERRETDB_TOOLS.length +
         REDIS_TOOLS.length +
         VALKEY_TOOLS.length +
         QDRANT_TOOLS.length +

--- a/tests/unit/ferretdb-restore.test.ts
+++ b/tests/unit/ferretdb-restore.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for FerretDB backup format detection
+ */
+
+import { describe, it } from 'node:test'
+import { assertEqual, assert } from '../utils/assertions'
+import { writeFile, mkdir, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { detectBackupFormat } from '../../engines/ferretdb/restore'
+
+describe('FerretDB Backup Format Detection', () => {
+  const testDir = join(tmpdir(), 'ferretdb-test-' + Date.now())
+
+  // Setup test directory
+  it('setup test directory', async () => {
+    await mkdir(testDir, { recursive: true })
+  })
+
+  describe('detectBackupFormat', () => {
+    it('should detect SQL format by extension', async () => {
+      const sqlFile = join(testDir, 'backup.sql')
+      await writeFile(sqlFile, '-- PostgreSQL dump\nCREATE TABLE...')
+
+      const format = await detectBackupFormat(sqlFile)
+      assert(
+        format.format === 'sql',
+        `Expected sql format, got ${format.format}`,
+      )
+    })
+
+    it('should detect custom format by extension', async () => {
+      const dumpFile = join(testDir, 'backup.dump')
+      // Write PGDMP header (PostgreSQL custom format magic)
+      const header = Buffer.from('PGDMP')
+      await writeFile(dumpFile, header)
+
+      const format = await detectBackupFormat(dumpFile)
+      assertEqual(format.format, 'custom', 'Should detect custom format')
+    })
+
+    it('should detect SQL format by content', async () => {
+      const sqlFile = join(testDir, 'test-backup')
+      await writeFile(sqlFile, '-- PostgreSQL database dump\n...')
+
+      const format = await detectBackupFormat(sqlFile)
+      assertEqual(format.format, 'sql', 'Should detect SQL format')
+    })
+
+    it('should throw error for non-existent file', async () => {
+      try {
+        await detectBackupFormat(join(testDir, 'nonexistent.sql'))
+        assert(false, 'Should have thrown an error')
+      } catch {
+        assert(true, 'Threw expected error')
+      }
+    })
+
+    it('should include restore command hint', async () => {
+      const sqlFile = join(testDir, 'hint-backup.sql')
+      await writeFile(sqlFile, '-- SQL backup')
+
+      const format = await detectBackupFormat(sqlFile)
+      assert(
+        format.restoreCommand !== undefined,
+        'Should include restore command',
+      )
+      assert(
+        format.restoreCommand.includes('psql') ||
+          format.restoreCommand.includes('pg_restore'),
+        'Restore command should mention psql or pg_restore',
+      )
+    })
+
+    it('should detect directory format', async () => {
+      const dirPath = join(testDir, 'backup-dir')
+      await mkdir(dirPath, { recursive: true })
+
+      const format = await detectBackupFormat(dirPath)
+      assertEqual(format.format, 'directory', 'Should detect directory format')
+    })
+  })
+
+  // Cleanup
+  it('cleanup test directory', async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+})

--- a/tests/unit/ferretdb-version-validator.test.ts
+++ b/tests/unit/ferretdb-version-validator.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for FerretDB version validator
+ */
+
+import { describe, it } from 'node:test'
+import { assertEqual, assert } from '../utils/assertions'
+import {
+  FERRETDB_VERSION_MAP,
+  DOCUMENTDB_VERSION_MAP,
+  normalizeVersion,
+  normalizeDocumentDBVersion,
+  getFullVersion,
+  DEFAULT_DOCUMENTDB_VERSION,
+  SUPPORTED_MAJOR_VERSIONS,
+} from '../../engines/ferretdb/version-maps'
+
+describe('FerretDB Version Maps', () => {
+  describe('FERRETDB_VERSION_MAP', () => {
+    it('should contain major version 2', () => {
+      assert(
+        FERRETDB_VERSION_MAP['2'] !== undefined,
+        'Should have version 2',
+      )
+    })
+
+    it('should map major version to full version', () => {
+      const fullVersion = FERRETDB_VERSION_MAP['2']
+      assert(
+        fullVersion.startsWith('2.'),
+        'Full version should start with 2.',
+      )
+    })
+
+    it('should have identity mapping for full versions', () => {
+      assertEqual(
+        FERRETDB_VERSION_MAP['2.7.0'],
+        '2.7.0',
+        'Full version should map to itself',
+      )
+    })
+  })
+
+  describe('DOCUMENTDB_VERSION_MAP', () => {
+    it('should contain PostgreSQL 17 backend', () => {
+      assert(
+        DOCUMENTDB_VERSION_MAP['17'] !== undefined,
+        'Should have PostgreSQL 17 backend',
+      )
+    })
+
+    it('should map major version to full version', () => {
+      const fullVersion = DOCUMENTDB_VERSION_MAP['17']
+      assert(
+        fullVersion.startsWith('17-'),
+        'Full version should start with 17-',
+      )
+    })
+  })
+
+  describe('normalizeVersion', () => {
+    it('should return full version when given major version', () => {
+      const result = normalizeVersion('2')
+      assert(
+        result.startsWith('2.'),
+        'Should return full version starting with 2.',
+      )
+    })
+
+    it('should return same version when given full version', () => {
+      const result = normalizeVersion('2.7.0')
+      assertEqual(result, '2.7.0', 'Should return same version')
+    })
+
+    it('should handle unknown versions gracefully', () => {
+      const result = normalizeVersion('99')
+      // Should not throw, but return something
+      assert(result !== '', 'Should return something for unknown version')
+    })
+  })
+
+  describe('normalizeDocumentDBVersion', () => {
+    it('should normalize major PostgreSQL version', () => {
+      const result = normalizeDocumentDBVersion('17')
+      assert(
+        result.startsWith('17-'),
+        'Should return full version starting with 17-',
+      )
+    })
+
+    it('should return same version for full version', () => {
+      const result = normalizeDocumentDBVersion('17-0.107.0')
+      assertEqual(result, '17-0.107.0', 'Should return same version')
+    })
+  })
+
+  describe('getFullVersion', () => {
+    it('should return full version for major version', () => {
+      const result = getFullVersion('2')
+      assert(result !== null, 'Should return a version')
+      assert(result!.startsWith('2.'), 'Should start with 2.')
+    })
+
+    it('should return null for unknown version', () => {
+      const _result = getFullVersion('99')
+      // Could return null or try to find a match
+      // This depends on implementation - test just verifies no crash
+    })
+  })
+
+  describe('DEFAULT_DOCUMENTDB_VERSION', () => {
+    it('should be a valid version string', () => {
+      assert(
+        DEFAULT_DOCUMENTDB_VERSION.includes('-'),
+        'Should contain a hyphen separating PG version and DocumentDB version',
+      )
+    })
+
+    it('should start with PostgreSQL 17', () => {
+      assert(
+        DEFAULT_DOCUMENTDB_VERSION.startsWith('17-'),
+        'Should start with 17-',
+      )
+    })
+  })
+
+  describe('SUPPORTED_MAJOR_VERSIONS', () => {
+    it('should include version 2', () => {
+      assert(
+        SUPPORTED_MAJOR_VERSIONS.includes('2'),
+        'Should include major version 2',
+      )
+    })
+
+    it('should be a non-empty array', () => {
+      assert(
+        SUPPORTED_MAJOR_VERSIONS.length > 0,
+        'Should have at least one version',
+      )
+    })
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,10 @@ export type ContainerConfig = {
   clonedFrom?: string
   // Path to the engine binary (for system-installed engines like MySQL, MongoDB, Redis)
   binaryPath?: string
+  // FerretDB-specific: version of the postgresql-documentdb backend (e.g., "17-0.107.0")
+  backendVersion?: string
+  // FerretDB-specific: internal PostgreSQL backend port (e.g., 54320)
+  backendPort?: number
 }
 
 /**
@@ -23,6 +27,7 @@ export enum Engine {
   SQLite = 'sqlite',
   DuckDB = 'duckdb',
   MongoDB = 'mongodb',
+  FerretDB = 'ferretdb',
   Redis = 'redis',
   Valkey = 'valkey',
   ClickHouse = 'clickhouse',
@@ -54,6 +59,7 @@ export const ALL_ENGINES = [
   Engine.SQLite,
   Engine.DuckDB,
   Engine.MongoDB,
+  Engine.FerretDB,
   Engine.Redis,
   Engine.Valkey,
   Engine.ClickHouse,
@@ -183,6 +189,7 @@ export type ValkeyFormat = 'text' | 'rdb'
 export type ClickHouseFormat = 'sql'
 export type QdrantFormat = 'snapshot'
 export type MeilisearchFormat = 'snapshot'
+export type FerretDBFormat = 'sql' | 'custom'
 
 // Union of all backup formats
 export type BackupFormatType =
@@ -192,6 +199,7 @@ export type BackupFormatType =
   | SQLiteFormat
   | DuckDBFormat
   | MongoDBFormat
+  | FerretDBFormat
   | RedisFormat
   | ValkeyFormat
   | ClickHouseFormat
@@ -206,6 +214,7 @@ type EngineFormatMap = {
   [Engine.SQLite]: SQLiteFormat
   [Engine.DuckDB]: DuckDBFormat
   [Engine.MongoDB]: MongoDBFormat
+  [Engine.FerretDB]: FerretDBFormat
   [Engine.Redis]: RedisFormat
   [Engine.Valkey]: ValkeyFormat
   [Engine.ClickHouse]: ClickHouseFormat
@@ -312,6 +321,8 @@ export type BinaryTool =
   | 'qdrant'
   // Meilisearch tools
   | 'meilisearch'
+  // FerretDB tools
+  | 'ferretdb'
   // Enhanced shells (optional)
   | 'pgcli'
   | 'mycli'
@@ -383,6 +394,8 @@ export type SpinDBConfig = {
     qdrant?: BinaryConfig
     // Meilisearch tools
     meilisearch?: BinaryConfig
+    // FerretDB tools
+    ferretdb?: BinaryConfig
     // Enhanced shells (optional)
     pgcli?: BinaryConfig
     mycli?: BinaryConfig


### PR DESCRIPTION
… PostgreSQL backend

**FerretDB Engine:**
- Add composite engine requiring two binaries: `ferretdb` proxy + `postgresql-documentdb` backend
- Support two processes per container: PostgreSQL backend + FerretDB proxy
- Allocate two ports per container: external (27017 for MongoDB) + internal (54320+ for PostgreSQL)
- Use `mongodb://` connection scheme, compatible with mongosh
- Implement backup/restore via pg_dump/pg_restore on Postgre