### PR TITLE
fix: prevent TypeDB Windows test hang by using server binary directly

### DIFF
--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -158,7 +158,8 @@ export async function cleanupTestContainers(): Promise<string[]> {
       (c) =>
         c.engine !== Engine.CockroachDB &&
         c.engine !== Engine.SurrealDB &&
-        c.engine !== Engine.QuestDB,
+        c.engine !== Engine.QuestDB &&
+        c.engine !== Engine.TypeDB,
     )
   }
 


### PR DESCRIPTION
On Windows, the .bat launcher creates a cmd.exe wrapper process that becomes orphaned after tests, showing "Terminate batch job (Y/N)?" and causing a 15-minute CI timeout. Use typedb_server_bin.exe directly on Windows to avoid the cmd.exe wrapper entirely. Also add TypeDB to the Windows cleanup skip list in integration test helpers.