### PR TITLE
fix(branch): C locale for reflink EAGAIN detection

### DIFF
--- a/core/cow-copy.ts
+++ b/core/cow-copy.ts
@@ -87,7 +87,13 @@ async function cloneWithStrategy(
         // sync unavailable/failed — proceed; worst case is a fallback full copy.
       }
       try {
-        await spawnAsync('cp', ['-R', '--reflink=always', src, dst])
+        // Force the C locale: `cp` reports its EAGAIN error via strerror(), whose
+        // text is localized. In a non-English locale the message wouldn't match
+        // isTransientReflinkError() and we'd misclassify the transient txg race as
+        // a permanent failure and abandon the reflink.
+        await spawnAsync('cp', ['-R', '--reflink=always', src, dst], {
+          env: { LC_ALL: 'C' },
+        })
         return 'reflink'
       } catch (error) {
         lastError = error


### PR DESCRIPTION
Follow-up to the reflink EAGAIN retry: `cp`'s EAGAIN message is localized by strerror(), so `isTransientReflinkError` could miss it on a non-English locale and misclassify the transient txg race as permanent. Run the reflink `cp` under `LC_ALL=C`. Ships in 0.51.5 (this PR targets dev ahead of release #205). Typecheck + cow-copy tests green.