### PR TITLE
fix: branch/clone no longer reuses the source container's port (0.51.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.2] - 2026-05-29
+
+### Fixed
+
+- **Branching (and cloning) no longer reuses the source container's port.** To take a consistent snapshot, a running source is briefly stopped before its data dir is copied. Port allocation for the new container only excluded the ports of *running* containers, so the source's just-freed port could be handed to the branch/clone; the source then restarted and reclaimed it, leaving the new container unable to start (`started: false`, e.g. "pg_ctl ... could not start server"). `copyContainerData` now passes the source's own port through a new `excludePorts` option to the allocator, so a copy is never assigned the source's port regardless of the source's transient running state. Branching with an explicit `--port` was already unaffected.
+
 ## [0.51.1] - 2026-05-29
 
 ### Added

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.50.0'
+export const VERSION = '0.51.2'

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -27,9 +27,7 @@ import { duckdbRegistry } from '../engines/duckdb/registry'
 // recommended major. This keeps the displayed version consistent with whatever
 // binary spindb would currently use, instead of hardcoding shorthand `'3'` /
 // `'1'` that drifts away from the actual binary.
-function fileBasedEngineVersion(
-  engine: Engine.SQLite | Engine.DuckDB,
-): string {
+function fileBasedEngineVersion(engine: Engine.SQLite | Engine.DuckDB): string {
   const major = getEngineDefaults(engine).defaultVersion
   const dbEngine = getEngine(engine)
   return dbEngine.resolveFullVersion(major)
@@ -520,10 +518,16 @@ export class ContainerManager {
         config.port = options.port
       } else {
         const engineDefaults = getEngineDefaults(engine)
-        const { port } =
-          await portManager.findAvailablePortExcludingContainers({
+        const { port } = await portManager.findAvailablePortExcludingContainers(
+          {
             portRange: engineDefaults.portRange,
-          })
+            // Never reuse the source's port. Branching briefly stops a running
+            // source to snapshot it; without this the source's now-free port
+            // could be handed to the branch, which then fails to start once the
+            // source restarts and reclaims it.
+            excludePorts: [sourceConfig.port],
+          },
+        )
         config.port = port
       }
 

--- a/core/port-manager.ts
+++ b/core/port-manager.ts
@@ -13,6 +13,14 @@ const execAsync = promisify(exec)
 type FindPortOptions = {
   preferredPort?: number
   portRange?: { start: number; end: number }
+  /**
+   * Extra ports to treat as unavailable on top of the running containers'
+   * ports. Used when branching/cloning so the new container never reuses the
+   * source's port: a running source is briefly stopped to take a consistent
+   * snapshot, which would otherwise make its port look free and get reassigned
+   * to the copy - leaving the copy unable to start once the source restarts.
+   */
+  excludePorts?: number[]
 }
 
 export class PortManager {
@@ -131,10 +139,14 @@ export class PortManager {
     const preferredPort = options.preferredPort ?? defaults.port
     const portRange = options.portRange ?? defaults.portRange
     const containerPorts = await this.getContainerPorts()
+    const unavailable = new Set<number>([
+      ...containerPorts,
+      ...(options.excludePorts ?? []),
+    ])
 
     // First try the preferred port
     if (
-      !containerPorts.includes(preferredPort) &&
+      !unavailable.has(preferredPort) &&
       (await this.isPortAvailable(preferredPort))
     ) {
       return {
@@ -145,7 +157,7 @@ export class PortManager {
 
     // Scan for available ports in the range
     for (let port = portRange.start; port <= portRange.end; port++) {
-      if (containerPorts.includes(port)) continue // Skip ports used by containers
+      if (unavailable.has(port)) continue // Skip container + explicitly-excluded ports
       if (port === preferredPort) continue // Already tried this one
 
       if (await this.isPortAvailable(port)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/port-manager.test.ts
+++ b/tests/unit/port-manager.test.ts
@@ -214,6 +214,39 @@ describe('PortManager', () => {
         portManager.isPortAvailable = originalIsPortAvailable
       }
     })
+
+    it('should skip ports in excludePorts even when otherwise free', async () => {
+      const portManager = new PortManager()
+      const originalGetContainerPorts =
+        portManager.getContainerPorts.bind(portManager)
+      const originalIsPortAvailable =
+        portManager.isPortAvailable.bind(portManager)
+
+      // No running containers, and every port is bindable...
+      portManager.getContainerPorts = async () => []
+      portManager.isPortAvailable = async () => true
+
+      try {
+        // ...but the source's port (59990) is explicitly excluded. This is the
+        // branch/clone case: the source is briefly stopped to snapshot it, so
+        // its port looks free - it must still not be reassigned to the copy,
+        // which would then fail to start once the source restarts.
+        const result = await portManager.findAvailablePortExcludingContainers({
+          preferredPort: 59990,
+          portRange: { start: 59990, end: 59995 },
+          excludePorts: [59990],
+        })
+
+        assert(
+          result.port !== 59990,
+          'Should not return an excluded port even when it is free',
+        )
+        assertEqual(result.port, 59991, 'Should fall through to the next port')
+      } finally {
+        portManager.getContainerPorts = originalGetContainerPorts
+        portManager.isPortAvailable = originalIsPortAvailable
+      }
+    })
   })
 })
 


### PR DESCRIPTION
## Problem

Branching briefly stops a running source to take a consistent snapshot before copying its data dir. Port allocation (`findAvailablePortExcludingContainers`) only excluded the ports of **running** containers, so the source's just-freed port could be handed to the branch/clone. The source then restarted and reclaimed it, leaving the new container unable to start (`started: false`, e.g. `pg_ctl ... could not start server`). Branching with an explicit `--port` was unaffected.

## Fix

`copyContainerData` now passes the source's own port through a new `excludePorts` option on the allocator, so a copy is never assigned the source's port regardless of the source's transient running state. (`getContainerPorts`' "stopped containers don't block ports" behavior is left intact; the source is excluded explicitly instead.)

## Verification

- `tsc --noEmit` + eslint clean. New `port-manager` unit test for `excludePorts`; 18/18 port/branch unit tests pass.
- End-to-end on a running Postgres source with a blank port: branch now lands on a fresh port and starts cleanly (source `5434`, branch `5435`, both running). Before: branch got `5434` and stayed stopped.

Bumps `0.51.1 -> 0.51.2` and updates the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.51.2

* **Bug Fixes**
  * Fixed branch and clone operations that would fail to start when performed after the source container was stopped and restarted. The root cause was that newly created cloned or branched containers could be assigned the same port that the source container had just released.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robertjbass/spindb/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->