### PR TITLE
release: spindb 0.51.4 — branch-on-ZFS reflink fix

### DIFF
--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -7,14 +7,11 @@ name: ZFS lifecycle (manual investigation)
 #   (a) a clean reflink->destroy cycle even reproduces the "pool busy" teardown
 #       issue we hit on staging (which may have been a botched manual cleanup),
 #   (b) a freshly-built NEWER OpenZFS behaves any better.
-# workflow_dispatch only — it builds ZFS from source (~10 min) and isn't worth
-# running on every push.
+# Self-triggers on its own changes (workflow_dispatch needs the file on the
+# default branch; this lets us run it from dev during the spike).
 
 on:
   workflow_dispatch:
-  # Self-triggering: a push that touches this file runs it. Scoped to the file
-  # itself so it never fires on unrelated pushes. (workflow_dispatch needs the
-  # file on the default branch; this lets us run it from dev during the spike.)
   push:
     paths:
       - '.github/workflows/zfs-lifecycle.yml'
@@ -34,7 +31,7 @@ jobs:
       - name: Full reflink lifecycle (reflink -> rm delete -> explicit destroy)
         run: |
           set -euxo pipefail
-          echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled
+          echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled 2>/dev/null || true
           sudo truncate -s 2G /tmp/lc.img
           sudo zpool create -o feature@block_cloning=enabled lc /tmp/lc.img
           sudo zfs create lc/d
@@ -42,18 +39,20 @@ jobs:
           sudo chown "$(id -u):$(id -g)" "$M"
           head -c 200M </dev/urandom > "$M/parent"
           sync -f "$M/parent"
+          # `cp --reflink=always` ERRORS if it cannot reflink (it never silently
+          # full-copies), so reaching the next line under `set -e` IS the proof
+          # the reflink happened. bclonesaved is async (txg) — informational only.
           cp --reflink=always "$M/parent" "$M/clone"
-          saved=$(zpool get -Hp -o value bclonesaved lc)
-          echo "bclonesaved=$saved"
-          [ "$saved" -gt 0 ] || { echo "FAIL: no block sharing — reflink did not happen"; exit 1; }
-          echo "REFLINK OK (shared $saved bytes)"
-          # prod-model branch delete: rm the cloned file (we do NOT zfs-destroy a per-branch dataset)
+          echo "REFLINK OK (cp --reflink=always succeeded)"
+          sudo zpool sync lc; sleep 1
+          echo "  bclonesaved (informational): $(zpool get -Hp -o value bclonesaved lc)"
+          # prod-model branch delete: rm the cloned file (NOT zfs destroy a dataset)
           rm "$M/clone"; sync; sleep 2
           echo "rm-delete of clone OK"
-          # EXPLICIT teardown — fail loudly if the pool is 'busy'
+          # THE KEY TEST: explicit teardown — fails loudly if the pool is 'busy'
           sudo zfs destroy lc/d
           sudo zpool destroy lc
-          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded)"
+          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded with no busy)"
           sudo rm -f /tmp/lc.img
 
   newer-built:
@@ -61,15 +60,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Build + install latest OpenZFS release
-        id: build
         run: |
           set -euxo pipefail
           sudo apt-get update
+          # OpenZFS documented Ubuntu build deps + libtirpc-dev (newer releases).
           sudo apt-get install -y build-essential autoconf automake libtool gawk \
