### PR TITLE
fix: harden TypeDB engine, credential manager, and cross-engine impro…

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -38,6 +38,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -300,7 +300,7 @@ spindb users list mydb                  # List saved credentials
 spindb users list mydb --json           # JSON output
 ```
 
-> **Supported engines:** PostgreSQL, MySQL, MariaDB, CockroachDB, ClickHouse, MongoDB, FerretDB, Redis, Valkey, SurrealDB, CouchDB, Meilisearch, Qdrant. Not supported: SQLite, DuckDB, QuestDB.
+> **Supported engines:** PostgreSQL, MySQL, MariaDB, CockroachDB, ClickHouse, MongoDB, FerretDB, Redis, Valkey, SurrealDB, CouchDB, Meilisearch, Qdrant. Not supported: SQLite, DuckDB, QuestDB, TypeDB.
 >
 > **Credentials** are saved as `.env.{username}` files in `~/.spindb/containers/{engine}/{name}/credentials/`.
 >

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ spindb users list mydb                         # List usernames
 spindb users list mydb --json                  # JSON output
 ```
 
-Supports PostgreSQL, MySQL, MariaDB, CockroachDB, ClickHouse, MongoDB, FerretDB, Redis, Valkey, SurrealDB, CouchDB, Meilisearch, and Qdrant. Credentials are saved as `.env.<username>` files in `~/.spindb/containers/{engine}/{name}/credentials/`.
+Supports PostgreSQL, MySQL, MariaDB, CockroachDB, ClickHouse, MongoDB, FerretDB, Redis, Valkey, SurrealDB, CouchDB, Meilisearch, and Qdrant. Not supported: SQLite, DuckDB, QuestDB, TypeDB. Credentials are saved as `.env.<username>` files in `~/.spindb/containers/{engine}/{name}/credentials/`.
 
 ### Backup & Restore
 

