### PR TITLE
fix: add --skip-host-cache to MySQL/MariaDB, bump to 0.47.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **MySQL/MariaDB host cache poisoning** — Added `--skip-host-cache` to MySQL and MariaDB start args. Stale ProxySQL processes from deleted databases could poison MySQL's `performance_schema.host_cache`, causing intermittent connection blocks for all clients on the Docker bridge IP after 100 accumulated handshake errors.
+- **MySQL/MariaDB host cache poisoning** — Added `--host-cache-size=0` to MySQL and MariaDB start args to disable the host cache. Stale ProxySQL processes from deleted databases could poison MySQL's `performance_schema.host_cache`, causing intermittent connection blocks for all clients on the Docker bridge IP after 100 accumulated handshake errors. Uses `--host-cache-size=0` instead of the deprecated `--skip-host-cache` (removed in MySQL 8.3+).
 
 ## [0.47.14] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.16] - 2026-04-15
+
+### Fixed
+
+- **MySQL/MariaDB host cache poisoning** — Added `--skip-host-cache` to MySQL and MariaDB start args. Stale ProxySQL processes from deleted databases could poison MySQL's `performance_schema.host_cache`, causing intermittent connection blocks for all clients on the Docker bridge IP after 100 accumulated handshake errors.
+
 ## [0.47.14] - 2026-04-03
 
 ### Fixed

--- a/engines/mariadb/index.ts
+++ b/engines/mariadb/index.ts
@@ -434,6 +434,7 @@ export class MariaDBEngine extends BaseEngine {
       `--log-error=${logFile}`,
       `--bind-address=${container.bindAddress ?? '127.0.0.1'}`,
       `--max-connections=${engineDef.maxConnections}`,
+      '--skip-host-cache',
     ]
 
     if (platform !== Platform.Win32) {

--- a/engines/mariadb/index.ts
+++ b/engines/mariadb/index.ts
@@ -434,7 +434,7 @@ export class MariaDBEngine extends BaseEngine {
       `--log-error=${logFile}`,
       `--bind-address=${container.bindAddress ?? '127.0.0.1'}`,
       `--max-connections=${engineDef.maxConnections}`,
-      '--skip-host-cache',
+      '--host-cache-size=0',
     ]
 
     if (platform !== Platform.Win32) {

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -524,7 +524,7 @@ export class MySQLEngine extends BaseEngine {
       `--log-error=${logFile}`,
       `--bind-address=${container.bindAddress ?? '127.0.0.1'}`,
       `--max-connections=${engineDef.maxConnections}`,
-      '--skip-host-cache',
+      '--host-cache-size=0',
     ]
 
     if (platform !== Platform.Win32) {

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -524,6 +524,7 @@ export class MySQLEngine extends BaseEngine {
       `--log-error=${logFile}`,
       `--bind-address=${container.bindAddress ?? '127.0.0.1'}`,
       `--max-connections=${engineDef.maxConnections}`,
+      '--skip-host-cache',
     ]
 
     if (platform !== Platform.Win32) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.47.14",
+  "version": "0.47.16",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary

Added `--skip-host-cache` to MySQL and MariaDB start args to prevent intermittent connection blocks caused by host cache poisoning.

## Problem

Stale ProxySQL processes from deleted databases accumulate handshake errors in MySQL's `performance_schema.host_cache` for the Docker bridge IP (`172.18.0.1`). After 100 errors (`max_connect_errors` default), MySQL blocks ALL connections from that IP, causing intermittent outages for the cloud API's query proxy and PlanetScale compat layer.

## Fix

`--skip-host-cache` disables the host cache entirely, eliminating this class of failure. This is safe because host-based access control is handled at the network/firewall level, not MySQL's host cache.

## Test plan

- [ ] CI passes
- Manually verified fix on production Vultr server (flushed cache + killed stale ProxySQL + raised max_connect_errors as hotfix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the `--skip-host-cache` flag to both MySQL and MariaDB database startup configurations and bumps the package version to 0.47.16.

## Changes Made

- **CHANGELOG.md**: Added version 0.47.16 release entry documenting the host cache poisoning fix
- **engines/mysql/index.ts**: Added `'--skip-host-cache'` to the MySQL server startup arguments
- **engines/mariadb/index.ts**: Added `'--skip-host-cache'` to the MariaDB server startup arguments  
- **package.json**: Version bumped from 0.47.14 to 0.47.16

## Technical Details

The PR disables MySQL/MariaDB's host cache to prevent a specific failure mode that has caused intermittent outages in production environments. Stale ProxySQL processes from deleted databases were accumulating authentication and handshake errors in MySQL's `performance_schema.host_cache` for the Docker bridge IP (172.18.0.1). After exceeding the default `max_connect_errors` threshold (100 errors), MySQL blocks all connections from that IP address. 

By disabling the host cache entirely, this poisoning mechanism is eliminated while host-based access control remains enforced at the network/firewall level.

## Impact

- **spindb users**: MySQL and MariaDB instances will now start with the `--skip-host-cache` flag, preventing host cache poisoning that could cause intermittent connection failures
- **layerbase-desktop**: The backend spindb binary will reflect this behavioral change when starting MySQL/MariaDB instances
- **hostdb**: No direct impact; this is a configuration change, not a binary/hostdb change

## Code Review Notes

This is a low-risk configuration change affecting only the startup arguments for two database engines. No logic modifications, error handling changes, or exported API modifications are included. The changes are minimal (6 lines total across configuration files) and focused on addressing a specific production issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->