### PR TITLE
fix(start): skip createDatabase for single-database engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.6] - 2026-06-02
+
+### Fixed
+
+- **libSQL start no longer attempts (and fails) to "create database":** `spindb
+  start` unconditionally called `engine.createDatabase()` to ensure the target
+  database exists, but single-database engines — libSQL, SQLite, Redis, Valkey,
+  QuestDB, TigerBeetle, DuckDB — reject it because the instance/file IS the
+  database. For libSQL this surfaced `✖ Failed to create database "<name>"` plus a
+  `createDatabase error` log on every start/wake, and callers that scrape start
+  output (e.g. the cloud setup-database.sh wake/migration path) read it as a
+  failure signal. The call is now gated on `canCreateDatabase(engine)`, so
+  single-database engines skip it entirely — a clean start with no spurious error.
+
 ## [0.51.5] - 2026-06-02
 
 ### Fixed

--- a/cli/commands/start.ts
+++ b/cli/commands/start.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { containerManager } from '../../core/container-manager'
 import { processManager } from '../../core/process-manager'
 import { startWithRetry } from '../../core/start-with-retry'
+import { canCreateDatabase } from '../../core/database-capabilities'
 import { getEngine } from '../../engines'
 import { postgresqlEngine } from '../../engines/postgresql'
 import { getEngineDefaults } from '../../config/defaults'
@@ -283,9 +284,17 @@ export const startCommand = new Command('start')
           spinner?.succeed(`Container "${containerName}" started`)
         }
 
-        // Ensure user's database exists (may already exist, which is fine)
+        // Ensure user's database exists (may already exist, which is fine).
+        // Skip engines that don't support multiple databases (libsql, sqlite,
+        // redis, valkey, questdb, tigerbeetle, duckdb): the instance/file IS the
+        // database, so createDatabase throws UnsupportedOperationError and
+        // surfaces a spurious "Failed to create database" on every start/wake.
         const defaultDb = engineDefaults.superuser
-        if (config.database && config.database !== defaultDb) {
+        if (
+          canCreateDatabase(config.engine) &&
+          config.database &&
+          config.database !== defaultDb
+        ) {
           const dbSpinner = options.json
             ? null
             : createSpinner(`Ensuring database "${config.database}" exists...`)

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.51.2'
+export const VERSION = '0.51.6'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.5",
+  "version": "0.51.6",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Problem

`spindb start` unconditionally calls `engine.createDatabase()` to "ensure the user's database exists." But single-database engines — libSQL, SQLite, Redis, Valkey, QuestDB, TigerBeetle, DuckDB — reject it (`canCreateDatabase(engine) === false`); the instance/file IS the database. For libSQL this surfaces `✖ Failed to create database "<name>"` plus a `createDatabase error` log on **every start/wake**, and callers that scrape start output — notably the Layerbase Cloud `setup-database.sh` wake/migration path — read it as a failure signal.

## Fix

Gate the `createDatabase` call on `canCreateDatabase(config.engine)` so single-database engines skip it entirely — a clean start with no spurious error. Multi-database engines (PostgreSQL, MySQL, …) are unchanged.

## Test

- `lint` (eslint + `tsc --noEmit`) clean.
- 1600/1600 unit tests pass. `canCreateDatabase` is exhaustively tested across all engines (`database-capabilities.test.ts`) — the contract the gate relies on — and the integration suite exercises a real libSQL start.

Patch bump → `0.51.6`, changelog updated.