--- a/cli/commands/engines.ts
+++ b/cli/commands/engines.ts
@@ -44,6 +44,10 @@ import {
   type InstalledQdrantEngine,
   type InstalledMeilisearchEngine,
   type InstalledCouchDBEngine,
+  type InstalledCockroachDBEngine,
+  type InstalledSurrealDBEngine,
+  type InstalledQuestDBEngine,
+  type InstalledTypeDBEngine,
 } from '../helpers'
 import { Engine, Platform } from '../../types'
 import {
@@ -459,6 +463,18 @@ async function listEngines(options: { json?: boolean }): Promise<void> {
   const couchdbEngines = engines.filter(
     (e): e is InstalledCouchDBEngine => e.engine === 'couchdb',
   )
+  const cockroachdbEngines = engines.filter(
+    (e): e is InstalledCockroachDBEngine => e.engine === 'cockroachdb',
+  )
+  const surrealdbEngines = engines.filter(
+    (e): e is InstalledSurrealDBEngine => e.engine === 'surrealdb',
+  )
+  const questdbEngines = engines.filter(
+    (e): e is InstalledQuestDBEngine => e.engine === 'questdb',
+  )
+  const typedbEngines = engines.filter(
+    (e): e is InstalledTypeDBEngine => e.engine === 'typedb',
+  )
 
   // Calculate total size for PostgreSQL
   const totalPgSize = pgEngines.reduce((acc, e) => acc + e.sizeBytes, 0)
@@ -627,6 +643,62 @@ async function listEngines(options: { json?: boolean }): Promise<void> {
     )
   }
 
+  // CockroachDB rows
+  for (const engine of cockroachdbEngines) {
+    const platformInfo = `${engine.platform}-${engine.arch}`
+
+    console.log(
+      chalk.gray('  ') +
+        getEngineIcon('cockroachdb') +
+        chalk.cyan('cockroachdb'.padEnd(13)) +
+        chalk.yellow(engine.version.padEnd(12)) +
+        chalk.gray(platformInfo.padEnd(18)) +
+        chalk.white(formatBytes(engine.sizeBytes)),
+    )
+  }
+
+  // SurrealDB rows
+  for (const engine of surrealdbEngines) {
+    const platformInfo = `${engine.platform}-${engine.arch}`
+
+    console.log(
+      chalk.gray('  ') +
+        getEngineIcon('surrealdb') +
+        chalk.cyan('surrealdb'.padEnd(13)) +
+        chalk.yellow(engine.version.padEnd(12)) +
+        chalk.gray(platformInfo.padEnd(18)) +
+        chalk.white(formatBytes(engine.sizeBytes)),
+    )
+  }
+
+  // QuestDB rows
+  for (const engine of questdbEngines) {
+    const platformInfo = `${engine.platform}-${engine.arch}`
+
+    console.log(
+      chalk.gray('  ') +
+        getEngineIcon('questdb') +
+        chalk.cyan('questdb'.padEnd(13)) +
+        chalk.yellow(engine.version.padEnd(12)) +
+        chalk.gray(platformInfo.padEnd(18)) +
+        chalk.white(formatBytes(engine.sizeBytes)),
+    )
+  }
+
+  // TypeDB rows
+  for (const engine of typedbEngines) {
+    const platformInfo = `${engine.platform}-${engine.arch}`
+
+    console.log(
+      chalk.gray('  ') +
+        getEngineIcon('typedb') +
+        chalk.cyan('typedb'.padEnd(13)) +
+        chalk.yellow(engine.version.padEnd(12)) +
+        chalk.gray(platformInfo.padEnd(18)) +
+        chalk.white(formatBytes(engine.sizeBytes)),
+    )
+  }
+
   console.log(chalk.gray('  ' + '─'.repeat(59)))
 
   // Summary
@@ -733,6 +805,50 @@ async function listEngines(options: { json?: boolean }): Promise<void> {
     console.log(
       chalk.gray(
         `  CouchDB: ${couchdbEngines.length} version(s), ${formatBytes(totalCouchDBSize)}`,
+      ),
+    )
+  }
+  if (cockroachdbEngines.length > 0) {
+    const totalCockroachDBSize = cockroachdbEngines.reduce(
+      (acc, e) => acc + e.sizeBytes,
+      0,
+    )
+    console.log(
+      chalk.gray(
+        `  CockroachDB: ${cockroachdbEngines.length} version(s), ${formatBytes(totalCockroachDBSize)}`,
+      ),
+    )
+  }
+  if (surrealdbEngines.length > 0) {
+    const totalSurrealDBSize = surrealdbEngines.reduce(
+      (acc, e) => acc + e.sizeBytes,
+      0,
+    )
+    console.log(
+      chalk.gray(
+        `  SurrealDB: ${surrealdbEngines.length} version(s), ${formatBytes(totalSurrealDBSize)}`,
+      ),
+    )
+  }
+  if (questdbEngines.length > 0) {
+    const totalQuestDBSize = questdbEngines.reduce(
+      (acc, e) => acc + e.sizeBytes,
+      0,
+    )
+    console.log(
+      chalk.gray(
+        `  QuestDB: ${questdbEngines.length} version(s), ${formatBytes(totalQuestDBSize)}`,
+      ),
+    )
+  }
+  if (typedbEngines.length > 0) {
+    const totalTypeDBSize = typedbEngines.reduce(
+      (acc, e) => acc + e.sizeBytes,
+      0,
+    )
+    console.log(
+      chalk.gray(
+        `  TypeDB: ${typedbEngines.length} version(s), ${formatBytes(totalTypeDBSize)}`,
       ),
     )
   }

--- a/cli/commands/menu/container-handlers.ts
+++ b/cli/commands/menu/container-handlers.ts
@@ -17,6 +17,7 @@ import { platformService } from '../../../core/platform-service'
 import { portManager } from '../../../core/port-manager'
 import { processManager } from '../../../core/process-manager'
 import { getEngine } from '../../../engines'
+import { BaseEngine } from '../../../engines/base-engine'
 import { sqliteRegistry } from '../../../engines/sqlite/registry'
 import { duckdbRegistry } from '../../../engines/duckdb/registry'
 import { defaults } from '../../../config/defaults'
@@ -829,11 +830,9 @@ export async function showContainerSubmenu(
       : disabledItem('⎘', 'Copy connection string'),
   )
 
-  // Create user - only for engines that support users (hide for SQLite, DuckDB, QuestDB)
-  const supportsUsers =
-    config.engine !== Engine.SQLite &&
-    config.engine !== Engine.DuckDB &&
-    config.engine !== Engine.QuestDB
+  // Create user - only for engines that override createUser from BaseEngine
+  const engine = getEngine(config.engine)
+  const supportsUsers = engine.createUser !== BaseEngine.prototype.createUser
   if (supportsUsers) {
     actionChoices.push(
       containerReady

--- a/cli/commands/users.ts
+++ b/cli/commands/users.ts
@@ -133,6 +133,13 @@ usersCommand
           }
         }
 
+        // Copy to clipboard before output so JSON includes the status
+        let clipboardCopied: boolean | undefined
+        if (options.copy) {
+          const textToCopy = credentials.apiKey || credentials.connectionString
+          clipboardCopied = await platformService.copyToClipboard(textToCopy)
+        }
+
         // Output results
         if (options.json) {
           const result: Record<string, unknown> = {
@@ -146,6 +153,7 @@ usersCommand
             ...(credentialFile != null && {
               credentialFile,
             }),
+            ...(clipboardCopied !== undefined && { clipboardCopied }),
           }
           console.log(JSON.stringify(result, null, 2))
         } else {
@@ -175,14 +183,10 @@ usersCommand
             console.log(`  ${chalk.gray('Saved to:')} ${credentialFile}`)
           }
           console.log()
-        }
 
