### PR TITLE
fix: second-round review findings for database branching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ These engines bypass `spindb start` in layerbase-cloud's `setup-database.sh` due
 - [ ] **WSL proxy for Windows** - Create a proxy layer for Windows computers to use WSL seamlessly
 - [ ] **Migrate binaries from hostdb to spindb** - Self-host compiled engine binaries under spindb infrastructure
 - [ ] **Proxy/reverse-proxy MVP** - Build system to deploy directly to containers with network access
-- [ ] **Git hook integration** - Add hooks for pre-commit, post-checkout, etc. to automate database workflows
+- [ ] **Additional git-hook automation** - The branch-sync `post-checkout` hook is done (see the Database Branching → Phase 2 item above). Explore further hooks (pre-commit, pre-push) for other database workflows — e.g. auto-backup before risky ops, or migration/seed checks.
 - [ ] **Refine API** - Clean up and stabilize the programmatic API surface
 - [ ] **Build package to mimic CLI** - Export package that provides CLI functionality programmatically
 - [ ] **Rethink testing processes** - Optimize test suite for faster execution time

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -477,15 +477,17 @@ export class ContainerManager {
     const sourcePath = paths.getContainerPath(sourceName, { engine })
     const targetPath = paths.getContainerPath(targetName, { engine })
 
-    let method: CopyMethod = 'copy'
-    if (strategy === 'cow') {
-      method = (await cloneDirectory(sourcePath, targetPath)).method
-    } else {
-      await cp(sourcePath, targetPath, { recursive: true })
-    }
-
-    // If anything fails after the copy, clean up the target directory
+    // Copy the data directory, then write the new config. If anything fails —
+    // the copy itself, reading the config back, or the engine fixup hook —
+    // clean up the (possibly partial) target directory.
     try {
+      let method: CopyMethod = 'copy'
+      if (strategy === 'cow') {
+        method = (await cloneDirectory(sourcePath, targetPath)).method
+      } else {
+        await cp(sourcePath, targetPath, { recursive: true })
+      }
+
       // Update target config
       const config = await this.getConfig(targetName, { engine })
       if (!config) {

--- a/engines/clickhouse/index.ts
+++ b/engines/clickhouse/index.ts
@@ -392,6 +392,7 @@ export class ClickHouseEngine extends BaseEngine {
    */
   override async prepareBranchedDataDir(
     container: ContainerConfig,
+    _options: { sourceName: string },
   ): Promise<void> {
     await this.regenerateConfig(container.name, container.port)
   }

--- a/engines/ferretdb/index.ts
+++ b/engines/ferretdb/index.ts
@@ -1442,6 +1442,25 @@ export class FerretDBEngine extends BaseEngine {
   }
 
   /**
+   * After a branch/clone copies the data directory, the branch inherits the
+   * source's PostgreSQL backend port. Clear it so the next start() allocates a
+   * fresh free port — otherwise the branch's backend collides with the
+   * source's when both run (e.g. during the branch manager's
+   * stop -> snapshot -> restart of the source).
+   */
+  override async prepareBranchedDataDir(
+    container: ContainerConfig,
+    _options: { sourceName: string },
+  ): Promise<void> {
+    if (container.backendPort !== undefined) {
+      await containerManager.updateConfig(container.name, {
+        backendPort: undefined,
+      })
+      container.backendPort = undefined
+    }
+  }
+
+  /**
    * Get the path to mongosh (uses MongoDB's mongosh)
    * FerretDB is MongoDB-compatible, so it uses the same shell
    */

--- a/tests/unit/git-branch-sync.test.ts
+++ b/tests/unit/git-branch-sync.test.ts
@@ -105,6 +105,9 @@ describe('git-branch-sync: post-checkout hook management', () => {
   })
 
   it('uninstall removes the managed block but keeps the custom hook', async () => {
+    // Self-contained: seed a hook with both a custom body and our managed block.
+    await writeFile(hookFile(), '#!/bin/sh\necho "my custom hook"\n')
+    await installHooks(repo)
     await uninstallHooks(repo)
     const content = await readFile(hookFile(), 'utf8')
     assert.ok(content.includes('my custom hook'))


### PR DESCRIPTION
Addresses the round-2 review on #197 (all five items). No public API changes.

- **copyContainerData** now copies inside the try block, so a copy failure cleans up a partial target dir.
- **FerretDB** clears the inherited `backendPort` on branch so the branch's PostgreSQL backend allocates a fresh free port (no collision with the source when both run).
- **ClickHouse** `prepareBranchedDataDir` matches the base signature.
- **TODO** re-scopes the older git-hook item vs the completed Phase 2 hook.
- **test** hook-uninstall case is now self-contained.

Validated: lint clean, affected unit tests (54) green.