### PR TITLE
fix(typedb): use correct console subcommand 'update-password' (BUG-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.3] - 2026-05-16
+
+### Fixed
+
+- **TypeDB user password rotation against an existing user always failed (BUG-13 from `~/dev/qa-sweep-bug-tracker.md`).** `engines/typedb/index.ts:1234` invoked `user password-update <name> <pw>` via the `--command` flag of `typedb_console_bin`. The TypeDB 3.x console registers the subcommand as `update-password` (verified against `typedb/typedb-console` `main.rs` from 3.8.0 through 3.10.1), so the call surfaced as `Unrecognised 'user' subcommand: 'password-update …'` and the close handler bubbled `Failed to update user password`. The `createUser` flow's `user create` → on-"already exists" → password-update fallback was therefore broken for every admin-password rotation, which in layerbase-cloud surfaces as a 401 AUT1 on the very first query (cloud's stored credential is the rotated one, but TypeDB still has `admin/password`). Fix: swap the subcommand to the canonical `update-password`.
+
 ## [0.50.2] - 2026-05-16
 
 ### Fixed

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -1225,13 +1225,23 @@ export class TypeDBEngine extends BaseEngine {
           logDebug(`Created TypeDB user: ${username}`)
           resolve()
         } else if (stderr.toLowerCase().includes('already exists')) {
-          // User exists - update password instead
+          // User exists - update password instead.
+          //
+          // The TypeDB 3.x console subcommand is `update-password`, not
+          // `password-update`. The words were transposed here, so every
+          // password rotation against an existing user (including the
+          // built-in admin) failed with "Unrecognised 'user' subcommand:
+          // 'password-update <pw>'", caught by the close handler and
+          // bubbled up as "Failed to update user password" — see typedb-
+          // console main.rs CommandLeaf registration: the canonical name
+          // is "update-password". Verified across 3.8.0..3.10.1 console
+          // releases.
           logDebug(`User "${username}" already exists, updating password`)
           try {
             const updateArgs = [
               ...getConsoleBaseArgs(port),
               '--command',
-              `user password-update ${username} ${password}`,
+              `user update-password ${username} ${password}`,
             ]
             await new Promise<void>((res, rej) => {
               const updateProc = spawn(consolePath, updateArgs, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/integration/typedb.test.ts
+++ b/tests/integration/typedb.test.ts
@@ -287,6 +287,54 @@ describe('TypeDB Integration Tests', () => {
     console.log('   Created user successfully')
   })
 
+  // BUG-13 regression: createUser's "already exists" fallback used the
+  // wrong console subcommand (`user password-update` instead of the
+  // canonical `user update-password`), so EVERY password rotation against
+  // an existing user silently failed. Layerbase-cloud calls this exact
+  // path on every fresh TypeDB provision via setup-database.sh's
+  // `spindb users create <db> admin --password <pw>` — a failure leaves
+  // TypeDB on its default `admin/password` while cloud stores the rotated
+  // value, surfacing as a 401 AUT1 on every query.
+  //
+  // We avoid rotating the built-in admin here because subsequent tests
+  // (and the test harness's cleanup path) authenticate as admin/password.
+  // Instead, create a fresh user twice with different passwords — the
+  // second call exercises the "already exists" → update-password branch.
+  it('should rotate password on an existing user (BUG-13 regression)', async () => {
+    console.log(`\n Testing createUser password rotation on existing user...`)
+
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    const engine = getEngine(ENGINE)
+    const rotationUser = 'bug13user'
+
+    // First call goes through the `user create` happy path.
+    await engine.createUser(config!, {
+      username: rotationUser,
+      password: 'initial-pw-456',
+      database: DATABASE,
+    })
+
+    // Second call triggers `user create` → "already exists" → falls through
+    // to `user update-password <name> <newpw>`. Before BUG-13 fix this
+    // threw `Failed to update user password: Unrecognised 'user'
+    // subcommand: 'password-update bug13user rotated-pw-789'`.
+    const rotated = await engine.createUser(config!, {
+      username: rotationUser,
+      password: 'rotated-pw-789',
+      database: DATABASE,
+    })
+    assertEqual(rotated.username, rotationUser, 'Username should match')
+    assertEqual(
+      rotated.password,
+      'rotated-pw-789',
+      'Returned password should be the rotated one',
+    )
+
+    console.log('   Password rotation against existing user succeeded')
+  })
+
   it('should clone container using backup/restore', async () => {
     console.log(
       `\n Creating container "${clonedContainerName}" via backup/restore...`,


### PR DESCRIPTION
## Summary

Root-cause fix for the TypeDB auth failures hitting layerbase-cloud QA on every fresh provision.

`engines/typedb/index.ts:1234` invoked the TypeDB 3.x console with:

```bash
typedb_console_bin --address … --tls-disabled --username admin --password password \
  --command "user password-update <name> <newpw>"
```

The subcommand is registered in `typedb-console` as **`update-password`** (verified across 3.8.0 → 3.10.1 in `main.rs`'s `CommandLeaf::new_with_inputs("update-password", …)`). With the words transposed, every call surfaced:

```
Unrecognised 'user' subcommand: 'password-update <name> <newpw>'
```

The close handler bubbled `Failed to update user password: <stderr>`, which was caught by the layerbase-cloud setup-database.sh BUG-12 guard (PR #298), letting the container provision successfully — but TypeDB stayed on its **default `admin/password`** while the cloud stored the rotated password. Every subsequent query 401'd with `AUT1`.

## Verification

The TypeDB 3.x console subcommand registration confirms the canonical name (also unchanged in current `main`):

```rust
// typedb/typedb-console: src/main.rs (3.8.0..3.10.1)
.add(CommandLeaf::new_with_inputs(
    "update-password",
    "Set existing user's password.",
    vec![
        CommandInput::new_required("name", get_word, None),
        CommandInput::new_hidden("new password", get_word, get_word, None),
    ],
    user_update_password,
));
```

`CommandInput::new_hidden` accepts the value as a positional argument when given on the command line; the prompt only fires when the value is missing (per `repl/command.rs`'s `RequiredHidden(_)` arm). So the existing call form (`user update-password <name> <newpw>`) is correct — only the subcommand name needed to flip.

## What ships

- `engines/typedb/index.ts:1234` — `user password-update` → `user update-password`
- Inline comment documenting why the wrong word order silently broke and citing the console source
- New integration test in `tests/integration/typedb.test.ts` that exercises the "already exists" → password-rotation branch by calling `createUser` twice on the same non-admin user with different passwords (avoids rotating the built-in admin, which would break subsequent tests in the suite)
- CHANGELOG entry under [0.50.3]
- Version bump 0.50.2 → 0.50.3

## Test plan

- [ ] Matrix CI passes (TypeDB integration test on macOS arm64/x64 + Linux 22/24)
- [ ] After publish, bump `SPINDB_VERSION` in `layerbase-cloud/images/Dockerfile.base` to 0.50.3
- [ ] After cloud image rebuild + deploy, provision a fresh `qa_typedb_v4`, open the query console, run `match \$x isa thing;` — expect empty TypeQL result, **no AUT1 auth error**