### PR TITLE
fix(couchdb): add write probe to waitForReady to gate slow-runner race

### DIFF
--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -877,12 +877,14 @@ export class CouchDBEngine extends BaseEngine {
   // half-initialized node and return a 5xx with `{"error":"no_majority"}`,
   // which then poisons follow-up restore/PUT logic.
   //
-  // CouchDB exposes `GET /_up` for exactly this readiness signal: the endpoint
-  // is documented to return `{"status":"ok"}` 200 only once the node is fully
-  // ready to serve requests. We additionally verify that a GET against a
-  // synthetic, definitely-nonexistent database returns 404 rather than 5xx —
-  // that catches the rare case where `/_up` is satisfied but the fabric layer
-  // still rejects queries.
+  // Three-stage gate:
+  //   1. `GET /_up` returns `{"status":"ok"}` — chttpd is up.
+  //   2. `GET /<nonexistent-db>` returns 404 — the routing layer can talk
+  //      to mem3/fabric for reads.
+  //   3. `PUT /<probe-db>` + `DELETE` succeed — the cluster writer
+  //      machinery (shard-creation) is also bootstrapped. Without this
+  //      third stage the reader can be ready while writes still 5xx, and
+  //      any caller doing `PUT /<dbname>` (e.g. restore, tests) fails.
   private async waitForReady(
     port: number,
     timeoutMs = 30000,
@@ -908,10 +910,9 @@ export class CouchDBEngine extends BaseEngine {
         }
 
         if (upOk) {
-          // Verify the node will actually answer a database lookup with 404
-          // rather than 5xx. This proves the cluster machinery (mem3/fabric)
-          // is bootstrapped, not just chttpd.
-          const probeResponse = await couchdbApiRequest(
+          // Read probe: nonexistent DB lookup must return 404, not 5xx.
+          // Proves the routing + mem3/fabric layer is bootstrapped.
+          const readProbe = await couchdbApiRequest(
             port,
             'GET',
             '/_spindb_readiness_probe',
@@ -919,13 +920,45 @@ export class CouchDBEngine extends BaseEngine {
             undefined,
             null,
           )
-          if (probeResponse.status === 404 || probeResponse.status === 401) {
-            logDebug(`CouchDB ready on port ${port}`)
+          if (
+            readProbe.status !== 404 &&
+            readProbe.status !== 401
+          ) {
+            logDebug(
+              `CouchDB _up ok but read probe returned ${readProbe.status} ` +
+                `on port ${port}, waiting...`,
+            )
+            await new Promise((resolve) => setTimeout(resolve, checkInterval))
+            continue
+          }
+          // Write probe: PUT + DELETE a synthetic DB. Until this round-trips
+          // the node isn't safe for callers that create databases.
+          // Underscore-prefixed names are reserved for system DBs and will
+          // be rejected on PUT, so use a plain name.
+          const probeDbPath = '/spindb_writeprobe'
+          const putResponse = await couchdbApiRequest(
+            port,
+            'PUT',
+            probeDbPath,
+          )
+          if (
+            putResponse.status === 201 ||
+            putResponse.status === 412 ||
+            putResponse.status === 202
+          ) {
+            // Best-effort cleanup. If the DELETE fails, the next probe will
+            // see 412 (already exists) and still treat the cluster as ready.
+            try {
+              await couchdbApiRequest(port, 'DELETE', probeDbPath)
+            } catch {
+              /* probe cleanup is best-effort */
+            }
+            logDebug(`CouchDB ready (read + write) on port ${port}`)
             return true
           }
           logDebug(
-            `CouchDB _up ok but DB lookup returned ${probeResponse.status} ` +
-              `on port ${port}, waiting...`,
+            `CouchDB read probe ok but write probe PUT returned ` +
+              `${putResponse.status} on port ${port}, waiting...`,
           )
         }
       } catch {

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -850,10 +850,16 @@ export async function waitForReady(
         }
       } else if (engine === Engine.CouchDB) {
         // CouchDB's HTTP listener answers `GET /` before the cluster machinery
-        // (mem3/fabric) finishes bootstrapping. Use `/_up` plus a synthetic
-        // 404 probe to confirm the node is actually ready to serve DB lookups.
-        // Without this, restore/PUT requests can hit a half-initialized node
-        // and silently fail on slow runners (notably macOS x64 GHA).
+        // (mem3/fabric) finishes bootstrapping. Three-stage readiness gate:
+        //   1. `/_up` returns {status:"ok"} — chttpd is up.
+        //   2. GET on a synthetic DB returns 404 — the routing layer can
+        //      reach mem3/fabric for reads.
+        //   3. PUT + DELETE a synthetic probe DB succeed — the cluster
+        //      writer machinery (shard-creation) is also bootstrapped.
+        // Without (3), the read probe can succeed while writes still 5xx
+        // with no_majority on slow runners (notably macOS x64 GHA), which
+        // is the race that caused recurring failures in the
+        // backup-restore-with-auth integration test.
         const controller = new AbortController()
         const timeoutId = setTimeout(() => controller.abort(), 5000)
         try {
@@ -877,16 +883,45 @@ export async function waitForReady(
             `http://127.0.0.1:${port}/_spindb_test_probe`,
             { signal: controller.signal },
           )
-          clearTimeout(timeoutId)
           if (
-            probeResponse.status === 404 ||
-            probeResponse.status === 401
+            probeResponse.status !== 404 &&
+            probeResponse.status !== 401
           ) {
-            return true
+            clearTimeout(timeoutId)
+            throw new Error(
+              `CouchDB DB-lookup probe returned ${probeResponse.status}, cluster not ready`,
+            )
           }
-          throw new Error(
-            `CouchDB DB-lookup probe returned ${probeResponse.status}, cluster not ready`,
-          )
+          // Write probe: PUT a synthetic DB and DELETE it. Until this
+          // round-trips the node is not safe to hand off to test code that
+          // creates databases. Underscore-prefixed names are reserved for
+          // CouchDB system DBs, so the probe uses a plain name.
+          const writeProbeUrl = `http://127.0.0.1:${port}/spindb_writeprobe`
+          const putResponse = await fetch(writeProbeUrl, {
+            method: 'PUT',
+            headers: { Authorization: COUCHDB_AUTH_HEADER },
+            signal: controller.signal,
+          })
+          // 201 = freshly created, 412 = leftover from a previous probe
+          // (still proves writes work — we'll DELETE either way).
+          if (putResponse.status !== 201 && putResponse.status !== 412) {
+            clearTimeout(timeoutId)
+            throw new Error(
+              `CouchDB write probe PUT returned ${putResponse.status}, cluster writer not ready`,
+            )
+          }
+          // Best-effort cleanup. If DELETE fails, the next probe iteration
+          // (or the next waitForReady call on the same port) will hit 412
+          // and still treat the cluster as ready.
+          await fetch(writeProbeUrl, {
+            method: 'DELETE',
+            headers: { Authorization: COUCHDB_AUTH_HEADER },
+            signal: controller.signal,
+          }).catch(() => {
+            /* probe cleanup is best-effort */
+          })
+          clearTimeout(timeoutId)
+          return true
         } catch {
           clearTimeout(timeoutId)
           throw new Error('CouchDB health check failed or timed out')


### PR DESCRIPTION
## Problem

The CouchDB integration test \`should backup and restore with password-authenticated local admin credentials\` has been failing intermittently on macOS x64 GHA runners (also occasionally Windows). The May 22 failure on commit \`711690a\` (run [26302468589](https://github.com/robertjbass/spindb/actions/runs/26302468589)) hit:

\`\`\`
not ok 11 - should backup and restore with password-authenticated local admin credentials
  error: 'Assertion failed: Should create source database'
  location: tests/integration/couchdb.test.ts:471:7
\`\`\`

This is the same race the BUG-9 fix from May 16 ([commit 65804be](https://github.com/robertjbass/spindb/commit/65804be)) tried to close, but it only covers half of it.

## Root cause (the part the existing fix missed)

CouchDB has **three** layers that come up in order:

1. **chttpd HTTP listener** — binds the port, serves \`GET /\` (currently gated by \`/_up\`)
2. **Routing + mem3/fabric for reads** — answers \`GET /<some-db>\` with 404 (currently gated by the synthetic GET probe)
3. **Cluster writer machinery / shard-creation** — accepts \`PUT /<dbname>\` (NOT currently gated)

The existing \`waitForReady\` validates 1 and 2. On slow runners (notably macOS x64 GHA) layer 3 lags behind, so the test's immediate \`createCouchDBDatabase\` (PUT) gets 5xx with \`no_majority\` even though the probe just succeeded.

## Fix

Add a third stage to \`waitForReady\`: PUT a synthetic probe DB (\`spindb_writeprobe\`), expect 201/412, then DELETE it (best-effort). Only return ready when all three stages succeed. Applied to:

- **\`engines/couchdb/index.ts\`** — runtime path used by spindb CLI / desktop / cloud
- **\`tests/integration/helpers.ts\`** — the path the failing test actually calls

## Implementation notes

- Probe DB name is plain (\`spindb_writeprobe\`, no underscore) — CouchDB reserves underscore-prefixed names for system DBs and rejects PUT on them.
- Accept \`201\` (created) or \`412\` (already exists) on the PUT. A leftover from a previous crashed probe still proves writes work.
- DELETE is best-effort. If it fails, the next probe iteration sees 412 and still treats the cluster as ready.
- Read probe stays as-is — defense in depth.

## Test plan

- [x] \`pnpm check\` (typecheck) green
- [x] CouchDB integration suite locally: **3 consecutive runs, 12/12 each, ~17.5s per run**
- [ ] After this merges to dev, watch the next macOS x64 CI run. Goal: zero re-runs needed for CouchDB.

## Future hardening

If we ever see the race re-emerge in a different shape, the next layer is to mirror the BUG-9 retry-on-5xx in \`restore.ts\` for direct PUTs in test helpers — but with the write probe gating the readiness signal, that should be unnecessary.