-            dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev \
-            libattr1-dev libelf-dev "linux-headers-$(uname -r)" python3 python3-dev \
-            python3-setuptools python3-cffi libffi-dev python3-packaging git jq curl
-          # Drop the apt module/userland so the built one wins.
+            alien fakeroot dkms libblkid-dev uuid-dev libudev-dev libssl-dev \
+            zlib1g-dev libaio-dev libattr1-dev libelf-dev "linux-headers-$(uname -r)" \
+            python3 python3-dev python3-setuptools python3-cffi libffi-dev \
+            python3-packaging git jq curl libtirpc-dev libcurl4-openssl-dev libpam0g-dev
           sudo modprobe -r zfs 2>/dev/null || true
           sudo apt-get remove -y zfsutils-linux zfs-zed 2>/dev/null || true
           TAG=$(curl -fsSL https://api.github.com/repos/openzfs/zfs/releases/latest | jq -r .tag_name)
@@ -78,8 +77,8 @@ jobs:
           curl -fsSL -o zfs.tar.gz "https://github.com/openzfs/zfs/releases/download/${TAG}/${TAG}.tar.gz"
           tar xf zfs.tar.gz
           cd "${TAG}"
-          ./configure --prefix=/usr >/tmp/zfs-configure.log 2>&1 || { tail -30 /tmp/zfs-configure.log; exit 1; }
-          make -j"$(nproc)" >/tmp/zfs-make.log 2>&1 || { tail -30 /tmp/zfs-make.log; exit 1; }
+          ./configure --prefix=/usr >/tmp/zfs-configure.log 2>&1 || { tail -40 /tmp/zfs-configure.log; exit 1; }
+          make -j"$(nproc)" >/tmp/zfs-make.log 2>&1 || { tail -40 /tmp/zfs-make.log; exit 1; }
           sudo make install >/dev/null
           sudo ldconfig
           sudo depmod -a
@@ -88,7 +87,6 @@ jobs:
       - name: Full reflink lifecycle (reflink -> rm delete -> explicit destroy)
         run: |
           set -euxo pipefail
-          # Newer OpenZFS may default block cloning on; set it regardless.
           echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled 2>/dev/null || true
           sudo truncate -s 2G /tmp/lc.img
           sudo zpool create -o feature@block_cloning=enabled lc /tmp/lc.img
@@ -98,13 +96,12 @@ jobs:
           head -c 200M </dev/urandom > "$M/parent"
           sync -f "$M/parent"
           cp --reflink=always "$M/parent" "$M/clone"
-          saved=$(zpool get -Hp -o value bclonesaved lc)
-          echo "bclonesaved=$saved"
-          [ "$saved" -gt 0 ] || { echo "FAIL: no block sharing — reflink did not happen"; exit 1; }
-          echo "REFLINK OK (shared $saved bytes)"
+          echo "REFLINK OK (cp --reflink=always succeeded)"
+          sudo zpool sync lc; sleep 1
+          echo "  bclonesaved (informational): $(zpool get -Hp -o value bclonesaved lc)"
           rm "$M/clone"; sync; sleep 2
           echo "rm-delete of clone OK"
           sudo zfs destroy lc/d
           sudo zpool destroy lc
-          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded)"
+          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded with no busy)"
           sudo rm -f /tmp/lc.img

--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -12,9 +12,6 @@ name: ZFS lifecycle (manual investigation)
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - '.github/workflows/zfs-lifecycle.yml'
 
 jobs:
   baseline-2_2_2:

