### PR TITLE
fix(clickhouse): write PID file independent of waitForReady

### DIFF
--- a/engines/clickhouse/index.ts
+++ b/engines/clickhouse/index.ts
@@ -530,40 +530,104 @@ export class ClickHouseEngine extends BaseEngine {
       )
     }
 
+    // ClickHouse runs with --daemon, so it forks immediately. The PID file is
+    // written by scraping `lsof -ti tcp:PORT` (the config <pid_file> directive
+    // is not honored in daemon mode). Previously this only happened AFTER
+    // waitForReady succeeded — which produced a race: if waitForReady timed
+    // out (or lsof/findProcessByPort hiccupped), the daemon was left running
+    // but PID-fileless. spindb's container manager then reports the container
+    // as "stopped" (no PID file → process-manager.isRunning returns false),
+    // and the cloud's health reconciler flips the DB row to Stopped despite
+    // the daemon being alive. See spindb-status-invariants notes.
+    //
+    // The fix: try to write the PID file BEFORE waitForReady (with a short
+    // bounded retry, since the daemon needs ~1-2s to bind the port). If the
+    // daemon isn't bound yet, waitForReady will still confirm readiness and
+    // we make a second PID-write attempt afterwards. The PID file is therefore
+    // written iff the daemon ever managed to listen on the port, independent
+    // of the readiness handshake (which can fail under low-memory conditions
+    // even when the daemon is fine).
+    let pidWritten = await this.writePidFromPort(port, pidFile)
+    if (pidWritten) {
+      logDebug(`Wrote PID file ${pidFile} before waitForReady`)
+    }
+
     // Wait for server to be ready (outside of event handler to keep event loop alive)
     logDebug(`Waiting for ClickHouse server to be ready on port ${port}...`)
     const ready = await this.waitForReady(port, version)
     logDebug(`waitForReady returned: ${ready}`)
 
-    if (!ready) {
-      throw new Error(
-        `ClickHouse failed to start within timeout. Check logs at: ${logFile}`,
-      )
+    // Second attempt — covers the case where the daemon bound the port
+    // late (e.g., after the first writePidFromPort retry budget exhausted
+    // but before waitForReady gave up).
+    if (!pidWritten) {
+      pidWritten = await this.writePidFromPort(port, pidFile)
+      if (pidWritten) {
+        logDebug(`Wrote PID file ${pidFile} after waitForReady`)
+      }
     }
 
-    // ClickHouse in daemon mode doesn't respect <pid_file> config
-    // So we manually find and write the PID after server is ready
-    logDebug(`Finding PID for port ${port}...`)
-    try {
-      const pids = await platformService.findProcessByPort(port)
-      logDebug(`findProcessByPort output: ${JSON.stringify(pids)}`)
-      if (pids.length > 0) {
-        const serverPid = String(pids[0])
-        logDebug(`Writing PID ${serverPid} to ${pidFile}`)
-        await writeFile(pidFile, serverPid, 'utf8')
-        logDebug(`Wrote PID ${serverPid} to ${pidFile}`)
-      } else {
-        logDebug(`No PIDs found for port ${port}`)
+    if (!ready) {
+      // Only treat this as a hard failure if the daemon also never bound
+      // the port. If pidWritten is true, the daemon is alive and listening
+      // — readiness probe failure is likely a transient handshake issue
+      // (lsof race, slow client spawn, low-memory VM). Let the caller see
+      // the daemon as running rather than misreport it as failed-to-start.
+      if (!pidWritten) {
+        throw new Error(
+          `ClickHouse failed to start within timeout. Check logs at: ${logFile}`,
+        )
       }
-    } catch (pidError) {
-      // Non-fatal: PID file is optional for operation
-      logDebug(`Could not write PID file: ${pidError}`)
+      logWarning(
+        `ClickHouse readiness probe timed out but daemon is listening on port ${port}; treating as started`,
+      )
     }
 
     return {
       port,
       connectionString: this.getConnectionString(container),
     }
+  }
+
+  /**
+   * Find the daemon process bound to `port` and write its PID to `pidFile`.
+   *
+   * Tries up to `maxAttempts` times with `intervalMs` between attempts.
+   * Returns true iff the PID file was written. Non-fatal on any error.
+   *
+   * Exposed as a method (rather than inlined) so it's directly unit-testable:
+   * a test can drive this with a known port and assert the PID file appears
+   * without spawning a real ClickHouse server.
+   */
+  async writePidFromPort(
+    port: number,
+    pidFile: string,
+    options: { maxAttempts?: number; intervalMs?: number } = {},
+  ): Promise<boolean> {
+    const maxAttempts = options.maxAttempts ?? 10
+    const intervalMs = options.intervalMs ?? 200
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const pids = await platformService.findProcessByPort(port)
+        logDebug(
+          `writePidFromPort attempt ${attempt}/${maxAttempts}: findProcessByPort(${port}) -> ${JSON.stringify(pids)}`,
+        )
+        if (pids.length > 0) {
+          const serverPid = String(pids[0])
+          await writeFile(pidFile, serverPid, 'utf8')
+          logDebug(`writePidFromPort: wrote ${serverPid} to ${pidFile}`)
+          return true
+        }
+      } catch (error) {
+        // Non-fatal: keep trying. Surface error in debug logs for visibility.
+        logDebug(`writePidFromPort attempt ${attempt} error: ${error}`)
+      }
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs))
+      }
+    }
+    return false
   }
 
   // Wait for ClickHouse to be ready

