### PR TITLE
fix(docker-exporter): add pnpm setup before global install

### DIFF
--- a/core/docker-exporter.ts
+++ b/core/docker-exporter.ts
@@ -317,8 +317,12 @@ RUN groupadd -r spindb && useradd -r -g spindb -d /home/spindb -m -s /bin/bash s
 # Install pnpm and SpinDB globally
 ENV PNPM_HOME="/home/spindb/.local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 10+ refuses 'add -g' unless 'pnpm setup' has written PNPM_HOME into
+# the shell profile (env-var alone isn't trusted). \`SHELL\` tells setup which
+# rc file to touch; without it, setup errors on a fresh container.
 RUN npm install -g pnpm \\
     && mkdir -p "$PNPM_HOME" \\
+    && SHELL=/bin/bash pnpm setup \\
     && pnpm add -g spindb
 
 # Create spindb directories with proper ownership


### PR DESCRIPTION
## Summary

Unblocks PR #167 (dev → main) which is currently red because the Docker Export CI job fails on \`pnpm add -g spindb\`. The root cause is a recent pnpm version bump on the GitHub runner — pnpm 10+ refuses global installs without \`pnpm setup\` first.

\`\`\`
Run "pnpm setup" to update your shell configuration.
ERROR: process "/bin/sh -c npm install -g pnpm && mkdir -p \$PNPM_HOME && pnpm add -g spindb" did not complete successfully: exit code: 1
\`\`\`

## Fix

Add \`SHELL=/bin/bash pnpm setup\` between mkdir and \`pnpm add\` in the Dockerfile that \`spindb export docker\` generates:

\`\`\`diff
 RUN npm install -g pnpm \\
     && mkdir -p "\$PNPM_HOME" \\
+    && SHELL=/bin/bash pnpm setup \\
     && pnpm add -g spindb
\`\`\`

The \`SHELL\` env var tells \`pnpm setup\` which rc file to touch (without it, setup errors on a fresh root container with no \$SHELL). The setup writes a sentinel that satisfies pnpm's check on every subsequent \`pnpm add\`.

## Why not switch to \`npm install -g spindb\`?

Considered. The update path emits \`pnpm add -g spindb@latest\` (\`core/update-manager.ts:146\`) and the README docs install via pnpm. Splitting install (npm) from upgrade (pnpm) would point them at different global stores — silent "update doesn't take effect" bug. Keeping pnpm everywhere preserves one mental model.

## Why this branch?

\`fix/weaviate-raft-bind\` already has the weaviate raft fix (PR #166, already merged to dev) plus the 0.48.1 → 0.48.2 version bump. This is one more commit on top. Merging gets all three to dev in one move and unblocks the dev → main release.

## Verification

- \`pnpm check\` clean
- Generated Dockerfile inspected; output is:
  \`\`\`dockerfile
  RUN npm install -g pnpm \\
      && mkdir -p "\$PNPM_HOME" \\
      && SHELL=/bin/bash pnpm setup \\
      && pnpm add -g spindb
  \`\`\`
- CI will re-run on this PR to confirm