### PR TITLE
fix: spindb which prefers running container that hosts target database (0.48.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-04-20
+
+### Fixed
+
+- **`spindb which` picks a stopped container when multiple share a port** — When two or more containers were registered on the same port (e.g., one stopped from an earlier project and one currently running an app's database), `spindb which --url <DATABASE_URL>` could return either, because the resolver was a naive `containers.find(c => c.port === targetPort)` with no preference for running state or which container actually hosted the requested database. Scripts downstream (e.g., `pnpm db:clone` tooling) then had to self-heal the wrong answer. Fixed by ranking candidates: running containers score higher than stopped, and containers that host the database named in the URL path score higher still. The first candidate wins ties so behavior stays deterministic.
+
+### Added
+
+- **URL-path database parsing in `spindb which`** — `parseConnectionUrl` now extracts the database name from the URL pathname (e.g., `postgresql://localhost:5433/offlabelinsight` → `offlabelinsight`) and passes it through to the candidate ranker as `targetDatabase`. Previously the pathname was discarded.
+- **`selectContainerForWhich` helper** — The ranking logic is extracted from the command action into a pure, testable helper exported from `cli/commands/which.ts`. Covered by `tests/unit/which-select.test.ts` (8 cases including the original regression: running vs stopped on the same port, running+hosts-database preference, and stable tiebreakers).
+
 ## [0.48.0] - 2026-04-20
 
 ### Fixed

--- a/cli/commands/which.ts
+++ b/cli/commands/which.ts
@@ -15,7 +15,56 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import { containerManager } from '../../core/container-manager'
 import { uiError } from '../ui/theme'
-import { Engine } from '../../types'
+import { Engine, type ContainerConfig } from '../../types'
+
+export type WhichSelectCriteria = {
+  targetPort?: number
+  targetEngine?: Engine
+  targetDatabase?: string
+  runningOnly?: boolean
+}
+
+/**
+ * Pick the best-matching container for the given criteria.
+ *
+ * Multiple containers can legitimately share a port (e.g., one running, others
+ * stopped from earlier experiments). Prefer running containers, and if the
+ * caller passed a database name, prefer containers that actually host it.
+ * Stable — containers that tie on score keep their original order.
+ */
+export function selectContainerForWhich(
+  containers: ContainerConfig[],
+  criteria: WhichSelectCriteria,
+): ContainerConfig | null {
+  const { targetPort, targetEngine, targetDatabase, runningOnly } = criteria
+
+  const candidates = containers.filter((c) => {
+    if (targetPort !== undefined && c.port !== targetPort) return false
+    if (targetEngine && c.engine !== targetEngine) return false
+    if (runningOnly && c.status !== 'running') return false
+    return true
+  })
+
+  function score(c: ContainerConfig): number {
+    let s = 0
+    if (c.status === 'running') s += 4
+    if (targetDatabase) {
+      const hostsTarget =
+        c.database === targetDatabase ||
+        (c.databases?.includes(targetDatabase) ?? false)
+      if (hostsTarget) s += 2
+    }
+    return s
+  }
+
+  // Decorate-sort-undecorate to keep the sort stable across Node versions that
+  // previously had unstable Array#sort for equal scores.
+  const ranked = candidates
+    .map((c, i) => ({ c, i, s: score(c) }))
+    .sort((a, b) => b.s - a.s || a.i - b.i)
+
+  return ranked[0]?.c ?? null
+}
 
 /**
  * Parse a database connection URL and extract host, port, and engine type.
@@ -24,17 +73,20 @@ import { Engine } from '../../types'
 function parseConnectionUrl(url: string): {
   host: string
   port: number
+  database?: string
   engine?: Engine
   unsupportedProtocol?: string
 } | null {
   try {
     const parsed = new URL(url)
+    const database = parsed.pathname.replace(/^\//, '').split('?')[0] || undefined
 
     // If URL has explicit port, use it
     if (parsed.port) {
       return {
         host: parsed.hostname,
         port: parseInt(parsed.port, 10),
+        database,
         engine: getEngineFromProtocol(parsed.protocol),
       }
     }
@@ -46,6 +98,7 @@ function parseConnectionUrl(url: string): {
       return {
         host: parsed.hostname,
         port: 0, // Will be caught by caller
+        database,
         unsupportedProtocol: parsed.protocol.replace(/:$/, ''),
       }
     }
@@ -53,6 +106,7 @@ function parseConnectionUrl(url: string): {
     return {
       host: parsed.hostname,
       port: defaultPort,
+      database,
       engine: getEngineFromProtocol(parsed.protocol),
     }
   } catch {
@@ -126,6 +180,7 @@ export const whichCommand = new Command('which')
         // Parse the port/URL to find what we're looking for
         let targetPort: number | undefined
         let targetEngine: Engine | undefined
+        let targetDatabase: string | undefined
 
         if (options.url) {
           const parsed = parseConnectionUrl(options.url)
@@ -163,6 +218,7 @@ export const whichCommand = new Command('which')
 
           targetPort = parsed.port
           targetEngine = parsed.engine
+          targetDatabase = parsed.database
         } else if (options.port) {
           targetPort = parseInt(options.port, 10)
           if (isNaN(targetPort)) {
@@ -217,26 +273,12 @@ export const whichCommand = new Command('which')
           }
         }
 
-        // Get all containers and find matching one
         const containers = await containerManager.list()
-
-        const match = containers.find((c) => {
-          // Port must match
-          if (targetPort !== undefined && c.port !== targetPort) {
-            return false
-          }
-
-          // Engine must match if specified
-          if (targetEngine && c.engine !== targetEngine) {
-            return false
-          }
-
-          // Running filter
-          if (options.running && c.status !== 'running') {
-            return false
-          }
-
-          return true
+        const match = selectContainerForWhich(containers, {
+          targetPort,
+          targetEngine,
+          targetDatabase,
+          runningOnly: options.running,
         })
 
         if (!match) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/which-select.test.ts
+++ b/tests/unit/which-select.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from 'node:test'
+import { selectContainerForWhich } from '../../cli/commands/which'
+import { Engine, type ContainerConfig } from '../../types'
+import { assert, assertEqual, assertNullish } from '../utils/assertions'
+
+function container(
+  overrides: Partial<ContainerConfig> & {
+    name: string
+    port: number
+    status: ContainerConfig['status']
+  },
+): ContainerConfig {
+  return {
+    engine: Engine.PostgreSQL,
+    version: '17.7.0',
+    database: overrides.database ?? overrides.name,
+    created: '2026-04-20T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('selectContainerForWhich', () => {
+  it('prefers a running container over a stopped one on the same port', () => {
+    // Regression: `containers.find(c => c.port === target)` used to return the
+    // first hit, which could be a stopped container even when a running one
+    // was present. Fixed by ranking running > stopped.
+    const containers = [
+      container({ name: 'efficient', port: 5433, status: 'stopped' }),
+      container({ name: 'offlabelinsight', port: 5433, status: 'running' }),
+    ]
+    const match = selectContainerForWhich(containers, { targetPort: 5433 })
+    assertEqual(
+      match?.name,
+      'offlabelinsight',
+      'Should pick the running container even when it is not first in the list',
+    )
+  })
+
+  it('prefers a running container that hosts the target database', () => {
+    // Two running containers share a port — pick the one that actually has the
+    // requested database on it.
+    const containers = [
+      container({
+        name: 'layerbase',
+        port: 5433,
+        status: 'running',
+        database: 'layerbase',
+        databases: ['layerbase'],
+      }),
+      container({
+        name: 'offlabelinsight',
+        port: 5433,
+        status: 'running',
+        database: 'offlabelinsight',
+        databases: ['offlabelinsight'],
+      }),
+    ]
+    const match = selectContainerForWhich(containers, {
+      targetPort: 5433,
+      targetDatabase: 'offlabelinsight',
+    })
+    assertEqual(
+      match?.name,
+      'offlabelinsight',
+      'Should pick the container that hosts the requested database',
+    )
+  })
+
+  it('prefers running+hosts-database over either alone', () => {
+    const containers = [
+      // stopped but has the DB
+      container({
+        name: 'legacy',
+        port: 5433,
+        status: 'stopped',
+        databases: ['offlabelinsight'],
+      }),
+      // running but different DB
+      container({
+        name: 'other',
+        port: 5433,
+        status: 'running',
+        databases: ['other'],
+      }),
+      // running AND has the DB — the winner
+      container({
+        name: 'winner',
+        port: 5433,
+        status: 'running',
+        databases: ['offlabelinsight'],
+      }),
+    ]
+    const match = selectContainerForWhich(containers, {
+      targetPort: 5433,
+      targetDatabase: 'offlabelinsight',
+    })
+    assertEqual(match?.name, 'winner', 'Should prefer running+hosts')
+  })
+
+  it('falls back to the first candidate when nothing distinguishes them', () => {
+    const containers = [
+      container({ name: 'a', port: 5433, status: 'stopped' }),
+      container({ name: 'b', port: 5433, status: 'stopped' }),
+    ]
+    const match = selectContainerForWhich(containers, { targetPort: 5433 })
+    assertEqual(
+      match?.name,
+      'a',
+      'Should be stable — first candidate wins on a tie',
+    )
+  })
+
+  it('returns null when no container matches the port', () => {
+    const containers = [
+      container({ name: 'a', port: 5432, status: 'running' }),
+    ]
+    const match = selectContainerForWhich(containers, { targetPort: 9999 })
+    assertNullish(match, 'Should return null when nothing matches')
+  })
+
+  it('honors the running-only filter', () => {
+    const containers = [
+      container({ name: 'stopped-one', port: 5433, status: 'stopped' }),
+    ]
+    const match = selectContainerForWhich(containers, {
+      targetPort: 5433,
+      runningOnly: true,
+    })
+    assertNullish(
+      match,
+      'runningOnly must exclude stopped containers even when they match port',
+    )
+  })
+
+  it('filters by engine before ranking', () => {
+    const containers = [
+      container({
+        name: 'pg',
+        port: 5432,
+        status: 'running',
+        engine: Engine.PostgreSQL,
+      }),
+      container({
+        name: 'mysql',
+        port: 5432,
+        status: 'running',
+        engine: Engine.MySQL,
+      }),
+    ]
+    const match = selectContainerForWhich(containers, {
+      targetPort: 5432,
+      targetEngine: Engine.MySQL,
+    })
+    assertEqual(match?.name, 'mysql', 'Engine filter should apply before rank')
+  })
+
+  it('does not award the database bonus when target is undefined', () => {
+    // Edge case: with no target database, a running container must not get
+    // "bumped up" by coincidentally having a database that happens to match
+    // a property on the request (which is undefined in this case).
+    const containers = [
+      container({
+        name: 'a',
+        port: 5433,
+        status: 'running',
+        databases: ['anything'],
+      }),
+      container({
+        name: 'b',
+        port: 5433,
+        status: 'running',
+        databases: ['something'],
+      }),
+    ]
+    const match = selectContainerForWhich(containers, { targetPort: 5433 })
+    assertEqual(match?.name, 'a', 'Ties on score resolve to first candidate')
+    assert(match !== null, 'A running match should still be found')
+  })
+})


### PR DESCRIPTION
## Summary

- **Bug**: `spindb which --url <DATABASE_URL>` could return a stopped container when a running container on the same port actually hosted the requested database. Downstream scripts (e.g. offlabelinsight's `pnpm db:clone`) had to self-heal the wrong answer with extra logic.
- **Root cause**: `cli/commands/which.ts` used `containers.find(c => c.port === targetPort)` with no preference for running state, and `parseConnectionUrl` threw away the database name from the URL path.
- **Fix**: Extracted the selection into `selectContainerForWhich(containers, criteria)` that ranks candidates: running (+4), hosts-target-database (+2). First candidate wins ties for deterministic behavior. Plumbed `targetDatabase` through from the URL pathname.

## What changed

- `cli/commands/which.ts` — new `selectContainerForWhich` helper, URL pathname now parsed into `targetDatabase`, action calls the helper
- `tests/unit/which-select.test.ts` — 8 new unit tests, including the original regression (running vs stopped on same port), running-hosts-database preference, engine filters, running-only filter, stable tiebreakers
- `package.json` — 0.48.0 → 0.48.1
- `CHANGELOG.md` — 0.48.1 entry

## Test plan

- [x] `pnpm lint` (ESLint + tsc --noEmit)
- [x] `pnpm test:unit` — 1562/1562 passing (+8 new)
- [ ] Manual verification: with two Postgres containers registered on port 5433 (one stopped, one running with the target DB), `spindb which --url postgresql://localhost:5433/<db>` should return the running one every time

## Followup the script side can now drop

Consumers like offlabelinsight's `scripts/clone-db/index.ts` currently have a `selfHealResolvedContainer` workaround for this exact bug. Once 0.48.1 lands they can delete that helper and keep just the `--container <name>` override (still useful for ambiguous cases where no heuristic can decide).