--- a/tests/unit/clickhouse-pid-write.test.ts
+++ b/tests/unit/clickhouse-pid-write.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test for the ClickHouse PID-write race.
+ *
+ * Bug: spindb's ClickHouse engine.start() only wrote the daemon PID file
+ * AFTER waitForReady succeeded. When the readiness probe timed out (240s on
+ * low-memory cloud containers) or when findProcessByPort hiccupped, the
+ * daemon was left running but PID-fileless. spindb then reports the
+ * container as "stopped" (no PID file → process-manager.isRunning returns
+ * false), and the cloud's health reconciler flips the DB row to Stopped
+ * despite the daemon being alive.
+ *
+ * Fix: writePidFromPort() is now called BEFORE waitForReady, and again
+ * after, so the PID file is written iff the daemon ever managed to bind
+ * the port — independent of readiness handshake.
+ *
+ * These tests verify the helper itself without spawning a real ClickHouse
+ * server. They use a bare TCP listener as a stand-in for the daemon's
+ * port-bound state, since findProcessByPort just looks at who owns the
+ * TCP socket via `lsof -ti`.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'net'
+import { existsSync } from 'fs'
+import { mkdir, readFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { ClickHouseEngine } from '../../engines/clickhouse/index'
+
+const engine = new ClickHouseEngine()
+
+let testDir: string
+
+function listenOnEphemeralPort(): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        resolve({ port: address.port, server })
+      } else {
+        reject(new Error('No address bound'))
+      }
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve())
+  })
+}
+
+describe('ClickHouse writePidFromPort (BUG-2 regression)', () => {
+  before(async () => {
+    testDir = join(tmpdir(), `spindb-ch-pidwrite-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+  })
+
+  after(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('writes the listening process PID to the file when a process is bound to the port', async () => {
+    const { port, server } = await listenOnEphemeralPort()
+    const pidFile = join(testDir, `bound-${port}.pid`)
+    try {
+      const wrote = await engine.writePidFromPort(port, pidFile, {
+        maxAttempts: 3,
+        intervalMs: 50,
+      })
+      assert.equal(wrote, true, 'should report PID file was written')
+      assert.equal(
+        existsSync(pidFile),
+        true,
+        'PID file should exist on disk',
+      )
+      const contents = (await readFile(pidFile, 'utf8')).trim()
+      assert.match(contents, /^\d+$/, 'PID file should contain a numeric PID')
+      // The lsof scrape may return any process holding the port — at minimum
+      // it should be a valid PID we can signal-zero. (On macOS lsof reports
+      // the Node test process; on Linux CI same.) Just sanity-check it's not
+      // zero or negative.
+      assert.ok(
+        Number(contents) > 0,
+        `PID should be positive, got: ${contents}`,
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  it('returns false and does not create the file when nothing is listening on the port', async () => {
+    // Pick an ephemeral port and immediately close so we know nothing is on it.
+    const { port, server } = await listenOnEphemeralPort()
+    await closeServer(server)
+
+    const pidFile = join(testDir, `unbound-${port}.pid`)
+    const wrote = await engine.writePidFromPort(port, pidFile, {
+      maxAttempts: 2,
+      intervalMs: 25,
+    })
+    assert.equal(wrote, false, 'should report PID file was not written')
+    assert.equal(
+      existsSync(pidFile),
+      false,
+      'PID file should not be created when no process holds the port',
+    )
+  })
+
+  it('respects maxAttempts and intervalMs (bounded retry, no hang)', async () => {
+    const { port, server } = await listenOnEphemeralPort()
+    await closeServer(server)
+
+    const pidFile = join(testDir, `bounded-${port}.pid`)
+    const started = Date.now()
+    const wrote = await engine.writePidFromPort(port, pidFile, {
+      maxAttempts: 4,
+      intervalMs: 50,
+    })
+    const elapsed = Date.now() - started
+
+    assert.equal(wrote, false)
+    // 4 attempts with 50ms between = up to ~3 sleeps of 50ms = ~150ms minimum
+    // plus per-attempt lsof exec overhead. Cap at 5s to catch infinite-loop regressions.
+    assert.ok(
+      elapsed < 5000,
+      `writePidFromPort should be bounded; took ${elapsed}ms`,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes BUG-2 from the spindb 0.50 + hostdb 0.31 QA sweep: ClickHouse provisions briefly, transitions to Running, then auto-flips to Stopped within ~4 minutes and refuses to restart.

## Bug

ClickHouse runs with `--daemon`, which forks immediately. spindb scrapes the daemon's PID via `lsof -ti tcp:PORT` because the config `<pid_file>` directive is not honored in daemon mode. Previously this scrape happened **only after `waitForReady` returned true**, which produced a race:

- When `waitForReady` times out (240s budget on low-memory cloud containers), the daemon is left running but PID-fileless.
- When `lsof`/`findProcessByPort` hiccups during the post-ready scrape (e.g., timing race after CH just rebound), same result.

spindb's container-manager then reports the container as `stopped` (no PID file -> `process-manager.isRunning` returns false). The cloud's `health-monitor` reconciler (60s cadence) sees `actualStatus === 'stopped'` and flips the DB row to Stopped despite the daemon being alive and serving queries. The user-facing Start button then can't recover the row cleanly because the cloud and spindb disagree about state.

Investigation findings (from architect agent, full analysis in `qa-sweep-bug-tracker.md` BUG-2):
- This is **not a spindb 0.50 regression** in ClickHouse code — the engine source has been unchanged since 0.46.4.
- The bug was latent. It surfaced now because the 0.50 image rebuild recreated all user containers, forcing every CH database through a fresh `spindb start` cycle that trips the race.

## Fix

1. Extracted `writePidFromPort(port, pidFile, options?)` helper method on `ClickHouseEngine`.
2. Call it **before** `waitForReady` — with a short bounded retry (10 attempts × 200ms) so the daemon has time to bind.
3. Call it **again** after `waitForReady` if the first attempt didn't find the process bound (covers late-bind cases).
4. If `waitForReady` fails but the PID file was written, log a warning and treat the daemon as started. The readiness handshake will retry on the next client query — but spindb's view of "running" now matches reality (daemon is alive iff it's bound to the port).
5. Only throw `"failed to start within timeout"` if **both** the readiness probe **and** the port scrape never saw the daemon — i.e., the daemon truly didn't start.

Net behavior change: spindb's view of CH "running" is now derived from "daemon bound to port" instead of "daemon bound to port AND readiness probe succeeded within budget". Same invariant `process-manager.isRunning` checks (PID file + `process.kill(pid, 0)`), but the PID file is now consistently present whenever the daemon is alive.

## Files

- `engines/clickhouse/index.ts` — fix in `start()` (lines ~524-590) + new `writePidFromPort()` helper
- `tests/unit/clickhouse-pid-write.test.ts` — new regression test (TCP listener as daemon stand-in)

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm check` (`tsc --noEmit`) — passes
- [x] `pnpm test:unit` — 1567/1567 pass (3 new tests for `writePidFromPort`)
- [x] `pnpm test:engine clickhouse` — 17/17 pass (full container lifecycle: create, start, stop, backup, restore, rename, user create, port conflicts)

## Follow-up (not in this PR)

- After merge to `main`, spindb needs a 0.50.1 release. The cloud's `images/Dockerfile.base` `SPINDB_VERSION` pin will then need bumping so the fix lands in user containers.
- The cloud-side write-`'error'`-from-`waitForHealthy` issue (BUG-3 in the QA tracker) is independent and tracked separately.