### PR TITLE
fix(fetch): retry on transient network errors during binary downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.5] - 2026-05-22
+
+### Fixed
+
+- **Hostdb fetch had zero retry logic, producing recurring `"<engine> <version> not available: fetch failed"` errors during cloud provisioning.** A single transient network blip (`TypeError: fetch failed` from Node's undici on `ECONNRESET` / `ETIMEDOUT` / `EAI_AGAIN`) would kill the entire `spindb create`, with no second chance. Combined with `ENABLE_GITHUB_FALLBACK = false`, even the URL fallback was disabled. Two layers of retry now in place: (1) `fetchWithRetries` in `core/hostdb-client.ts` wraps every fetch with up to 3 attempts at `0/300/900 ms` backoff on transient network errors and HTTP 5xx/408/429; used by both `fetchWithRegistryFallback` and `fetchFromRegistryUrls`. (2) `core/base-binary-manager.ts` wraps the entire binary download — `fetch()` + stream pipeline to disk — in an outer 3-attempt retry at `0/1/3 s` backoff, catching stream-mid-flight failures (socket reset after the body started streaming). `AbortError` still propagates immediately so caller timeouts work; 4xx other than 408/429 are not retried since they won't change.
+
 ## [0.50.4] - 2026-05-17
 
 ### Fixed

--- a/core/base-binary-manager.ts
+++ b/core/base-binary-manager.ts
@@ -176,59 +176,101 @@ export abstract class BaseBinaryManager {
 
     let success = false
     try {
-      // Download the archive with timeout (5 minutes)
+      // Download the archive with timeout (5 minutes) + retry on stream
+      // failures. The fetch() call already retries internally on the
+      // initial connection (see fetchWithRetries in hostdb-client.ts);
+      // this outer loop covers stream-mid-flight failures (the body
+      // socket dies after fetch returned a Response but before the
+      // pipeline finishes consuming it). Common cause: brief network
+      // partition during a multi-second binary download. Retry budget
+      // here is short (max 3 attempts) because each attempt re-downloads
+      // the entire archive from scratch — fail-fast over hours of stuck
+      // retries.
       onProgress?.({
         stage: 'downloading',
         message: `Downloading ${this.config.displayName} binaries...`,
       })
 
-      const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), 5 * 60 * 1000)
+      const MAX_DOWNLOAD_ATTEMPTS = 3
+      const DOWNLOAD_RETRY_DELAYS_MS = [0, 1000, 3000]
 
-      let response: Response
-      try {
-        response = await fetchWithRegistryFallback(url, {
-          signal: controller.signal,
-        })
-      } catch (error) {
-        const err = error as Error
-        if (err.name === 'AbortError') {
-          throw new Error('Download timed out after 5 minutes')
-        }
-        throw error
-      } finally {
-        clearTimeout(timeoutId)
-      }
-
-      if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error(
-            `${this.config.displayName} ${fullVersion} binaries not found (404). ` +
-              `This version may have been removed from hostdb. ` +
-              `Try a different version or check https://registry.layerbase.host`,
+      let attempt = 0
+      let lastDownloadError: unknown = null
+      while (attempt < MAX_DOWNLOAD_ATTEMPTS) {
+        if (DOWNLOAD_RETRY_DELAYS_MS[attempt] > 0) {
+          await new Promise((r) =>
+            setTimeout(r, DOWNLOAD_RETRY_DELAYS_MS[attempt]),
           )
         }
-        throw new Error(
-          `Failed to download ${this.config.displayName} binaries: ${response.status} ${response.statusText}`,
-        )
+        attempt++
+
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), 5 * 60 * 1000)
+
+        let response: Response
+        try {
+          response = await fetchWithRegistryFallback(url, {
+            signal: controller.signal,
+          })
+        } catch (error) {
+          clearTimeout(timeoutId)
+          const err = error as Error
+          if (err.name === 'AbortError') {
+            throw new Error('Download timed out after 5 minutes')
+          }
+          // Already retried internally; if we get here, propagate.
+          throw error
+        }
+
+        if (!response.ok) {
+          clearTimeout(timeoutId)
+          if (response.status === 404) {
+            throw new Error(
+              `${this.config.displayName} ${fullVersion} binaries not found (404). ` +
+                `This version may have been removed from hostdb. ` +
+                `Try a different version or check https://registry.layerbase.host`,
+            )
+          }
+          throw new Error(
+            `Failed to download ${this.config.displayName} binaries: ${response.status} ${response.statusText}`,
+          )
+        }
+
+        if (!response.body) {
+          clearTimeout(timeoutId)
+          throw new Error(
+            `Download failed: response has no body (status ${response.status})`,
+          )
+        }
+
+        // Create file stream only after confirming response.body is present.
+        // Truncate any previous attempt's partial file.
+        const fileStream = createWriteStream(archiveFile)
+        try {
+          const nodeStream = Readable.fromWeb(response.body)
+          await pipeline(nodeStream, fileStream)
+          clearTimeout(timeoutId)
+          break // download succeeded — exit retry loop
+        } catch (pipelineError) {
+          clearTimeout(timeoutId)
+          fileStream.destroy()
+          lastDownloadError = pipelineError
+          if (attempt >= MAX_DOWNLOAD_ATTEMPTS) {
+            throw pipelineError
+          }
+          // Stream broke mid-flight (common transient: socket reset,
+          // brief partition). Retry the whole download from scratch.
+          onProgress?.({
+            stage: 'downloading',
+            message: `Download interrupted, retrying (attempt ${attempt + 1}/${MAX_DOWNLOAD_ATTEMPTS})...`,
+          })
+        }
       }
 
