### PR TITLE
fix(weaviate): use loopback advertise addr when REST bind is a wildcard

### DIFF
--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.48.1'
+export const VERSION = '0.48.2'

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.47.1'
+export const VERSION = '0.48.1'

--- a/engines/weaviate/index.ts
+++ b/engines/weaviate/index.ts
@@ -521,6 +521,14 @@ export class WeaviateEngine extends BaseEngine {
     // Use port-based naming for uniqueness when multiple containers run.
     const nodeHostname = `node-${port}`
 
+    // Weaviate's RAFT layer rejects wildcard bind addresses (0.0.0.0, ::)
+    // as cluster advertise addresses — "local bind address is not advertisable"
+    // and the process exits fatal during raft init. For single-node operation
+    // the cluster is intra-process anyway, so we advertise on loopback whenever
+    // the REST API is on a wildcard. Routable explicit binds pass through.
+    const isWildcardBind = ['0.0.0.0', '::', ''].includes(currentBind)
+    const clusterAdvertiseAddr = isWildcardBind ? '127.0.0.1' : currentBind
+
     const env = {
       ...process.env,
       // Defaults from weaviate.env file (includes auth settings from createUser)
@@ -530,7 +538,7 @@ export class WeaviateEngine extends BaseEngine {
       BACKUP_FILESYSTEM_PATH: backupsDir,
       ENABLE_MODULES: 'backup-filesystem',
       CLUSTER_HOSTNAME: nodeHostname,
-      CLUSTER_ADVERTISE_ADDR: currentBind,
+      CLUSTER_ADVERTISE_ADDR: clusterAdvertiseAddr,
       CLUSTER_JOIN: '',
       RAFT_JOIN: nodeHostname,
       RAFT_BOOTSTRAP_EXPECT: '1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary

Weaviate's RAFT layer fatal-errors on startup when \`CLUSTER_ADVERTISE_ADDR\` is a wildcard (\`0.0.0.0\`, \`::\`). The cloud (and any user passing \`--bind 0.0.0.0\`) was hitting this — provisioning hung ~4 minutes (spindb-start internal timeout + setup-database.sh wait_ready 120s) before erroring out.

The fix: when the REST API is on a wildcard, advertise RAFT on \`127.0.0.1\` instead. RAFT is intra-process for single-node, so loopback advertise is always correct in that case. Routable explicit binds still propagate so future multi-node setups aren't affected.

## Root cause

\`engines/weaviate/index.ts\` line 533 set \`CLUSTER_ADVERTISE_ADDR: currentBind\` directly. \`currentBind\` comes from \`container.bindAddress ?? '127.0.0.1'\`, so default starts worked, but \`spindb start --bind 0.0.0.0\` propagated the wildcard into RAFT and Weaviate refused to come up:

\`\`\`
fatal: could not open cloud meta store
open raft store: initialize raft store: raft transport address=0.0.0.0:N
local bind address is not advertisable
\`\`\`

## Verification

End-to-end test against staging (\`dev.cloud.layerbase.dev\`):

| | Before | After |
|---|---|---|
| Provision time | 245s then rollback / 500 | 7s, status 'running' |
| \`/v1/.well-known/ready\` | unreachable | HTTP 200 |
| \`/v1/meta\` | unreachable | full payload |

The patched \`dist/engines/weaviate/index.js\` was hot-copied into a staging user container and the cloud's \`setup-database.sh weaviate\` was invoked with the cloud's exact arguments to reproduce.

## Rollout

- Merge to dev.
- Cut a new spindb npm release (0.48.2 or similar).
- Bump the version in the \`layerbase-cloud\` user-container Docker image so new user containers pick up the fix.
- Existing user containers still have the bug; either restart them or hot-patch (the cloud's image-rebuild cadence handles this naturally).

Filed during a Weaviate smoke-test session for [Layerbase-LLC/layerbase-cloud#229](https://github.com/Layerbase-LLC/layerbase-cloud/pull/229) — three other REST consoles (CouchDB, Meilisearch, Qdrant) provisioned and responded correctly through the new raw-HTTP forwarder, but Weaviate was the unlucky engine that hit this latent spindb bug.