### PR TITLE
fix(couchdb): wait for cluster bootstrap before restore

### DIFF
--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -868,7 +868,21 @@ export class CouchDBEngine extends BaseEngine {
     )
   }
 
-  // Wait for CouchDB to be ready
+  // Wait for CouchDB to be ready.
+  //
+  // CouchDB's chttpd HTTP listener binds and serves `GET /` before the rest of
+  // the node (mem3 / fabric / cluster machinery) has finished bootstrapping.
+  // On slow runners (notably GitHub Actions macOS x64) the gap is wide enough
+  // that the very next operation — a GET against a user database — can hit the
+  // half-initialized node and return a 5xx with `{"error":"no_majority"}`,
+  // which then poisons follow-up restore/PUT logic.
+  //
+  // CouchDB exposes `GET /_up` for exactly this readiness signal: the endpoint
+  // is documented to return `{"status":"ok"}` 200 only once the node is fully
+  // ready to serve requests. We additionally verify that a GET against a
+  // synthetic, definitely-nonexistent database returns 404 rather than 5xx —
+  // that catches the rare case where `/_up` is satisfied but the fabric layer
+  // still rejects queries.
   private async waitForReady(
     port: number,
     timeoutMs = 30000,
@@ -878,17 +892,41 @@ export class CouchDBEngine extends BaseEngine {
 
     while (Date.now() - startTime < timeoutMs) {
       try {
-        const response = await couchdbApiRequest(
+        const upResponse = await couchdbApiRequest(
           port,
           'GET',
-          '/',
+          '/_up',
           undefined,
           undefined,
           null,
         )
-        if (response.status >= 200 && response.status < 500) {
-          logDebug(`CouchDB ready on port ${port}`)
-          return true
+
+        let upOk = false
+        if (upResponse.status === 200) {
+          const upData = upResponse.data as { status?: string } | null
+          upOk = upData?.status === 'ok'
+        }
+
+        if (upOk) {
+          // Verify the node will actually answer a database lookup with 404
+          // rather than 5xx. This proves the cluster machinery (mem3/fabric)
+          // is bootstrapped, not just chttpd.
+          const probeResponse = await couchdbApiRequest(
+            port,
+            'GET',
+            '/_spindb_readiness_probe',
+            undefined,
+            undefined,
+            null,
+          )
+          if (probeResponse.status === 404 || probeResponse.status === 401) {
+            logDebug(`CouchDB ready on port ${port}`)
+            return true
+          }
+          logDebug(
+            `CouchDB _up ok but DB lookup returned ${probeResponse.status} ` +
+              `on port ${port}, waiting...`,
+          )
         }
       } catch {
         // Connection failed, wait and retry

--- a/engines/couchdb/restore.ts
+++ b/engines/couchdb/restore.ts
@@ -145,6 +145,14 @@ export async function restoreBackup(
 
   logDebug(`Restoring ${backup.databases.length} database(s) from backup`)
 
+  // CouchDB's chttpd HTTP listener answers `GET /` before the cluster
+  // machinery (mem3/fabric) finishes bootstrapping. If the caller hands us a
+  // freshly-started node, the very first DB lookup or PUT can race the init
+  // and return 5xx (e.g. `{"error":"no_majority"}`). Block until the node
+  // proves it can answer DB lookups deterministically before we touch any
+  // real data.
+  await waitForCouchDBReady(port, auth)
+
   let restoredCount = 0
   const errors: string[] = []
 
@@ -159,15 +167,9 @@ export async function restoreBackup(
       `Restoring database: ${dbName} (${dbBackup.docs.length} documents)`,
     )
 
-    // Check if database exists
-    const checkResponse = await couchdbApiRequest(
-      port,
-      'GET',
-      `/${encodeURIComponent(dbName)}`,
-      undefined,
-      undefined,
-      auth,
-    )
+    // Check if database exists. Retry briefly on transient cluster-init
+    // errors so we can distinguish "doesn't exist" from "node not ready yet".
+    const checkResponse = await getDatabaseStatusWithRetry(port, dbName, auth)
 
     if (checkResponse.status === 200) {
       if (flush) {
@@ -190,6 +192,16 @@ export async function restoreBackup(
       } else {
         logDebug(`Database ${dbName} exists, merging documents`)
       }
+    } else if (checkResponse.status !== 404) {
+      // Anything other than 200 (exists) or 404 (clean) is a hard failure —
+      // do NOT silently fall through to bulk_docs against a missing DB. This
+      // was the original BUG-9 footgun: a 5xx from a half-initialized cluster
+      // caused the PUT branch below to be skipped, restore to "succeed" with
+      // code:1 stderr, and the calling test to see an empty database list.
+      errors.push(
+        `Unexpected status ${checkResponse.status} checking database ${dbName}: ${JSON.stringify(checkResponse.data)}`,
+      )
+      continue
     }
 
     // Create database if it doesn't exist (or was just deleted)
@@ -250,12 +262,110 @@ export async function restoreBackup(
     `Restored ${restoredCount} database(s)` +
     (errors.length > 0 ? ` with ${errors.length} error(s)` : '')
 
+  // Surface errors loudly instead of returning code:1 and letting the caller
+  // assume success. Silently returning success-with-stderr is what allowed
+  // BUG-9 to slip past the clone integration test on macOS x64.
+  if (errors.length > 0) {
+    throw new Error(`CouchDB restore failed: ${errors.join('; ')}`)
+  }
+
   return {
     format: 'json',
     stdout: message,
-    stderr: errors.length > 0 ? errors.join('\n') : undefined,
-    code: errors.length > 0 ? 1 : 0,
+    stderr: undefined,
+    code: 0,
   }
+}
+
+/**
+ * Poll CouchDB until the node is fully bootstrapped and can answer database
+ * lookups. Combines `/_up` (returns `status:"ok"` once the node is ready)
+ * with a synthetic GET against a known-nonexistent database (must return 404,
+ * not 5xx). The combination proves that mem3/fabric are up, not just chttpd.
+ */
+async function waitForCouchDBReady(
+  port: number,
+  auth: { username: string; password: string } | undefined,
+  timeoutMs = 30000,
+): Promise<void> {
+  const startTime = Date.now()
+  const checkInterval = 250
+  let lastFailure = 'no probe attempted'
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const up = await couchdbApiRequest(
+        port,
+        'GET',
+        '/_up',
+        undefined,
+        5000,
+        auth ?? null,
+      )
+      if (up.status === 200) {
+        const data = up.data as { status?: string } | null
+        if (data?.status === 'ok') {
+          const probe = await couchdbApiRequest(
+            port,
+            'GET',
+            '/_spindb_restore_probe',
+            undefined,
+            5000,
+            auth ?? null,
+          )
+          if (probe.status === 404 || probe.status === 401) {
+            return
+          }
+          lastFailure = `db-lookup probe returned ${probe.status}`
+        } else {
+          lastFailure = `/_up status was ${data?.status ?? 'undefined'}`
+        }
+      } else {
+        lastFailure = `/_up returned ${up.status}`
+      }
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((resolve) => setTimeout(resolve, checkInterval))
+  }
+
+  throw new Error(
+    `CouchDB on port ${port} did not become ready within ${timeoutMs}ms ` +
+      `(last failure: ${lastFailure})`,
+  )
+}
+
+/**
+ * Issue `GET /{db}` with a short retry loop. Transient 5xx responses can
+ * happen if the node is still settling — we don't want a one-off blip to
+ * cascade into a silent restore failure.
+ */
+async function getDatabaseStatusWithRetry(
+  port: number,
+  dbName: string,
+  auth: { username: string; password: string } | undefined,
+  maxAttempts = 5,
+): Promise<{ status: number; data: unknown }> {
+  let lastResponse: { status: number; data: unknown } | null = null
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const response = await couchdbApiRequest(
+      port,
+      'GET',
+      `/${encodeURIComponent(dbName)}`,
+      undefined,
+      undefined,
+      auth,
+    )
+    if (response.status === 200 || response.status === 404) {
+      return response
+    }
+    lastResponse = response
+    logDebug(
+      `CouchDB GET /${dbName} returned ${response.status}, retrying (${attempt + 1}/${maxAttempts})`,
+    )
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  return lastResponse ?? { status: 0, data: null }
 }
 
 /**

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -849,17 +849,44 @@ export async function waitForReady(
           throw new Error('Meilisearch health check failed or timed out')
         }
       } else if (engine === Engine.CouchDB) {
-        // Use fetch to ping CouchDB REST API with timeout
+        // CouchDB's HTTP listener answers `GET /` before the cluster machinery
+        // (mem3/fabric) finishes bootstrapping. Use `/_up` plus a synthetic
+        // 404 probe to confirm the node is actually ready to serve DB lookups.
+        // Without this, restore/PUT requests can hit a half-initialized node
+        // and silently fail on slow runners (notably macOS x64 GHA).
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 5000)
         try {
-          const response = await fetch(`http://127.0.0.1:${port}/`, {
+          const upResponse = await fetch(`http://127.0.0.1:${port}/_up`, {
             signal: controller.signal,
           })
+          if (!upResponse.ok) {
+            clearTimeout(timeoutId)
+            throw new Error(
+              `CouchDB /_up returned ${upResponse.status}, not ready`,
+            )
+          }
+          const upData = (await upResponse.json()) as { status?: string }
+          if (upData?.status !== 'ok') {
+            clearTimeout(timeoutId)
+            throw new Error(
+              `CouchDB /_up status=${upData?.status}, not ready`,
+            )
+          }
+          const probeResponse = await fetch(
+            `http://127.0.0.1:${port}/_spindb_test_probe`,
+            { signal: controller.signal },
+          )
           clearTimeout(timeoutId)
-          if (response.ok) {
+          if (
+            probeResponse.status === 404 ||
+            probeResponse.status === 401
+          ) {
             return true
           }
+          throw new Error(
+            `CouchDB DB-lookup probe returned ${probeResponse.status}, cluster not ready`,
+          )
         } catch {
           clearTimeout(timeoutId)
           throw new Error('CouchDB health check failed or timed out')


### PR DESCRIPTION
## Summary

Resolves **BUG-9**: CouchDB clone-verify integration test (`should verify cloned data matches source`) failed deterministically on macOS x64 GitHub Actions runners on spindb PR #178 (run 25972241021, both attempts), blocking the 0.50.2 release. All other platforms — Linux x64 22.04/24.04, macOS arm64, Windows — passed the same test in the same run. The test had passed on macOS x64 in the 0.50.1 release run (25970731140) one hour earlier; no CouchDB code changed between the runs, so this is a long-latent race that finally became deterministic on GHA's macOS x64 timing profile.

## Root cause

CouchDB's `chttpd` HTTP listener binds the port and answers `GET /` (the welcome endpoint) as soon as Erlang boots, but the rest of the node — `mem3`, `fabric`, and the local cluster machinery — finishes bootstrapping asynchronously. Until that finishes, requests against a real database name (`GET /test_db`, `PUT /test_db`) can return a 5xx with `{"error":"no_majority","reason":"..."}`.

The clone integration test does:
1. `engine.start(clonedConfig)` — waits for `GET /` to return any 2xx-4xx, then returns
2. `engine.restore(clonedConfig, backupPath, { database: 'test_db' })`

Inside `restoreBackup` (`engines/couchdb/restore.ts:162-243`), the very first call is `GET /test_db`. The branching only handles two cases:

- `200` → database exists, flush or merge
- `404` → fall into the create branch (`PUT /test_db`)

**Any other status (including the 5xx from a half-bootstrapped cluster) hits neither branch.** Execution falls through to `POST /test_db/_bulk_docs`, which returns 404 (database doesn't exist), gets pushed onto an `errors[]` array, and the function returns `{ code: 1, stderr: "..." }` — but **does not throw**. The engine wrapper (`index.ts:1080-1091`) just forwards that result. The integration test `await engine.restore(...)` sees no exception and treats it as success. Test 6 passes. Test 7 then queries `_all_dbs`, sees `[]`, and fails with the cryptic `Cloned container should have at least 1 database`.

The CI log confirms the timing — test 7 fails in 3.5ms (basically the time for one `fetch` round trip) because `_all_dbs` returned an empty array, not because of a timeout.

## Fix

Three layers, all in `engines/couchdb/` and `tests/integration/helpers.ts`:

1. **`engines/couchdb/index.ts` — `waitForReady`** now waits for `GET /_up` to return `{"status":"ok"}` AND for a synthetic GET against `/_spindb_readiness_probe` to return 404 (or 401 under auth). The combination proves the cluster machinery is up, not just `chttpd`. CouchDB's `_up` endpoint is documented as the readiness signal for exactly this scenario.

2. **`engines/couchdb/restore.ts` — `restoreBackup`** gains defense-in-depth:
   - `waitForCouchDBReady` runs first so direct CLI restores against a manually-started container can't race the cluster init.
   - `getDatabaseStatusWithRetry` wraps the database-exists check with a short retry on transient 5xx.
   - Any status other than 200 or 404 is now a **hard error**, not a silent fall-through to `_bulk_docs`.
   - The function **throws** when errors occur instead of returning `{ code: 1, stderr }`. Callers in `core/backup-restore.ts` already have a `try/catch` and surface `error.message` cleanly, so the user-visible behavior is "restore failed: ..." instead of the previous "restore succeeded with warnings, but actually didn't".

3. **`tests/integration/helpers.ts` — `waitForReady`** for CouchDB applies the same `/_up` + 404-probe check, so tests calling the helper directly can't be fooled either.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm check` (tsc --noEmit) clean
- [x] `pnpm test:unit` — 1574 unit tests pass (includes existing `couchdb-restore.test.ts` and `couchdb-version-validator.test.ts`)
- [x] `pnpm test:engine couchdb` — 12/12 pass, 4 consecutive runs locally on macOS arm64 (~17s per run)
- [ ] CI matrix — verify macOS x64 attempt 1 passes (was previously failing both attempts)
- [ ] Author smoke test: `spindb backup` + `spindb restore` round-trip on a real local CouchDB container

## Notes

- No spindb scripting API surface changed. The behavior change is on the failure path: callers that previously got `{ success: true, warnings: [...] }` on a broken restore now get `{ success: false, error: "..." }`. That's strictly better — the previous behavior was the BUG-9 root cause.
- No cloud / web ecosystem impact. CouchDB on layerbase-cloud uses the same engine code; the readiness improvement also helps the cloud provisioner avoid a similar (currently-untriggered) race.
- No new dependencies, no engine-version pin changes.