### PR TITLE
chore(release): 0.51.0 — database branching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-05-28
+
 ### Added
 
 - **Database branching (`spindb branch`) — Neon/Vercel-style copy-on-write forks, local, for every engine.** A branch duplicates a container's data directory via a filesystem reflink/clonefile (APFS on macOS; Btrfs / XFS-reflink / ZFS on Linux), so it's effectively instant and shares disk blocks with its source until the two diverge. Where the filesystem can't do copy-on-write (ext4, NTFS) it transparently falls back to a full copy; `--json` reports `"method": "reflink"` vs `"copy"` either way. A running source is handled with an automatic stop → snapshot → restart cycle so the snapshot is consistent and downtime is minimal; file-based engines (SQLite/DuckDB) clone the backing file with no server involved. Branches record their parent and form a lineage tree.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.50.8",
+  "version": "0.51.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
Bumps version 0.50.8 → 0.51.0 and finalizes the CHANGELOG for the **database branching** feature (copy-on-write forks for all engines + git-driven stable-port branching).

Merge this into `dev`, then a `dev → main` PR publishes 0.51.0 to npm via the OIDC workflow.

- package.json: 0.50.8 → 0.51.0
- CHANGELOG: moved the branching entries from [Unreleased] to [0.51.0]

No code changes — release bookkeeping only. The feature itself landed in #195.