### PR TITLE
fix: MongoDB waitForReady falls back to TCP when auth rejects mongosh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.13] - 2026-04-01
+
+### Fixed
+
+- **MongoDB waitForReady with --auth** — Health check falls back to TCP port probe when `mongosh` fails due to auth requirements, so PID tracking works correctly for auth-enabled instances.
+
 ## [0.47.12] - 2026-04-01
 
 ### Fixed

--- a/engines/mongodb/index.ts
+++ b/engines/mongodb/index.ts
@@ -594,6 +594,10 @@ export class MongoDBEngine extends BaseEngine {
         })
         return true
       } catch {
+        // mongosh may fail due to --auth. Fall back to TCP port check —
+        // any listener on the port means mongod is up, even if auth is required.
+        const isOpen = await this.checkPortOpen(port)
+        if (isOpen) return true
         await new Promise((resolve) => setTimeout(resolve, checkInterval))
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.47.12",
+  "version": "0.47.13",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB readiness probe handling for authentication-enabled instances with a TCP connectivity fallback.

* **Chores**
  * Version bump to 0.47.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->