-      if (!response.body) {
-        throw new Error(
-          `Download failed: response has no body (status ${response.status})`,
-        )
-      }
-
-      // Create file stream only after confirming response.body is present
-      const fileStream = createWriteStream(archiveFile)
-      try {
-        // Convert WHATWG ReadableStream to Node.js Readable (requires Node.js 18+)
-        const nodeStream = Readable.fromWeb(response.body)
-        await pipeline(nodeStream, fileStream)
-      } catch (pipelineError) {
-        // Ensure fileStream is destroyed on pipeline errors
-        fileStream.destroy()
-        throw pipelineError
+      // Defensive: if we somehow exit the loop without success and
+      // without throwing, surface the last error.
+      if (lastDownloadError && attempt >= MAX_DOWNLOAD_ATTEMPTS) {
+        throw lastDownloadError
       }
 
       // Create binPath only after download succeeds (avoids leaving empty dirs on failure)

--- a/core/hostdb-client.ts
+++ b/core/hostdb-client.ts
@@ -242,26 +242,121 @@ export function getRegistryFallbackUrl(url: string): string | null {
   return null
 }
 
+// Retry policy for transient network failures. Picked so a 1-2s blip
+// gets absorbed but a real outage fails quickly. Total worst-case
+// budget per URL = sum of delays = 0 + 300 + 900 = 1.2s of backoff
+// across 3 attempts.
+const TRANSIENT_RETRY_DELAYS_MS = [0, 300, 900]
+
+/**
+ * Returns true when an error from `fetch` looks like a transient
+ * network problem worth retrying. Excludes intentional timeouts
+ * (AbortError, which carry their own meaning) and non-retryable
+ * client errors at this layer.
+ *
+ * Node's undici throws `TypeError: fetch failed` for almost every
+ * connection-level failure; the underlying reason lives in
+ * `error.cause.code` (e.g., 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN',
+ * 'UND_ERR_SOCKET'). Treating all of those as transient is the right
+ * call — none of them indicate the URL is permanently broken.
+ */
+function isTransientFetchError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.name === 'AbortError') return false
+  if (error.message === 'fetch failed') return true
+  const cause = (error as { cause?: { code?: string } }).cause
+  if (cause?.code) {
+    return [
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+      'UND_ERR_SOCKET',
+      'UND_ERR_CONNECT_TIMEOUT',
+    ].includes(cause.code)
+  }
+  return false
+}
+
+/**
+ * Returns true when an HTTP response status code is worth retrying.
+ * Covers transient server-side conditions (5xx) and rate limiting
+ * (429). Client errors (other 4xx) are NOT retried — they won't
+ * change on retry and are usually a bug in the request.
+ */
+function isTransientStatus(status: number): boolean {
+  return status >= 500 || status === 408 || status === 429
+}
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Fetch a URL with retry on transient network errors and transient
+ * HTTP responses (5xx, 408, 429). Used as the base primitive that
+ * fetchWithRegistryFallback and fetchFromRegistryUrls build on, so a
+ * single network blip doesn't take down a binary download. Honors
+ * AbortError so caller-supplied timeouts still terminate immediately.
+ */
+async function fetchWithRetries(
+  url: string,
+  options?: RequestInit,
+): Promise<Response> {
+  let lastError: unknown
+  let lastStatus: number | null = null
+  for (let attempt = 0; attempt < TRANSIENT_RETRY_DELAYS_MS.length; attempt++) {
+    await sleep(TRANSIENT_RETRY_DELAYS_MS[attempt])
+    try {
+      const response = await fetch(url, options)
+      if (response.ok || !isTransientStatus(response.status)) {
+        return response
+      }
+      lastStatus = response.status
+      logDebug(
+        `Fetch ${url} returned ${response.status} on attempt ${attempt + 1}/${TRANSIENT_RETRY_DELAYS_MS.length}, retrying...`,
+      )
+    } catch (error) {
+      if (!isTransientFetchError(error)) {
+        throw error
+      }
+      lastError = error
+      logDebug(
+        `Fetch ${url} failed transiently on attempt ${attempt + 1}/${TRANSIENT_RETRY_DELAYS_MS.length}: ${(error as Error).message}`,
+      )
+    }
+  }
+  // All attempts exhausted. Throw the last error we saw, or a
+  // synthetic one carrying the last HTTP status if we never threw.
+  if (lastError) throw lastError
+  throw new Error(
+    `fetch ${url} failed after ${TRANSIENT_RETRY_DELAYS_MS.length} attempts (last status: ${lastStatus ?? 'unknown'})`,
+  )
+}
+
 /**
  * Fetch wrapper that tries the primary URL first, then falls back to the
  * GitHub registry if the primary is a layerbase URL and the request fails
  * with a 404, 5xx, or network error.
  *
- * AbortError (timeout) is never retried — it propagates immediately.
+ * Each URL attempt internally retries on transient errors before falling
+ * back to the next URL — a single network blip won't burn through the
+ * fallback. AbortError (timeout) still propagates immediately.
  */
 export async function fetchWithRegistryFallback(
   url: string,
   options?: RequestInit,
 ): Promise<Response> {
   try {
-    const response = await fetch(url, options)
+    const response = await fetchWithRetries(url, options)
     if (response.status === 404 || response.status >= 500) {
       const fallbackUrl = getRegistryFallbackUrl(url)
       if (fallbackUrl) {
         logDebug(
           `Primary registry returned ${response.status}, trying GitHub fallback`,
         )
-        return await fetch(fallbackUrl, options)
+        return await fetchWithRetries(fallbackUrl, options)
       }
     }
     return response
@@ -276,7 +371,7 @@ export async function fetchWithRegistryFallback(
       logDebug(
         `Primary registry fetch failed (${err.message}), trying GitHub fallback`,
       )
-      return await fetch(fallbackUrl, options)
+      return await fetchWithRetries(fallbackUrl, options)
     }
     throw error
   }
@@ -284,8 +379,9 @@ export async function fetchWithRegistryFallback(
 
 /**
  * Try fetching from multiple registry URLs in order, returning the first
- * successful (response.ok) Response. Logs per-URL failures via the
- * supplied logger callback.
+ * successful (response.ok) Response. Each URL gets its own retry budget
+ * before moving on to the next so transient blips don't burn through the
+ * registry list. Logs per-URL failures via the supplied logger callback.
  *
  * @param urls - URLs to try in order (e.g., layerbase then GitHub)
  * @param logger - Callback for logging per-URL failures
@@ -301,7 +397,7 @@ export async function fetchFromRegistryUrls(
   let lastError: Error | null = null
   for (const url of urls) {
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithRetries(url, {
         signal: AbortSignal.timeout(timeoutMs),
       })
       if (response.ok) return response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1542,15 +1542,36 @@ export async function createCouchDBDatabase(
   port: number,
   name: string,
 ): Promise<boolean> {
+  const url = `http://127.0.0.1:${port}/${encodeURIComponent(name)}`
   try {
-    const encodedName = encodeURIComponent(name)
-    const response = await fetch(`http://127.0.0.1:${port}/${encodedName}`, {
+    const response = await fetch(url, {
       method: 'PUT',
       headers: { Authorization: COUCHDB_AUTH_HEADER },
     })
     // 201 = created, 412 = already exists (both are acceptable)
-    return response.status === 201 || response.status === 412
-  } catch {
+    if (response.status === 201 || response.status === 412) {
+      return true
+    }
+    // Surface the real reason on unexpected statuses. The previous
+    // `catch {}` and bare-false-return path hid these from CI and made
+    // the assertion message "Should create source database" useless for
+    // diagnosing intermittent failures on the macOS x64 runner.
+    let body = ''
+    try {
+      body = await response.text()
+    } catch {
+      body = '(response body unreadable)'
+    }
+    console.error(
+      `createCouchDBDatabase PUT ${url} returned ${response.status} ${response.statusText}: ${body.slice(0, 500)}`,
+    )
+    return false
+  } catch (error) {
+    const err = error as Error & { cause?: { code?: string; message?: string } }
+    console.error(
+      `createCouchDBDatabase PUT ${url} threw ${err.name}: ${err.message}` +
+        (err.cause ? ` (cause.code=${err.cause.code} cause.message=${err.cause.message})` : ''),
+    )
     return false
   }
 }


### PR DESCRIPTION
The hostdb fetch path had zero resilience: a single TypeError: fetch failed (Node's generic message for any underlying ECONNRESET / ETIMEDOUT / EAI_AGAIN / etc.) would kill the entire 'spindb create' even though the registry was usually reachable a moment later. Combined with ENABLE_GITHUB_FALLBACK=false, there was no second chance at all, which produced the recurring 'libSQL/Valkey not available: fetch failed' errors in layerbase-cloud staging.

Two layers of retry now:

1) fetchWithRetries in hostdb-client.ts wraps every fetch with up to 3 attempts (0ms / 300ms / 900ms backoff) on transient network errors and transient HTTP statuses (5xx, 408, 429). Used by both fetchWithRegistryFallback and fetchFromRegistryUrls, so releases.json fetches and HEAD-style metadata calls are all covered. AbortError still propagates immediately so caller timeouts work.

2) base-binary-manager.ts wraps the entire binary download — fetch() + stream pipeline to disk — in an outer 3-attempt retry (0ms / 1s / 3s). The inner fetch retry covers initial-connection failures; this outer loop covers stream-mid-flight failures (socket reset after the body started streaming, brief network partition during a multi-second tarball download). Each attempt re-downloads from scratch into a truncated archive file.

Transient-error classifier:

  - TypeError 'fetch failed' (Node undici generic)

  - error.cause.code in {ECONNRESET, ECONNREFUSED, ETIMEDOUT, EAI_AGAIN, UND_ERR_SOCKET, UND_ERR_CONNECT_TIMEOUT}

  - HTTP 5xx, 408, 429

  Excludes: AbortError (caller timeout), 4xx other than 408/429 (client bug, won't change)

Worst-case retry budget per URL = 1.2s of backoff across 3 fetch attempts; binary download adds up to 4s of additional backoff across 3 stream attempts. Both terminate quickly on real outages so we don't pin downloads for hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability with automatic retry logic for temporary network issues and timeouts.
  * Enhanced error messaging for download interruptions and failure scenarios.
  * Added timeout protection for archive downloads to prevent indefinite hangs.
  * Strengthened fallback behavior for registry requests with improved resilience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robertjbass/spindb/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->