-        // Copy to clipboard if requested
-        if (options.copy) {
-          const textToCopy = credentials.apiKey || credentials.connectionString
-          const copied = await platformService.copyToClipboard(textToCopy)
-          if (!options.json) {
-            if (copied) {
+          // Show clipboard status in human-readable output
+          if (clipboardCopied !== undefined) {
+            if (clipboardCopied) {
               console.log(
                 uiSuccess(
                   credentials.apiKey

--- a/engines/clickhouse/index.ts
+++ b/engines/clickhouse/index.ts
@@ -1277,7 +1277,7 @@ export class ClickHouseEngine extends BaseEngine {
 
     const clickhouse = await this.getClickHouseClientPath(version)
 
-    const escapedPass = password.replace(/'/g, "''")
+    const escapedPass = password.replace(/\\/g, '\\\\').replace(/'/g, "''")
     const sql = `CREATE USER IF NOT EXISTS ${escapedUser} IDENTIFIED BY '${escapedPass}'; ALTER USER ${escapedUser} IDENTIFIED BY '${escapedPass}'; GRANT ALL ON ${escapedDb}.* TO ${escapedUser};`
 
     const args = [

--- a/engines/typedb/hostdb-releases.ts
+++ b/engines/typedb/hostdb-releases.ts
@@ -40,7 +40,14 @@ export async function fetchAvailableVersions(): Promise<
   }
 
   try {
-    const response = await fetch(HOSTDB_RELEASES_URL)
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 10000)
+    let response: Response
+    try {
+      response = await fetch(HOSTDB_RELEASES_URL, { signal: controller.signal })
+    } finally {
+      clearTimeout(timeoutId)
+    }
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
     }

--- a/engines/typedb/restore.ts
+++ b/engines/typedb/restore.ts
@@ -176,9 +176,10 @@ async function restoreTypeQLBackup(
 ): Promise<RestoreResult> {
   const consolePath = await requireTypeDBConsolePath(version)
 
-  // Check if this is a schema+data pair
-  const schemaPath = backupPath.replace(/\.typeql$/, '-schema.typeql')
-  const dataPath = backupPath.replace(/\.typeql$/, '-data.typeql')
+  // Derive base name by stripping known extensions (.typeql or .tql)
+  const baseName = backupPath.replace(/\.(typeql|tql)$/, '')
+  const schemaPath = `${baseName}-schema.typeql`
+  const dataPath = `${baseName}-data.typeql`
 
   const hasSchema = existsSync(schemaPath)
   const hasData = existsSync(dataPath)

--- a/engines/typedb/version-validator.ts
+++ b/engines/typedb/version-validator.ts
@@ -6,6 +6,7 @@
 /**
  * Parse a TypeDB version string into components
  * Handles formats like "3.8.0", "3.8", "v3.8.0"
+ * Rejects pre-release suffixes (e.g., "3.8.0-beta") and extra segments (e.g., "3.8.0.1")
  */
 export function parseVersion(versionString: string): {
   major: number
@@ -14,9 +15,14 @@ export function parseVersion(versionString: string): {
   raw: string
 } | null {
   const cleaned = versionString.replace(/^v/, '').trim()
+
+  // Reject versions with pre-release suffixes or metadata
+  if (/[-+]/.test(cleaned)) return null
+
   const parts = cleaned.split('.')
 
-  if (parts.length < 1) return null
+  // Only allow 1-3 segments (major, major.minor, major.minor.patch)
+  if (parts.length < 1 || parts.length > 3) return null
 
   const major = parseInt(parts[0], 10)
   const minor = parts[1] ? parseInt(parts[1], 10) : 0

--- a/scripts/generate/db/typedb.ts
+++ b/scripts/generate/db/typedb.ts
@@ -112,7 +112,11 @@ async function main(): Promise<void> {
   ])
 
   if (verifyResult.status === 0) {
-    const match = verifyResult.stdout.match(/(\d+)/)
+    // Match a standalone count number from TypeDB reduce output (e.g., "{ $c = 5; }")
+    const match =
+      verifyResult.stdout.match(/\$c\s*=\s*(\d+)/) ||
+      verifyResult.stdout.match(/count[:\s]+(\d+)/i) ||
+      verifyResult.stdout.match(/^\s*(\d+)\s*$/m)
     if (match) {
       console.log(`Verified: ${match[1]} users in test_user entity type`)
     } else {

--- a/tests/docker/run-e2e.sh
+++ b/tests/docker/run-e2e.sh
@@ -141,6 +141,8 @@ handle_interrupt() {
 }
 trap handle_interrupt INT TERM
 trap cleanup EXIT
+# TypeDB HTTP port is main port + this offset (default: 1729 + 6271 = 8000)
+TYPEDB_HTTP_PORT_OFFSET=6271
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES_DIR="$SCRIPT_DIR/../fixtures"
 
@@ -1319,7 +1321,7 @@ run_test() {
       local typedb_port
       typedb_port=$(spindb info "$container_name" --json 2>/dev/null | jq -r '.port' 2>/dev/null)
       if [ -n "$typedb_port" ]; then
-        local http_port=$((typedb_port + 6271))
+        local http_port=$((typedb_port + TYPEDB_HTTP_PORT_OFFSET))
         if curl -sf "http://127.0.0.1:${http_port}/" &>/dev/null; then
           query_ok=true
         fi

--- a/tests/integration/typedb.test.ts
+++ b/tests/integration/typedb.test.ts
@@ -128,6 +128,17 @@ describe('TypeDB Integration Tests', () => {
     console.log('\n Finding available test ports...')
     // TypeDB uses 1 main port per container (HTTP port derived as main + 6271)
     testPorts = await findConsecutiveFreePorts(3, TEST_PORTS.typedb.base)
+    // Also verify HTTP ports (main + 6271) are free
+    const { portManager } = await import('../../core/port-manager')
+    for (const port of testPorts) {
+      const httpPort = port + 6271
+      const httpFree = await portManager.isPortAvailable(httpPort)
+      if (!httpFree) {
+        console.log(
+          `   WARNING: HTTP port ${httpPort} (for main port ${port}) is in use`,
+        )
+      }
+    }
     console.log(`   Using ports: ${testPorts.join(', ')}`)
 
     containerName = generateTestName('typedb-test')

--- a/tests/unit/credential-manager.test.ts
+++ b/tests/unit/credential-manager.test.ts
@@ -233,6 +233,39 @@ describe('Credential Manager', () => {
       assertDeepEqual(users, ['alice', 'bob'], 'Should list both users sorted')
     })
 
+    it('should return sorted results regardless of insertion order', async () => {
+      const base: Omit<UserCredentials, 'username' | 'connectionString'> = {
+        password: 'pass',
+        engine: Engine.PostgreSQL,
+        container: TEST_CONTAINER,
+        database: 'mydb',
+      }
+
+      // Insert in reverse alphabetical order
+      await saveCredentials(TEST_CONTAINER, Engine.PostgreSQL, {
+        ...base,
+        username: 'zara',
+        connectionString: 'postgresql://zara:pass@127.0.0.1:5432/mydb',
+      })
+      await saveCredentials(TEST_CONTAINER, Engine.PostgreSQL, {
+        ...base,
+        username: 'alice',
+        connectionString: 'postgresql://alice:pass@127.0.0.1:5432/mydb',
+      })
+      await saveCredentials(TEST_CONTAINER, Engine.PostgreSQL, {
+        ...base,
+        username: 'mike',
+        connectionString: 'postgresql://mike:pass@127.0.0.1:5432/mydb',
+      })
+
+      const users = await listCredentials(TEST_CONTAINER, Engine.PostgreSQL)
+      assertDeepEqual(
+        users,
+        ['alice', 'mike', 'zara'],
+        'Should be alphabetically sorted regardless of insert order',
+      )
+    })
+
     it('should return empty array when no credentials', async () => {
       const users = await listCredentials(TEST_CONTAINER, Engine.PostgreSQL)
       assertDeepEqual(users, [], 'Should return empty array')

--- a/tests/unit/json-output.test.ts
+++ b/tests/unit/json-output.test.ts
@@ -198,7 +198,7 @@ describe('JSON Output Validation', () => {
 
     it('spindb doctor --json', () => {
       // doctor command can be slow on Windows CI due to system checks
-      // (spawns binary detection for all 16 engines — dozens of process spawns)
+      // (spawns binary detection for all 17 engines — dozens of process spawns)
       const result = runCommand('doctor --json', 120000)
       // doctor --json should always output valid JSON
       assertValidJson(result.stdout, 'doctor --json')
@@ -417,7 +417,7 @@ describe('JSON Output Validation', () => {
 
     it('doctor --json should have correct structure', () => {
       // doctor command can be slow on Windows CI due to system checks
-      // (spawns binary detection for all 16 engines — dozens of process spawns)
+      // (spawns binary detection for all 17 engines — dozens of process spawns)
       const result = runCommand('doctor --json', 120000)
       const parsed = JSON.parse(result.stdout.trim())
 

--- a/tests/unit/typedb-version-validator.test.ts
+++ b/tests/unit/typedb-version-validator.test.ts
@@ -10,6 +10,7 @@ import {
   getMajorVersion,
   compareVersions,
   isVersionCompatible,
+  isValidVersionFormat,
 } from '../../engines/typedb/version-validator'
 
 describe('TypeDB Version Validator', () => {
@@ -125,6 +126,32 @@ describe('TypeDB Version Validator', () => {
     it('should return null for invalid versions', () => {
       const result = compareVersions('invalid', '3.8.0')
       assertEqual(result, null, 'Should return null for invalid version')
+    })
+  })
+
+  describe('isValidVersionFormat', () => {
+    it('should accept full semver', () => {
+      assert(isValidVersionFormat('3.8.0'), '3.8.0 should be valid')
+    })
+
+    it('should accept major.minor', () => {
+      assert(isValidVersionFormat('3.8'), '3.8 should be valid')
+    })
+
+    it('should accept major only', () => {
+      assert(isValidVersionFormat('3'), '3 should be valid')
+    })
+
+    it('should accept v prefix', () => {
+      assert(isValidVersionFormat('v3.8.0'), 'v3.8.0 should be valid')
+    })
+
+    it('should reject non-numeric strings', () => {
+      assert(!isValidVersionFormat('invalid'), 'invalid should be rejected')
+    })
+
+    it('should reject empty string', () => {
+      assert(!isValidVersionFormat(''), 'empty string should be rejected')
     })
   })
 


### PR DESCRIPTION
…vements

ClickHouse: escape backslashes in passwords for CREATE/ALTER USER SQL. CI: add lint dependency to unit-tests job in ci-fast workflow. TypeDB: validate backup files aren't empty, add fetch timeout for hostdb releases, use centralized credential constants in getConnectionString, add TLS parameter to getConsoleBaseArgs, fix platformService usage for Windows .bat detection, add filesystem fallback in getTypeDBPath, improve generate script count verification regex, harden version-validator with pre-release/segment rejection.
Credential manager: extract host/port from connection strings, trim raw values before decoding.
Users CLI: fix double JSON output by moving clipboard copy before output. Container handlers: replace hardcoded supportsUsers exclusion list with capability-driven BaseEngine.prototype check.
Docker E2E: extract TYPEDB_HTTP_PORT_OFFSET constant. Tests: add isValidVersionFormat tests, credential sorting test, TypeDB integration improvements.