### PR TITLE
chore: release spindb 0.50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.2] - 2026-05-16
+
+### Fixed
+
+- **TigerBeetle integration test flakiness (~25% failure rate on CI).** Two distinct races in `engines/tigerbeetle/index.ts` were causing intermittent CI failures on macOS arm64, macOS x64, and Windows x64 runners (BUG-7 from `~/dev/qa-sweep-bug-tracker.md`). (1) **Format timeout race**: `tigerbeetle format` allocates ~1.06 GiB on disk even with `--development`; the old 30s `execFileSync` budget was too tight for cold CI disks, surfacing as `ETIMEDOUT` during format. (2) **Start readiness race + unconditional kill**: `waitForReady` used `portManager.isPortAvailable`, which flips false the moment anything binds the port (including a half-bound socket not yet accepting); follow-on TCP connects raced and observed `ECONNREFUSED`. When the probe timed out the code unconditionally killed `proc.pid`, terminating actually-alive daemons. Fix: format runs via async `spawnAsync` with a 120s budget + `waitForDataFileReady` poll; start retries the data-file existence check, uses real TCP connect probing with port-bound fallback (60s wait budget), and — mirroring spindb 0.50.1's ClickHouse PID-race fix — treats "port has a listener" as ready when the probe times out instead of killing the daemon. New `tests/unit/tigerbeetle-startup-race.test.ts` adds 7 regression tests covering both races.
+
+### Changed
+
+- **`hostdb` dep bumped: `0.31.0` → `0.31.1` (exact pin).** `hostdb@0.31.1` moves `tsx` from `dependencies` to `devDependencies` (no API surface change). End users installing spindb no longer get a transitive `tsx` install, which removes the platform-specific `@esbuild/<platform>` binaries that previously broke electron-builder's universal-macOS merge in layerbase-desktop. Spindb's compiled `dist/` doesn't need tsx at runtime.
+
 ## [0.50.1] - 2026-05-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.31.0",
+    "hostdb": "0.31.1",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.31.0
-        version: 0.31.0
+        specifier: 0.31.1
+        version: 0.31.1
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.31.0:
-    resolution: {integrity: sha512-ptuKIbUjMvNSym/+uIWGNbpCuXbP+JaDX41f9e2y+CX92lCoZyXBDt6HrZqg4PMrneFJeIqbXwFwLlS9H0J0tg==}
+  hostdb@0.31.1:
+    resolution: {integrity: sha512-X2EQuHj3UMzA2M7JFORF49/SioPxFP2zsyUThLwNXAwzTuFzEov319MEqNvXLVoX/Fi7RxmW1IkVrcogpyEGHw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,9 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.31.0:
-    dependencies:
-      tsx: 4.22.0
+  hostdb@0.31.1: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Summary

Patch release. Contents:

- **#177** — fix(tigerbeetle): make format + start deterministic on slow CI runners (BUG-7)
- **chore(deps)** — bump hostdb pin 0.31.0 → 0.31.1 (tsx moved to devDeps; no API surface change)

## CHANGELOG

Added under \`[0.50.2] - 2026-05-16\` with both Fixed + Changed sections.

## After merge

This PR merges to \`dev\`. The existing dev→main PR #178 will then pick up the version bump. When #178 merges to main, the publish workflow fires and \`spindb@0.50.2\` lands on npm.

## Next-step plan (for orchestration tracking)

After 0.50.2 publishes:
- Cloud \`Dockerfile.base\` + \`deploy/setup.sh\` bump 0.50.1 → 0.50.2 (separate cloud PR)
- Desktop \`package.json\` spindb pin bump 0.50.0 → 0.50.2 (separate desktop PR)

## Test plan

- [x] \`pnpm test:hostdb-sync\` passes (23/23) with new hostdb pin
- [x] BUG-7 PR #177's 1574 unit tests + 8 TB integration tests pass
- [ ] CI green on this PR
- [ ] After #178 merge: publish workflow succeeds; \`npm view spindb version\` returns \`0.50.2\`