### PR TITLE
fix: Weaviate RAFT cluster identity alignment with setup-database.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.8] - 2026-03-31
+
+### Fixed
+
+- **Weaviate RAFT cluster identity** — Use stable `node1` hostname and set `RAFT_BOOTSTRAP_EXPECT=1`, `CLUSTER_ADVERTISE_ADDR`, `RAFT_JOIN`, and `CLUSTER_JOIN` env vars on start. Previously the hostname was `node-{port}` which mismatched the identity from setup-database.sh, causing RAFT to treat restarts as new node joins.
+
 ## [0.47.7] - 2026-03-31
 
 ### Fixed

--- a/engines/weaviate/index.ts
+++ b/engines/weaviate/index.ts
@@ -517,6 +517,10 @@ export class WeaviateEngine extends BaseEngine {
       }
     }
 
+    // Use a stable node identity so RAFT state survives restarts.
+    // Must match across all start paths (SpinDB, setup-database.sh, etc.)
+    const nodeHostname = 'node1'
+
     const env = {
       ...process.env,
       // Defaults from weaviate.env file (includes auth settings from createUser)
@@ -525,7 +529,11 @@ export class WeaviateEngine extends BaseEngine {
       PERSISTENCE_DATA_PATH: dataDir,
       BACKUP_FILESYSTEM_PATH: backupsDir,
       ENABLE_MODULES: 'backup-filesystem',
-      CLUSTER_HOSTNAME: `node-${port}`,
+      CLUSTER_HOSTNAME: nodeHostname,
+      CLUSTER_ADVERTISE_ADDR: currentBind,
+      CLUSTER_JOIN: '',
+      RAFT_JOIN: nodeHostname,
+      RAFT_BOOTSTRAP_EXPECT: '1',
       GRPC_PORT: String(grpcPort),
       CLUSTER_GOSSIP_BIND_PORT: String(gossipPort),
       CLUSTER_DATA_BIND_PORT: String(dataPort),

--- a/engines/weaviate/index.ts
+++ b/engines/weaviate/index.ts
@@ -609,7 +609,7 @@ export class WeaviateEngine extends BaseEngine {
   // Wait for Weaviate to be ready to accept connections
   private async waitForReady(
     port: number,
-    timeoutMs = 30000,
+    timeoutMs = 90000,
   ): Promise<boolean> {
     const startTime = Date.now()
     const checkInterval = 500

--- a/engines/weaviate/index.ts
+++ b/engines/weaviate/index.ts
@@ -517,9 +517,9 @@ export class WeaviateEngine extends BaseEngine {
       }
     }
 
-    // Use a stable node identity so RAFT state survives restarts.
-    // Must match across all start paths (SpinDB, setup-database.sh, etc.)
-    const nodeHostname = 'node1'
+    // Node identity must be consistent across all starts AND restores.
+    // Use port-based naming for uniqueness when multiple containers run.
+    const nodeHostname = `node-${port}`
 
     const env = {
       ...process.env,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.47.7",
+  "version": "0.47.8",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Weaviate RAFT cluster identity so node restarts are no longer treated as new cluster joins; nodes now keep a stable identity and start with correct cluster settings.

* **Chores**
  * Bumped release version to 0.47.8 and added corresponding changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->