--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -1,0 +1,104 @@
+name: ZFS lifecycle (manual investigation)
+
+# Manual deep-dive prompted by the 2026-05-30 staging finding that OpenZFS
+# 2.2.2 block cloning has rough edges. Runs the FULL branch lifecycle on a
+# throwaway file-backed pool — reflink, then prod-style rm delete, then an
+# EXPLICIT zpool destroy (no `|| true`) — so we can see whether:
+#   (a) a clean reflink->destroy cycle even reproduces the "pool busy" teardown
+#       issue we hit on staging (which may have been a botched manual cleanup),
+#   (b) a freshly-built NEWER OpenZFS behaves any better.
+# workflow_dispatch only — it builds ZFS from source (~10 min) and isn't worth
+# running on every push.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  baseline-2_2_2:
+    name: "lifecycle on Ubuntu apt OpenZFS (2.2.2)"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install OpenZFS from apt
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y zfsutils-linux
+          sudo modprobe zfs
+          zfs version | head -1
+      - name: Full reflink lifecycle (reflink -> rm delete -> explicit destroy)
+        run: |
+          set -euxo pipefail
+          echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled
+          sudo truncate -s 2G /tmp/lc.img
+          sudo zpool create -o feature@block_cloning=enabled lc /tmp/lc.img
+          sudo zfs create lc/d
+          M=$(zfs get -H -o value mountpoint lc/d)
+          sudo chown "$(id -u):$(id -g)" "$M"
+          head -c 200M </dev/urandom > "$M/parent"
+          sync -f "$M/parent"
+          cp --reflink=always "$M/parent" "$M/clone"
+          saved=$(zpool get -Hp -o value bclonesaved lc)
+          echo "bclonesaved=$saved"
+          [ "$saved" -gt 0 ] || { echo "FAIL: no block sharing — reflink did not happen"; exit 1; }
+          echo "REFLINK OK (shared $saved bytes)"
+          # prod-model branch delete: rm the cloned file (we do NOT zfs-destroy a per-branch dataset)
+          rm "$M/clone"; sync; sleep 2
+          echo "rm-delete of clone OK"
+          # EXPLICIT teardown — fail loudly if the pool is 'busy'
+          sudo zfs destroy lc/d
+          sudo zpool destroy lc
+          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded)"
+          sudo rm -f /tmp/lc.img
+
+  newer-built:
+    name: "lifecycle on newer OpenZFS (built from latest release)"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Build + install latest OpenZFS release
+        id: build
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool gawk \
+            dkms libblkid-dev uuid-dev libudev-dev libssl-dev zlib1g-dev libaio-dev \
+            libattr1-dev libelf-dev "linux-headers-$(uname -r)" python3 python3-dev \
+            python3-setuptools python3-cffi libffi-dev python3-packaging git jq curl
+          # Drop the apt module/userland so the built one wins.
+          sudo modprobe -r zfs 2>/dev/null || true
+          sudo apt-get remove -y zfsutils-linux zfs-zed 2>/dev/null || true
+          TAG=$(curl -fsSL https://api.github.com/repos/openzfs/zfs/releases/latest | jq -r .tag_name)
+          echo "building OpenZFS $TAG"
+          cd /tmp
+          curl -fsSL -o zfs.tar.gz "https://github.com/openzfs/zfs/releases/download/${TAG}/${TAG}.tar.gz"
+          tar xf zfs.tar.gz
+          cd "${TAG}"
+          ./configure --prefix=/usr >/tmp/zfs-configure.log 2>&1 || { tail -30 /tmp/zfs-configure.log; exit 1; }
+          make -j"$(nproc)" >/tmp/zfs-make.log 2>&1 || { tail -30 /tmp/zfs-make.log; exit 1; }
+          sudo make install >/dev/null
+          sudo ldconfig
+          sudo depmod -a
+          sudo modprobe zfs
+          zfs version | head -2
+      - name: Full reflink lifecycle (reflink -> rm delete -> explicit destroy)
+        run: |
+          set -euxo pipefail
+          # Newer OpenZFS may default block cloning on; set it regardless.
+          echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled 2>/dev/null || true
+          sudo truncate -s 2G /tmp/lc.img
+          sudo zpool create -o feature@block_cloning=enabled lc /tmp/lc.img
+          sudo zfs create lc/d
+          M=$(zfs get -H -o value mountpoint lc/d)
+          sudo chown "$(id -u):$(id -g)" "$M"
+          head -c 200M </dev/urandom > "$M/parent"
+          sync -f "$M/parent"
+          cp --reflink=always "$M/parent" "$M/clone"
+          saved=$(zpool get -Hp -o value bclonesaved lc)
+          echo "bclonesaved=$saved"
+          [ "$saved" -gt 0 ] || { echo "FAIL: no block sharing — reflink did not happen"; exit 1; }
+          echo "REFLINK OK (shared $saved bytes)"
+          rm "$M/clone"; sync; sleep 2
+          echo "rm-delete of clone OK"
+          sudo zfs destroy lc/d
+          sudo zpool destroy lc
+          echo "TEARDOWN CLEAN (zfs destroy + zpool destroy succeeded)"
+          sudo rm -f /tmp/lc.img

--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -12,6 +12,12 @@ name: ZFS lifecycle (manual investigation)
 
 on:
   workflow_dispatch:
+  # Self-triggering: a push that touches this file runs it. Scoped to the file
+  # itself so it never fires on unrelated pushes. (workflow_dispatch needs the
+  # file on the default branch; this lets us run it from dev during the spike.)
+  push:
+    paths:
+      - '.github/workflows/zfs-lifecycle.yml'
 
 jobs:
   baseline-2_2_2:

--- a/.github/workflows/zfs-reflink.yml
+++ b/.github/workflows/zfs-reflink.yml
@@ -1,0 +1,80 @@
+name: ZFS reflink guard
+
+# Guards the copy-on-write reflink path in core/cow-copy.ts — the primitive
+# `spindb branch` relies on, and the reason Layerbase cloud branching is instant
+# on ZFS. Stands up a throwaway file-backed zpool, runs cloneDirectory on it, and
+# asserts method == "reflink". If a change drops --reflink=always or block
+# cloning regresses, this fails. Only runs when the copy path or this guard
+# changes (the heavy ZFS setup isn't worth it on unrelated pushes).
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'core/cow-copy.ts'
+      - 'tests/integration/zfs-reflink.test.ts'
+      - '.github/workflows/zfs-reflink.yml'
+  pull_request:
+    paths:
+      - 'core/cow-copy.ts'
+      - 'tests/integration/zfs-reflink.test.ts'
+      - '.github/workflows/zfs-reflink.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reflink:
+    name: ZFS reflink
+    # 24.04 ships OpenZFS 2.2.2 — the first release with block cloning AND the
+    # fix for the 2.2.0/2.2.1 cloning corruption bug.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenZFS + load module
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y zfsutils-linux
+          sudo modprobe zfs
+          zfs version
+
+      - name: Create file-backed zpool with block cloning
+        run: |
+          set -euxo pipefail
+          sudo truncate -s 3G /tmp/spindbci.img
+          sudo zpool create -o feature@block_cloning=enabled spindbci /tmp/spindbci.img
+          sudo zfs create spindbci/test
+          sudo chown -R "$(id -u):$(id -g)" /spindbci/test
+          # Fail fast + clearly if this runner can't reflink at all (e.g. ZFS
+          # module/version issue), before blaming the spindb code.
+          head -c 1M </dev/urandom > /spindbci/test/probe-a
+          cp --reflink=always /spindbci/test/probe-a /spindbci/test/probe-b
+          rm -f /spindbci/test/probe-a /spindbci/test/probe-b
+          echo "raw cp --reflink=always works on the pool"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run reflink guard
+        env:
+          SPINDB_ZFS_TEST_DIR: /spindbci/test
+        run: node --import tsx --test --test-reporter=spec tests/integration/zfs-reflink.test.ts
+        timeout-minutes: 5
+
+      - name: Teardown
+        if: always()
+        run: sudo zpool destroy spindbci || true

--- a/.github/workflows/zfs-reflink.yml
+++ b/.github/workflows/zfs-reflink.yml
@@ -35,12 +35,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install OpenZFS + load module
+      - name: Install OpenZFS + load module + enable block cloning
         run: |
           set -euxo pipefail
           sudo apt-get update
           sudo apt-get install -y zfsutils-linux
           sudo modprobe zfs
+          # Ubuntu ships block cloning DISABLED by default (zfs_bclone_enabled=0,
+          # a post-2.2.0/2.2.1-corruption safety default), so reflink would no-op.
+          # Enable it explicitly — prod does the same via deploy/setup.sh — so this
+          # guard exercises the real reflink path instead of passing by luck.
+          echo 1 | sudo tee /sys/module/zfs/parameters/zfs_bclone_enabled
           zfs version
 
       - name: Create file-backed zpool with block cloning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.4] - 2026-05-30
