### PR TITLE
chore(release): bump version to 0.50.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.7] - 2026-05-23
+
+### Tests
+
+- **New `tests/integration/redis-version-smoke.test.ts` for non-canonical Redis majors.** The existing `redis.test.ts` hardcodes `TEST_VERSION='8'`, so 21 lifecycle / clone / restore / auth tests all run on 8.x only. When hostdb 0.32.0 shipped the BSD-licensed `redis-7.2.14` binary and `spindb@0.50.6` cascaded it into production, no automated test ever booted the new binary - the suite was 100% green because it just never tested the new version. Manual smoke caught it during cloud rollout; could just as easily have shipped a broken binary. The new smoke iterates `SUPPORTED_MAJOR_VERSIONS` minus the canonical version and runs a minimal lifecycle (ensureBinaries -> create -> initDataDir -> start -> waitForReady -> SET smoke:key value -> GET smoke:key -> stop -> waitForStopped -> delete) for each. ~2.6s per version on Apple Silicon. Future Redis majors added to hostdb pick up smoke coverage automatically with no test edits. Scope is intentionally minimal - backup/restore/clone coverage stays on the canonical version; we just need proof the binary boots and serves traffic on this platform. Verified locally against Redis 7 before merge.
+
 ## [0.50.6] - 2026-05-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary

Patch release that ships the redis-version-smoke from PR #189 (merged via 7ebe224).

Pure test-only change but worth releasing on its own cadence so the cascade (cloud Dockerfile.base, desktop dep) can pick it up without waiting on whatever lands next.

## What's in 0.50.7

- \`tests/integration/redis-version-smoke.test.ts\` — minimal lifecycle smoke for every non-canonical Redis major in \`SUPPORTED_MAJOR_VERSIONS\`. Closes the gap that let redis-7.2.14 ship unexercised when hostdb 0.32.0 cascaded into spindb 0.50.6.

## Merge order

Standard: merge this to dev, then dev -> main releases (next PR) fires the OIDC publish.

## Test plan

- [x] CHANGELOG updated with the [0.50.7] entry under [Unreleased]
- [x] package.json bumped
- [ ] After main publish: \`npm view spindb version\` shows 0.50.7
- [ ] (Optional cascade) layerbase-cloud Dockerfile.base bump + desktop dep bump — only worth doing if other changes accumulate; pure test bump doesn't need an image rebuild on its own