### PR TITLE
chore(deps): bump hostdb 0.31.1 -> 0.32.0 (BSD Redis 7.2.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.6] - 2026-05-23
+
+### Changed
+
+- **`hostdb` dep bumped: `0.31.1` → `0.32.0` (exact pin).** Picks up the BSD-licensed `redis-7.2.14` binary added in `hostdb@0.32.0` (PR #192) and the registry's defaults flip — `resolveVersion('redis', '7')` now returns `7.2.14` instead of `7.4.9`. Redis 7.4.x and 8.x are RSALv2/SSPLv1 ("no competing managed services"); 7.2.x is the last branch still maintained under BSD-3-Clause by Redis Inc themselves. Existing `spindb create redis 7.4.x` / `redis 8.x` calls still work for desktop / dev use, but `redis 7` (the canonical default) now lands on the BSD line by default. `redis 7.4.9`/`7.4.7` remain resolvable from the registry but are marked `deprecated: true` in `releases.json`. Verified: all 44 integration tests pass against `hostdb@0.32.0`.
+
 ## [0.50.5] - 2026-05-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.31.1",
+    "hostdb": "0.32.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.31.1
-        version: 0.31.1
+        specifier: 0.32.0
+        version: 0.32.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.31.1:
-    resolution: {integrity: sha512-X2EQuHj3UMzA2M7JFORF49/SioPxFP2zsyUThLwNXAwzTuFzEov319MEqNvXLVoX/Fi7RxmW1IkVrcogpyEGHw==}
+  hostdb@0.32.0:
+    resolution: {integrity: sha512-KCSiXEQzVEhI6eq3duYGCrkNOKZc9eDCJ8qRPKv7zhWjtNQrhgBe2Q5C7+P/Ip7gDRnwWnntlQTwp+EtuVHglw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.31.1: {}
+  hostdb@0.32.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Summary

- Bumps `hostdb` exact-pin: `0.31.1` -> `0.32.0`
- Picks up the BSD-licensed Redis 7.2.14 binary added in hostdb#192
- Defaults flip: `resolveVersion('redis', '7')` now returns `7.2.14` (BSD-3-Clause) instead of `7.4.9` (RSALv2/SSPLv1)
- `redis 7.4.x` / `redis 8.x` still resolvable for desktop/dev use; cloud-side license guard (already shipped in layerbase-cloud) blocks them from being provisioned as a hosted service

## Why

Redis 7.4.0+ moved to RSALv2/SSPLv1 ("no competing managed services"). 7.2.x is the only branch Redis Inc still maintains under BSD-3-Clause. Until now spindb's `redis 7` default resolved to 7.4.9, which would put us in license violation if used as the foundation of layerbase-cloud's managed Redis offering. With hostdb 0.32.0 the registry default for `7` is 7.2.14, so just bumping the dep resolves the violation everywhere downstream.

## Test plan

- [x] `pnpm flip-hostdb-pin 0.32.0` passes (44/44 integration tests)
- [x] Sanity-check: `resolveVersion('redis', '7')` -> `7.2.14`, `redis 8` -> `8.4.0`
- [x] `tsc --noEmit` (via pre-commit hook) clean
- [ ] After merge + publish: layerbase-cloud bumps SPINDB_VERSION in Dockerfile.base
- [ ] After merge + publish: layerbase-desktop bumps spindb dep