+
+### Fixed
+
+- **Branching on ZFS:** `spindb branch` now flushes the source filesystem
+  (`sync -f`) before attempting a reflink on Linux. ZFS block cloning refuses to
+  clone a source whose blocks aren't on disk yet, returning `EAGAIN` — which made
+  `cp --reflink=always` fail and silently fall back to a full byte copy. Syncing
+  first lets the reflink proceed, so a branch on a ZFS volume is the intended
+  instant copy-on-write (`method: "reflink"`) instead of a hidden full copy.
+
 ## [0.51.3] - 2026-05-30
 
 ### Fixed

--- a/core/cow-copy.ts
+++ b/core/cow-copy.ts
@@ -63,6 +63,16 @@ async function cloneWithStrategy(
   }
 
   if (platform === 'linux') {
+    // ZFS block cloning (and some other reflink filesystems) refuse to clone a
+    // source whose blocks aren't on disk yet: `cp --reflink=always` then fails
+    // with EAGAIN and we'd silently fall back to a full copy. Flush the source's
+    // filesystem first so the reflink can proceed. Best-effort — if `sync -f`
+    // isn't available the clone still tries, and the copy fallback still works.
+    try {
+      await spawnAsync('sync', ['-f', src])
+    } catch {
+      // sync unavailable/failed — proceed; worst case is a fallback full copy.
+    }
     // `--reflink=always` errors out on filesystems without reflink support
     // (e.g. ext4), so a failure here cleanly means "no CoW on this volume".
     // We deliberately avoid `--reflink=auto` because it silently falls back to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.3",
+  "version": "0.51.4",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/integration/zfs-reflink.test.ts
+++ b/tests/integration/zfs-reflink.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, readFile } from 'fs/promises'
+import { join } from 'path'
+import { cloneDirectory } from '../../core/cow-copy'
+
+// Reflink guard. `cloneDirectory` (what `spindb branch` calls) MUST reflink on a
+// reflink-capable filesystem, not silently full-copy. The entire Layerbase
+// cloud branching cost model depends on this returning "reflink" on ZFS, so a
+// regression here — a future change that drops `--reflink=always`, mishandles
+// the fallback, or a ZFS/OpenZFS issue that loses block cloning — has to fail
+// CI loudly.
+//
+// This runs ONLY when SPINDB_ZFS_TEST_DIR points at a real ZFS mount, which the
+// .github/workflows/zfs-reflink.yml job sets up on a throwaway file-backed
+// zpool. On a normal ext4 runner the suite skips (ext4 has no reflink — the
+// generic cow-copy.test.ts already covers the copy-fallback path there).
+const ZFS_DIR = process.env.SPINDB_ZFS_TEST_DIR
+
+describe(
+  'cow-copy: reflink guarantee on a reflink-capable FS (ZFS)',
+  { skip: ZFS_DIR ? false : 'SPINDB_ZFS_TEST_DIR not set — ZFS-only guard' },
+  () => {
+    it('cloneDirectory reports method "reflink" and the clone is independent', async () => {
+      const base = await mkdtemp(join(ZFS_DIR as string, 'spindb-zfs-'))
+      const src = join(base, 'src')
+      const dst = join(base, 'dst')
+      await mkdir(src, { recursive: true })
+      // A few MB so a reflink is meaningfully cheaper than a byte copy.
+      await writeFile(join(src, 'data.bin'), Buffer.alloc(8 * 1024 * 1024, 7))
+      await writeFile(join(src, 'marker.txt'), 'parent')
+
+      const result = await cloneDirectory(src, dst)
+
+      assert.equal(
+        result.method,
+        'reflink',
+        `expected "reflink" on ZFS, got "${result.method}" — the cp --reflink=always ` +
+          'path regressed, or this filesystem/OpenZFS version lost block cloning. ' +
+          'Layerbase cloud branching depends on this.',
+      )
+      // Content copied through.
+      assert.equal(await readFile(join(dst, 'marker.txt'), 'utf8'), 'parent')
+      // Copy-on-write independence: writing the clone must not touch the source.
+      await writeFile(join(dst, 'marker.txt'), 'branch')
+      assert.equal(await readFile(join(src, 'marker.txt'), 'utf8'), 'parent')
+    })
+  },
+)


