### PR TITLE
release: spindb 0.51.5 (ZFS reflink EAGAIN retry)

### DIFF
--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -10,6 +10,9 @@ name: ZFS lifecycle (manual investigation)
 # Self-triggers on its own changes (workflow_dispatch needs the file on the
 # default branch; this lets us run it from dev during the spike).
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/zfs-reflink.yml
+++ b/.github/workflows/zfs-reflink.yml
@@ -7,6 +7,9 @@ name: ZFS reflink guard
 # cloning regresses, this fails. Only runs when the copy path or this guard
 # changes (the heavy ZFS setup isn't worth it on unrelated pushes).
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, dev]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.5] - 2026-06-02
+
+### Fixed
+
+- **Branching on ZFS (follow-up to 0.51.4):** `spindb branch` still silently fell
+  back to a full byte copy on ZFS hosts. The `sync -f` added in 0.51.4 flushes the
+  file but does **not** force the block-clone-ready transaction group — only
+  `zpool sync` does, which an unprivileged container can't run. So
+  `cp --reflink=always` kept losing the race to ZFS's txg commit, failing with
+  `EAGAIN` ("Resource temporarily unavailable") and producing `method: "copy"`
+  instead of `"reflink"` — defeating instant branching, the whole point of a ZFS
+  host. The reflink is now retried across the txg-commit window (~5s); a genuine
+  no-reflink-support failure (e.g. `ENOTSUP` on ext4) still falls back to a full
+  copy immediately. Verified on a ZFS host (a retry loop succeeds once the txg
+  commits and `feature@block_cloning` activates).
+
 ## [0.51.4] - 2026-05-30
 
 ### Fixed

--- a/core/cow-copy.ts
+++ b/core/cow-copy.ts
@@ -63,31 +63,72 @@ async function cloneWithStrategy(
   }
 
   if (platform === 'linux') {
-    // ZFS block cloning (and some other reflink filesystems) refuse to clone a
-    // source whose blocks aren't on disk yet: `cp --reflink=always` then fails
-    // with EAGAIN and we'd silently fall back to a full copy. Flush the source's
-    // filesystem first so the reflink can proceed. Best-effort — if `sync -f`
-    // isn't available the clone still tries, and the copy fallback still works.
-    try {
-      await spawnAsync('sync', ['-f', src])
-    } catch {
-      // sync unavailable/failed — proceed; worst case is a fallback full copy.
+    // ZFS block cloning refuses a source whose blocks aren't in a committed
+    // transaction group yet: `cp --reflink=always` then fails with EAGAIN
+    // ("Resource temporarily unavailable"). This is TRANSIENT — it clears once
+    // ZFS commits the txg (~zfs_txg_timeout, 5s default). `sync -f` flushes the
+    // file but does NOT force the block-clone-ready txg (only `zpool sync` does,
+    // which an unprivileged container can't run), so a single attempt routinely
+    // loses the race and we'd silently fall back to a full copy — defeating the
+    // whole point of branching on ZFS. Retry the reflink across the commit
+    // window. A NON-EAGAIN failure (e.g. ENOTSUP on ext4) means the volume has
+    // no reflink support at all — fall back immediately, no point retrying.
+    //
+    // We deliberately avoid `--reflink=auto` because it silently falls back to a
+    // full copy, which would make us report 'reflink' when nothing was shared.
+    const REFLINK_MAX_ATTEMPTS = 12
+    const REFLINK_RETRY_DELAY_MS = 1500
+    let lastError: unknown
+    for (let attempt = 1; attempt <= REFLINK_MAX_ATTEMPTS; attempt++) {
+      // Best-effort flush each attempt; harmless if `sync` is unavailable.
+      try {
+        await spawnAsync('sync', ['-f', src])
+      } catch {
+        // sync unavailable/failed — proceed; worst case is a fallback full copy.
+      }
+      try {
+        await spawnAsync('cp', ['-R', '--reflink=always', src, dst])
+        return 'reflink'
+      } catch (error) {
+        lastError = error
+        if (!isTransientReflinkError(error)) {
+          // No CoW on this volume (ext4 etc.) — retrying can't help.
+          return fallbackToDeepCopy(src, dst, error)
+        }
+        // EAGAIN: the failed clone may have left a partial dst behind — clear it,
+        // wait for the txg to commit, and retry.
+        await rm(dst, { recursive: true, force: true }).catch(() => {})
+        if (attempt < REFLINK_MAX_ATTEMPTS) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, REFLINK_RETRY_DELAY_MS),
+          )
+        }
+      }
     }
-    // `--reflink=always` errors out on filesystems without reflink support
-    // (e.g. ext4), so a failure here cleanly means "no CoW on this volume".
-    // We deliberately avoid `--reflink=auto` because it silently falls back to
-    // a full copy, which would make us report 'reflink' when nothing was shared.
-    try {
-      await spawnAsync('cp', ['-R', '--reflink=always', src, dst])
-      return 'reflink'
-    } catch (error) {
-      return fallbackToDeepCopy(src, dst, error)
-    }
+    // Still EAGAIN after the full commit window — fall back to a real copy so the
+    // branch still succeeds (just not instant).
+    return fallbackToDeepCopy(src, dst, lastError)
   }
 
   // Windows (NTFS has no reflink) and any unknown platform: full copy.
   await deepCopy(src, dst)
   return 'copy'
