### PR TITLE
fix: TypeDB robustness, validation, and cross-platform improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,7 +565,7 @@ jobs:
         id: ferretdb-cache
         with:
           path: ~/.spindb/bin
-          key: spindb-ferretdb-4-${{ runner.os }}-${{ runner.arch }}
+          key: spindb-ferretdb-2-${{ runner.os }}-${{ runner.arch }}
 
       # Download FerretDB binaries via SpinDB (downloads both ferretdb + postgresql-documentdb)
       - name: Download FerretDB binaries

--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -14,7 +14,7 @@ SpinDB tests every engine on every supported platform-arch combo in CI.
 
 ## Platform Coverage (ci.yml)
 
-Every engine runs on **5 runners** covering all **5 platform-arch combos**:
+Every engine runs on **6 runners** covering all **5 platform-arch combos**:
 
 | Platform-Arch | Runner | Notes |
 |---------------|--------|-------|

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -29,8 +29,8 @@ SpinDB consolidates the functionality of multiple single-purpose tools:
 
 | Tool | Platform | Databases | SpinDB Advantage |
 |------|----------|-----------|------------------|
-| [DBngin](https://dbngin.com/) | macOS | PostgreSQL, MySQL, Redis | + 13 more engines, cross-platform |
-| [Postgres.app](https://postgresapp.com/) | macOS | PostgreSQL only | + 15 more engines, cross-platform |
+| [DBngin](https://dbngin.com/) | macOS | PostgreSQL, MySQL, Redis | + 14 more engines, cross-platform |
+| [Postgres.app](https://postgresapp.com/) | macOS | PostgreSQL only | + 16 more engines, cross-platform |
 | [XAMPP](https://www.apachefriends.org/) | All | MySQL, MariaDB | + 14 more engines, no Apache bundling |
 | [MAMP](https://www.mamp.info/) | macOS/Windows | MySQL | + 15 more engines, no web server bundling |
 | [Laragon](https://laragon.org/) | Windows | MySQL, PostgreSQL, MongoDB, Redis | + 12 more engines, cross-platform |

--- a/cli/commands/menu/backup-handlers.ts
+++ b/cli/commands/menu/backup-handlers.ts
@@ -208,8 +208,14 @@ function validateConnectionString(
       }
       break
     case Engine.TypeDB:
-      if (!input.startsWith('typedb://')) {
-        return 'Connection string must start with typedb://'
+      if (
+        !input.startsWith('typedb://') &&
+        !input.startsWith('typedb-core://') &&
+        !input.startsWith('http://') &&
+        !input.startsWith('https://') &&
+        !/^[\w.-]+:\d+/.test(input)
+      ) {
+        return 'Connection string must be host:port, typedb://, typedb-core://, or http(s)://'
       }
       break
     case Engine.SQLite:

--- a/cli/commands/menu/container-handlers.ts
+++ b/cli/commands/menu/container-handlers.ts
@@ -2150,7 +2150,11 @@ async function handleCreateUser(
         `Credentials for "${username}" already exist. Overwrite?`,
         false,
       )
-      if (!overwrite) return
+      if (!overwrite) {
+        console.log(chalk.yellow('Credential creation cancelled.'))
+        await pressEnterToContinue()
+        return
+      }
     }
 
     const password = generatePassword({ length: 20, alphanumericOnly: true })

--- a/cli/commands/menu/settings-handlers.ts
+++ b/cli/commands/menu/settings-handlers.ts
@@ -74,7 +74,7 @@ function generatePreviewLine(mode: IconMode): string {
       [Engine.CockroachDB]: '\ue269',
       [Engine.SurrealDB]: '\uedfe',
       [Engine.QuestDB]: '\ued2f',
-      [Engine.TypeDB]: '\ue706',
+      [Engine.TypeDB]: '\uf288',
     }
     const icons = PREVIEW_ENGINES.map((engine) => {
       const icon = NERD_ICONS[engine] || '\ue706'

--- a/cli/commands/menu/shell-handlers.ts
+++ b/cli/commands/menu/shell-handlers.ts
@@ -996,9 +996,15 @@ async function launchShell(
     const engine = getEngine(config.engine)
     const consolePath = await engine
       .getTypeDBConsolePath(config.version)
-      .catch(() => 'typedb_console_bin')
-    shellCmd = consolePath
-    shellArgs = getConsoleBaseArgs(config.port)
+      .catch(() => null)
+    if (consolePath) {
+      shellCmd = consolePath
+      shellArgs = getConsoleBaseArgs(config.port)
+    } else {
+      // Fallback: use the typedb launcher with 'console' subcommand
+      shellCmd = 'typedb'
+      shellArgs = ['console', ...getConsoleBaseArgs(config.port)]
+    }
     installHint = 'spindb engines download typedb'
   } else {
     // PostgreSQL default shell - look up downloaded binary path

--- a/cli/commands/users.ts
+++ b/cli/commands/users.ts
@@ -137,7 +137,9 @@ usersCommand
         let clipboardCopied: boolean | undefined
         if (options.copy) {
           const textToCopy = credentials.apiKey || credentials.connectionString
-          clipboardCopied = await platformService.copyToClipboard(textToCopy)
+          if (textToCopy) {
+            clipboardCopied = await platformService.copyToClipboard(textToCopy)
+          }
         }
 
         // Output results

--- a/core/credential-manager.ts
+++ b/core/credential-manager.ts
@@ -170,7 +170,6 @@ export async function saveCredentials(
   if (!existsSync(credDir)) {
     await mkdir(credDir, { recursive: true, mode: 0o700 })
   }
-  await chmod(credDir, 0o700)
 
   const filePath = getCredentialFilePath(
     containerName,
@@ -181,7 +180,12 @@ export async function saveCredentials(
     encoding: 'utf-8',
     mode: 0o600,
   })
-  await chmod(filePath, 0o600)
+
+  // POSIX file permissions are no-ops on Windows
+  if (process.platform !== 'win32') {
+    await chmod(credDir, 0o700)
+    await chmod(filePath, 0o600)
+  }
   return filePath
 }
 

--- a/engines/typedb/backup.ts
+++ b/engines/typedb/backup.ts
@@ -54,11 +54,11 @@ async function createTypeQLBackup(
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
-    let _stdout = ''
+    let stdout = ''
     let stderr = ''
 
     proc.stdout.on('data', (data: Buffer) => {
-      _stdout += data.toString()
+      stdout += data.toString()
     })
     proc.stderr.on('data', (data: Buffer) => {
       stderr += data.toString()
@@ -106,15 +106,17 @@ async function createTypeQLBackup(
           reject(new Error(`Backup files not created: ${error}`))
         }
       } else if (code === null) {
+        const detail = stderr || stdout
         reject(
           new Error(
-            `typedb console export was terminated by signal${stderr ? `: ${stderr}` : ''}`,
+            `typedb console export was terminated by signal${detail ? `: ${detail}` : ''}`,
           ),
         )
       } else {
+        const detail = stderr || stdout
         reject(
           new Error(
-            `typedb console export exited with code ${code}${stderr ? `: ${stderr}` : ''}`,
+            `typedb console export exited with code ${code}${detail ? `: ${detail}` : ''}`,
           ),
         )
       }

--- a/engines/typedb/restore.ts
+++ b/engines/typedb/restore.ts
@@ -186,8 +186,11 @@ async function restoreTypeQLBackup(
 
   if (hasSchema || hasData) {
     // Import schema and data separately
-    const command =
-      `database import ${database} ${hasSchema ? schemaPath : ''} ${hasData ? dataPath : ''}`.trim()
+    const paths = [
+      ...(hasSchema ? [schemaPath] : []),
+      ...(hasData ? [dataPath] : []),
+    ]
+    const command = `database import ${database} ${paths.join(' ')}`
 
     return runConsoleCommand(consolePath, port, command)
   }

--- a/engines/typedb/version-maps.ts
+++ b/engines/typedb/version-maps.ts
@@ -30,7 +30,7 @@ export function normalizeVersion(version: string): string {
  * Check if a version is supported
  */
 export function isVersionSupported(version: string): boolean {
-  return version in TYPEDB_VERSION_MAP
+  return Object.hasOwn(TYPEDB_VERSION_MAP, version)
 }
 
 /**

--- a/engines/typedb/version-validator.ts
+++ b/engines/typedb/version-validator.ts
@@ -3,6 +3,8 @@
  * Handles version parsing, comparison, and compatibility checking
  */
 
+import { SUPPORTED_MAJOR_VERSIONS } from './version-maps'
+
 /**
  * Parse a TypeDB version string into components
  * Handles formats like "3.8.0", "3.8", "v3.8.0"
@@ -24,13 +26,12 @@ export function parseVersion(versionString: string): {
   // Only allow 1-3 segments (major, major.minor, major.minor.patch)
   if (parts.length < 1 || parts.length > 3) return null
 
+  // Reject segments that aren't purely numeric (e.g., "3b", "8rc1")
+  if (parts.some((p) => !/^\d+$/.test(p))) return null
+
   const major = parseInt(parts[0], 10)
   const minor = parts[1] ? parseInt(parts[1], 10) : 0
   const patch = parts[2] ? parseInt(parts[2], 10) : 0
-
-  if (isNaN(major)) return null
-  if (parts[1] && isNaN(minor)) return null
-  if (parts[2] && isNaN(patch)) return null
 
   return { major, minor, patch, raw: cleaned }
 }
@@ -43,7 +44,7 @@ export function isVersionSupported(version: string): boolean {
   const parsed = parseVersion(version)
   if (!parsed) return false
 
-  return parsed.major >= 3
+  return SUPPORTED_MAJOR_VERSIONS.includes(String(parsed.major))
 }
 
 /**

--- a/scripts/generate/db/typedb.ts
+++ b/scripts/generate/db/typedb.ts
@@ -7,7 +7,6 @@
  */
 
 import { existsSync } from 'fs'
-import { readFile } from 'fs/promises'
 import {
   parseArgs,
   runSpindb,
@@ -92,10 +91,9 @@ async function main(): Promise<void> {
   console.log('TypeDB is ready.\n')
 
   console.log('Seeding database with sample data...')
-  const seedContent = await readFile(SEED_FILE, 'utf-8')
 
   // TypeDB uses --script for .tqls files which contain transaction commands
-  const seedResult = runContainerCommand(containerName, ['-c', seedContent])
+  const seedResult = runContainerCommand(containerName, ['--script', SEED_FILE])
 
   if (seedResult.status !== 0) {
     console.error('Error seeding database:')


### PR DESCRIPTION
Harden TypeDB engine with idempotent createUser, URL credential parsing for remote dumps, --script seeding, and console fallback. Fix CI cache key, runner counts, engine comparison counts, connection validation, version checks, Windows chmod guard, and nerd font icon uniqueness.