### PR DESCRIPTION
Promotes `dev` to `main` and publishes **spindb 0.51.4** to npm.

## Ships

**`fix(branch)` — sync source before reflink so ZFS block cloning works (0.51.4)**

Found on a real Hetzner box: ZFS block cloning refuses to clone a source whose blocks aren't on disk yet (`EAGAIN`), so `cp --reflink=always` failed and `spindb branch` **silently fell back to a full byte copy** — branches looked fine but never reflinked. `core/cow-copy.ts` now runs `sync -f` on the source before the reflink on Linux. (ext4/APFS/Windows behavior unchanged; one cheap sync on the Linux branch path.)

**`test(ci)` — ZFS reflink regression guard + lifecycle investigation tool**

- `zfs-reflink.yml` — asserts `cloneDirectory` returns `method:reflink` on a file-backed `block_cloning` zpool (runs only when `core/cow-copy.ts` or the guard changes).
- `zfs-lifecycle.yml` — `workflow_dispatch`-only deep-dive that runs the full reflink → delete → teardown cycle against a given OpenZFS. Used to verify reflink + clean teardown on **2.2.2 and 2.4.2** (the "teardown rough edge" was operator error, not a defect).

CHANGELOG + version bumped to 0.51.4. Existing `cow-copy` unit tests pass.

After this merges + publishes, layerbase-cloud and layerbase-desktop bump to spindb 0.51.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `spindb branch` on ZFS filesystems by ensuring source data is synced to disk before attempting a reflink operation, preventing unintended fallback to full data copies.

* **Chores**
  * Added CI/CD workflows and integration tests for ZFS reflink validation.
  * Version bumped to 0.51.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robertjbass/spindb/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->