### PR TITLE
Release: spindb 0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.1] - 2026-05-16
+
+### Fixed
+
+- **ClickHouse PID-file race in `engine.start()`.** Previously the PID file was written only after `waitForReady` succeeded; on cold-start timeouts or `findProcessByPort` hiccups the daemon was left running but PID-fileless, which downstream consumers (notably layerbase-cloud's `health-monitor` task that runs `spindb list --json` every 60s and derives status from PID-file existence) interpreted as `stopped`. That stuck ClickHouse cloud databases in a Stopped → Start → Stopped loop they couldn't escape. Fixed by introducing a `writePidFromPort(port, pidFile, options?)` helper that scrapes the listening port and writes the PID file independently of `waitForReady` — invoked both before AND after `waitForReady` for belt-and-suspenders. If `waitForReady` times out but the PID file was successfully written, treat the daemon as started (it's bound and the readiness handshake will retry on the next client query). Only throw `"failed to start within timeout"` when neither signal saw the daemon. Surfaced by the 2026-05-16 prod QA sweep; tracked as BUG-2 in `~/dev/qa-sweep-bug-tracker.md`.
+
+### Tests
+
+- New `tests/unit/clickhouse-pid-write.test.ts` with 3 regression tests covering the PID-write helper (port-bound → file written, no listener → no file + returns false, bounded retry honors maxAttempts/intervalMs).
+
 ## [0.50.0] - 2026-05-15
 
 ### Changed — hostdb is now an npm dependency

--- a/engines/clickhouse/index.ts
+++ b/engines/clickhouse/index.ts
@@ -530,40 +530,104 @@ export class ClickHouseEngine extends BaseEngine {
       )
     }
 
+    // ClickHouse runs with --daemon, so it forks immediately. The PID file is
+    // written by scraping `lsof -ti tcp:PORT` (the config <pid_file> directive
+    // is not honored in daemon mode). Previously this only happened AFTER
+    // waitForReady succeeded — which produced a race: if waitForReady timed
+    // out (or lsof/findProcessByPort hiccupped), the daemon was left running
+    // but PID-fileless. spindb's container manager then reports the container
+    // as "stopped" (no PID file → process-manager.isRunning returns false),
+    // and the cloud's health reconciler flips the DB row to Stopped despite
+    // the daemon being alive. See spindb-status-invariants notes.
+    //
+    // The fix: try to write the PID file BEFORE waitForReady (with a short
+    // bounded retry, since the daemon needs ~1-2s to bind the port). If the
+    // daemon isn't bound yet, waitForReady will still confirm readiness and
+    // we make a second PID-write attempt afterwards. The PID file is therefore
+    // written iff the daemon ever managed to listen on the port, independent
+    // of the readiness handshake (which can fail under low-memory conditions
+    // even when the daemon is fine).
+    let pidWritten = await this.writePidFromPort(port, pidFile)
+    if (pidWritten) {
+      logDebug(`Wrote PID file ${pidFile} before waitForReady`)
+    }
+
     // Wait for server to be ready (outside of event handler to keep event loop alive)
     logDebug(`Waiting for ClickHouse server to be ready on port ${port}...`)
     const ready = await this.waitForReady(port, version)
     logDebug(`waitForReady returned: ${ready}`)
 
-    if (!ready) {
-      throw new Error(
-        `ClickHouse failed to start within timeout. Check logs at: ${logFile}`,
-      )
+    // Second attempt — covers the case where the daemon bound the port
+    // late (e.g., after the first writePidFromPort retry budget exhausted
+    // but before waitForReady gave up).
+    if (!pidWritten) {
+      pidWritten = await this.writePidFromPort(port, pidFile)
+      if (pidWritten) {
+        logDebug(`Wrote PID file ${pidFile} after waitForReady`)
+      }
     }
 
-    // ClickHouse in daemon mode doesn't respect <pid_file> config
-    // So we manually find and write the PID after server is ready
-    logDebug(`Finding PID for port ${port}...`)
-    try {
-      const pids = await platformService.findProcessByPort(port)
-      logDebug(`findProcessByPort output: ${JSON.stringify(pids)}`)
-      if (pids.length > 0) {
-        const serverPid = String(pids[0])
-        logDebug(`Writing PID ${serverPid} to ${pidFile}`)
-        await writeFile(pidFile, serverPid, 'utf8')
-        logDebug(`Wrote PID ${serverPid} to ${pidFile}`)
-      } else {
-        logDebug(`No PIDs found for port ${port}`)
+    if (!ready) {
+      // Only treat this as a hard failure if the daemon also never bound
+      // the port. If pidWritten is true, the daemon is alive and listening
+      // — readiness probe failure is likely a transient handshake issue
+      // (lsof race, slow client spawn, low-memory VM). Let the caller see
+      // the daemon as running rather than misreport it as failed-to-start.
+      if (!pidWritten) {
+        throw new Error(
+          `ClickHouse failed to start within timeout. Check logs at: ${logFile}`,
+        )
       }
-    } catch (pidError) {
-      // Non-fatal: PID file is optional for operation
-      logDebug(`Could not write PID file: ${pidError}`)
+      logWarning(
+        `ClickHouse readiness probe timed out but daemon is listening on port ${port}; treating as started`,
+      )
     }
 
     return {
       port,
       connectionString: this.getConnectionString(container),
     }
+  }
+
+  /**
+   * Find the daemon process bound to `port` and write its PID to `pidFile`.
+   *
+   * Tries up to `maxAttempts` times with `intervalMs` between attempts.
+   * Returns true iff the PID file was written. Non-fatal on any error.
+   *
+   * Exposed as a method (rather than inlined) so it's directly unit-testable:
+   * a test can drive this with a known port and assert the PID file appears
+   * without spawning a real ClickHouse server.
+   */
+  async writePidFromPort(
+    port: number,
+    pidFile: string,
+    options: { maxAttempts?: number; intervalMs?: number } = {},
+  ): Promise<boolean> {
+    const maxAttempts = options.maxAttempts ?? 10
+    const intervalMs = options.intervalMs ?? 200
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const pids = await platformService.findProcessByPort(port)
+        logDebug(
+          `writePidFromPort attempt ${attempt}/${maxAttempts}: findProcessByPort(${port}) -> ${JSON.stringify(pids)}`,
+        )
+        if (pids.length > 0) {
+          const serverPid = String(pids[0])
+          await writeFile(pidFile, serverPid, 'utf8')
+          logDebug(`writePidFromPort: wrote ${serverPid} to ${pidFile}`)
+          return true
+        }
+      } catch (error) {
+        // Non-fatal: keep trying. Surface error in debug logs for visibility.
+        logDebug(`writePidFromPort attempt ${attempt} error: ${error}`)
+      }
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs))
+      }
+    }
+    return false
   }
 
   // Wait for ClickHouse to be ready

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/clickhouse-pid-write.test.ts
+++ b/tests/unit/clickhouse-pid-write.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test for the ClickHouse PID-write race.
+ *
+ * Bug: spindb's ClickHouse engine.start() only wrote the daemon PID file
+ * AFTER waitForReady succeeded. When the readiness probe timed out (240s on
+ * low-memory cloud containers) or when findProcessByPort hiccupped, the
+ * daemon was left running but PID-fileless. spindb then reports the
+ * container as "stopped" (no PID file → process-manager.isRunning returns
+ * false), and the cloud's health reconciler flips the DB row to Stopped
+ * despite the daemon being alive.
+ *
+ * Fix: writePidFromPort() is now called BEFORE waitForReady, and again
+ * after, so the PID file is written iff the daemon ever managed to bind
+ * the port — independent of readiness handshake.
+ *
+ * These tests verify the helper itself without spawning a real ClickHouse
+ * server. They use a bare TCP listener as a stand-in for the daemon's
+ * port-bound state, since findProcessByPort just looks at who owns the
+ * TCP socket via `lsof -ti`.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'net'
+import { existsSync } from 'fs'
+import { mkdir, readFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { ClickHouseEngine } from '../../engines/clickhouse/index'
+
+const engine = new ClickHouseEngine()
+
+let testDir: string
+
+function listenOnEphemeralPort(): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        resolve({ port: address.port, server })
+      } else {
+        reject(new Error('No address bound'))
+      }
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve())
+  })
+}
+
+describe('ClickHouse writePidFromPort (BUG-2 regression)', () => {
+  before(async () => {
+    testDir = join(tmpdir(), `spindb-ch-pidwrite-${Date.now()}`)
+    await mkdir(testDir, { recursive: true })
+  })
+
+  after(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('writes the listening process PID to the file when a process is bound to the port', async () => {
+    const { port, server } = await listenOnEphemeralPort()
+    const pidFile = join(testDir, `bound-${port}.pid`)
+    try {
+      const wrote = await engine.writePidFromPort(port, pidFile, {
+        maxAttempts: 3,
+        intervalMs: 50,
+      })
+      assert.equal(wrote, true, 'should report PID file was written')
+      assert.equal(
+        existsSync(pidFile),
+        true,
+        'PID file should exist on disk',
+      )
+      const contents = (await readFile(pidFile, 'utf8')).trim()
+      assert.match(contents, /^\d+$/, 'PID file should contain a numeric PID')
+      // The lsof scrape may return any process holding the port — at minimum
+      // it should be a valid PID we can signal-zero. (On macOS lsof reports
+      // the Node test process; on Linux CI same.) Just sanity-check it's not
+      // zero or negative.
+      assert.ok(
+        Number(contents) > 0,
+        `PID should be positive, got: ${contents}`,
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  it('returns false and does not create the file when nothing is listening on the port', async () => {
+    // Pick an ephemeral port and immediately close so we know nothing is on it.
+    const { port, server } = await listenOnEphemeralPort()
+    await closeServer(server)
+
+    const pidFile = join(testDir, `unbound-${port}.pid`)
+    const wrote = await engine.writePidFromPort(port, pidFile, {
+      maxAttempts: 2,
+      intervalMs: 25,
+    })
+    assert.equal(wrote, false, 'should report PID file was not written')
+    assert.equal(
+      existsSync(pidFile),
+      false,
+      'PID file should not be created when no process holds the port',
+    )
+  })
+
+  it('respects maxAttempts and intervalMs (bounded retry, no hang)', async () => {
+    const { port, server } = await listenOnEphemeralPort()
+    await closeServer(server)
+
+    const pidFile = join(testDir, `bounded-${port}.pid`)
+    const started = Date.now()
+    const wrote = await engine.writePidFromPort(port, pidFile, {
+      maxAttempts: 4,
+      intervalMs: 50,
+    })
+    const elapsed = Date.now() - started
+
+    assert.equal(wrote, false)
+    // 4 attempts with 50ms between = up to ~3 sleeps of 50ms = ~150ms minimum
+    // plus per-attempt lsof exec overhead. Cap at 5s to catch infinite-loop regressions.
+    assert.ok(
+      elapsed < 5000,
+      `writePidFromPort should be bounded; took ${elapsed}ms`,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Patch release. Contents:

- **#174** — fix(clickhouse): write PID file independent of waitForReady
- **#175** — chore: release 0.50.1 (version bump + CHANGELOG)

Closes BUG-2 from the 2026-05-16 prod QA sweep (see \`~/dev/qa-sweep-bug-tracker.md\`).

## After merge

Push to main fires the publish workflow → \`npm view spindb version\` returns \`0.50.1\`. Then layerbase-cloud bumps \`SPINDB_VERSION\` in \`images/Dockerfile.base\` to pick up the fix in prod containers.

## Test plan

- [x] CI green on both contributing PRs (#174 + #175)
- [x] Unit tests pass (1567 + 3 new regression tests)
- [x] CH integration tests pass (17/17 in 18.1s)
- [ ] Publish workflow succeeds after merge
- [ ] \`npm view spindb version\` returns \`0.50.1\` with provenance attestation