### PR TITLE
fix: restart FerretDB proxy after restore for data visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.7] - 2026-02-14
+
+### Fixed
+- **FerretDB restore data visibility** - After `pg_restore`, the FerretDB proxy is now automatically restarted so it picks up the restored collections and documents. Previously, FerretDB's in-memory metadata cache would show 0 documents after a restore because the proxy didn't know about data written directly to PostgreSQL.
+
 ## [0.34.6] - 2026-02-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary
- After `pg_restore`, FerretDB's proxy is automatically restarted so it picks up restored collections/documents
- Previously restored data showed 0 documents because FerretDB cached the empty state in memory before the restore happened
- Fix applies to both v1 (plain PostgreSQL) and v2 (DocumentDB) — v2 test already tolerates 0 so no risk

## Test plan
- [ ] FerretDB v1 integration tests pass on all platforms (restore test now expects 5 documents)
- [ ] FerretDB v2 integration tests still pass (existing behavior unchanged)
- [ ] Unit tests pass (1179/1179)
- [ ] Lint clean