+}
+
+/**
+ * `cp --reflink=always` fails with EAGAIN ("Resource temporarily unavailable")
+ * when ZFS block cloning can't yet clone the source because its blocks aren't in
+ * a committed txg — a transient race that clears on the next txg commit.
+ * Distinguish it from a real "no reflink support" failure (ENOTSUP/EOPNOTSUPP on
+ * ext4, NTFS, etc.) so we retry the former and fall back immediately on the latter.
+ */
+export function isTransientReflinkError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  const stderr =
+    typeof error === 'object' && error !== null && 'stderr' in error
+      ? String((error as { stderr?: unknown }).stderr ?? '')
+      : ''
+  return /resource temporarily unavailable|EAGAIN/i.test(`${message} ${stderr}`)
 }
 
 /**

--- a/core/cow-copy.ts
+++ b/core/cow-copy.ts
@@ -87,7 +87,13 @@ async function cloneWithStrategy(
         // sync unavailable/failed — proceed; worst case is a fallback full copy.
       }
       try {
-        await spawnAsync('cp', ['-R', '--reflink=always', src, dst])
+        // Force the C locale: `cp` reports its EAGAIN error via strerror(), whose
+        // text is localized. In a non-English locale the message wouldn't match
+        // isTransientReflinkError() and we'd misclassify the transient txg race as
+        // a permanent failure and abandon the reflink.
+        await spawnAsync('cp', ['-R', '--reflink=always', src, dst], {
+          env: { LC_ALL: 'C' },
+        })
         return 'reflink'
       } catch (error) {
         lastError = error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.4",
+  "version": "0.51.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/cow-copy.test.ts
+++ b/tests/unit/cow-copy.test.ts
@@ -3,7 +3,11 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile, readFile, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { cloneDirectory, detectCowSupport } from '../../core/cow-copy'
+import {
+  cloneDirectory,
+  detectCowSupport,
+  isTransientReflinkError,
+} from '../../core/cow-copy'
 
 describe('cow-copy: cloneDirectory', () => {
   it('clones a directory tree and reports a method', async () => {
@@ -113,5 +117,43 @@ describe('cow-copy: detectCowSupport', () => {
     } finally {
       await rm(base, { recursive: true, force: true })
     }
+  })
+})
+
+describe('cow-copy: isTransientReflinkError (EAGAIN retry classifier)', () => {
+  it('treats ZFS block-cloning EAGAIN as transient (so the reflink is retried)', () => {
+    // The exact message `cp --reflink=always` prints when ZFS can't clone a
+    // source whose blocks aren't in a committed txg yet.
+    assert.equal(
+      isTransientReflinkError(
+        new Error(
+          "cp: failed to clone 'dst' from 'src': Resource temporarily unavailable",
+        ),
+      ),
+      true,
+    )
+    assert.equal(isTransientReflinkError(new Error('reflink: EAGAIN')), true)
+  })
+
+  it('reads EAGAIN off a subprocess error stderr field', () => {
+    const err = Object.assign(new Error('cp exited with code 1'), {
+      stderr: 'cp: failed to clone: Resource temporarily unavailable',
+    })
+    assert.equal(isTransientReflinkError(err), true)
+  })
+
+  it('treats no-reflink-support errors as permanent (fall straight back to copy)', () => {
+    // ext4 / NTFS: `cp --reflink=always` fails with ENOTSUP, not EAGAIN —
+    // retrying can never help, so this must NOT be classified as transient.
+    assert.equal(
+      isTransientReflinkError(
+        new Error(
+          "cp: failed to clone 'dst' from 'src': Operation not supported",
+        ),
+      ),
+      false,
+    )
+    assert.equal(isTransientReflinkError(new Error('some other failure')), false)
+    assert.equal(isTransientReflinkError('plain string error'), false)
   })
 })


### PR DESCRIPTION
Release **0.51.5**. Merging this publishes to npm (OIDC).

### Fixed
- **Branching on ZFS:** retry `cp --reflink=always` across the txg-commit window instead of a single attempt — fixes the silent `method: copy` fallback on ZFS hosts (EAGAIN race the 0.51.4 `sync -f` couldn't close, since a container can't `zpool sync`). ext4 still falls back immediately. Validated by the ZFS-reflink CI (real pool) + on the OVH box.

After publish: bump `SPINDB_VERSION` in layerbase-cloud (Dockerfile.base + setup.sh ×2) → rebuild universal image → deploy; bump layerbase-desktop spindb dep. Then re-verify `method: reflink` on OVH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `spindb branch` reliability on ZFS by implementing automatic retries for transient reflink operations, reducing failures due to temporary block-commit race conditions while maintaining fallback to full copy for genuine unsupported filesystems.

* **Chores**
  * Version bumped to 0.51.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->