### PR TITLE
fix(branch): skip socket/FIFO files in the full-copy branch path (0.51.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.3] - 2026-05-30
+
+### Fixed
+
+- **Branching:** a full (non-reflink) branch copy no longer fails on socket or
+  FIFO files inside a data directory — e.g. a running PgBouncer's `.s.PGSQL`
+  unix socket in a Postgres data dir. These ephemeral runtime files are now
+  skipped (the branch's own processes recreate them on start) instead of
+  aborting the whole copy with `ERR_FS_CP_SOCKET`.
+
 ## [0.51.2] - 2026-05-29
 
 ### Fixed

--- a/core/cow-copy.ts
+++ b/core/cow-copy.ts
@@ -13,7 +13,7 @@
  * consumers know whether the branch was instant or a full copy.
  */
 
-import { cp, rm, writeFile } from 'fs/promises'
+import { cp, rm, writeFile, lstat } from 'fs/promises'
 import { join } from 'path'
 import { spawnAsync } from './spawn-utils'
 import { logDebug } from './error-handler'
@@ -103,7 +103,23 @@ async function fallbackToDeepCopy(
 }
 
 async function deepCopy(src: string, dst: string): Promise<void> {
-  await cp(src, dst, { recursive: true })
+  await cp(src, dst, {
+    recursive: true,
+    // Node's fs.cp throws ERR_FS_CP_SOCKET on socket/FIFO entries — e.g. a
+    // running PgBouncer's `.s.PGSQL` unix socket that lives inside a Postgres
+    // data dir — which fails the whole branch on a full (non-reflink) copy.
+    // These are ephemeral runtime artifacts the branch's own processes recreate
+    // on start, so skip any non-regular, non-directory, non-symlink entry.
+    filter: async (source) => {
+      try {
+        const st = await lstat(source)
+        return st.isFile() || st.isDirectory() || st.isSymbolicLink()
+      } catch {
+        // Can't stat it (e.g. it vanished mid-copy) — don't try to copy it.
+        return false
+      }
+    },
+  })
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.2",
+  "version": "0.51.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/cow-copy.test.ts
+++ b/tests/unit/cow-copy.test.ts
@@ -65,6 +65,43 @@ describe('cow-copy: cloneDirectory', () => {
       await rm(base, { recursive: true, force: true })
     }
   })
+
+  it(
+    'skips socket entries instead of failing the full copy (e.g. a live PgBouncer .s.PGSQL)',
+    {
+      skip:
+        process.platform === 'win32'
+          ? 'unix domain sockets are POSIX-only'
+          : false,
+    },
+    async () => {
+      const { createServer } = await import('node:net')
+      const { existsSync } = await import('node:fs')
+      const base = await mkdtemp(join(tmpdir(), 'spindb-cow-'))
+      const server = createServer()
+      try {
+        const src = join(base, 'src')
+        const dst = join(base, 'dst')
+        await mkdir(join(src, 'pgbouncer'), { recursive: true })
+        await writeFile(join(src, 'base.db'), 'rows')
+        // A live unix socket inside the data dir, mimicking pgbouncer's .s.PGSQL.
+        const sock = join(src, 'pgbouncer', '.s.PGSQL')
+        await new Promise<void>((resolve) => server.listen(sock, resolve))
+
+        // Force the full-copy (deepCopy) path regardless of the host filesystem.
+        const result = await cloneDirectory(src, dst, { platform: 'win32' })
+
+        assert.equal(result.method, 'copy')
+        // Regular file copies; the socket is skipped rather than throwing.
+        assert.equal(await readFile(join(dst, 'base.db'), 'utf8'), 'rows')
+        assert.equal(existsSync(join(dst, 'pgbouncer')), true)
+        assert.equal(existsSync(join(dst, 'pgbouncer', '.s.PGSQL')), false)
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+        await rm(base, { recursive: true, force: true })
+      }
+    },
+  )
 })
 
 describe('cow-copy: detectCowSupport', () => {


### PR DESCRIPTION
## Bug

Every **pooled-engine branch on a non-reflink filesystem** (ext4 - our cloud volumes) failed:
```
spindb branch failed: Cannot copy a socket file (ERR_FS_CP_SOCKET):
.../pgbouncer/.s.PGSQL
```
A running PgBouncer keeps a unix socket (`.s.PGSQL`) inside the Postgres data dir. The full-copy path uses Node's `fs.cp`, which **throws on socket/FIFO entries**, aborting the whole branch.

## Fix

`deepCopy` now filters out non-regular / non-directory / non-symlink entries (sockets, FIFOs, device nodes) - ephemeral runtime artifacts the branch's own processes recreate on start. Reflink paths use the system `cp` (which already recreates such files), so they're unaffected.

- New unit test creates a live unix socket inside the tree and asserts the full copy skips it instead of throwing (forces the `copy` path via `{ platform: 'win32' }`; skipped on Windows where unix sockets don't exist).
- `0.51.2 → 0.51.3`, changelog updated. `tsc` + eslint clean, all cow-copy unit tests pass.

## Downstream

After this publishes, bump `SPINDB_VERSION` in **layerbase-cloud** (Dockerfile + setup.sh) and **layerbase-desktop**. This is what unblocks branching for Postgres (and any pooled engine) in the cloud.