### PR TITLE
fix(typedb): correct transaction type for spindb query (v0.51.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.7] - 2026-06-03
+
+### Fixed
+
+- **TypeDB `spindb query` now picks the right transaction type (schema / write
+  were impossible before):** the TypeDB `executeQuery` path — what `spindb query`
+  runs — hardcoded `transaction read`, so every schema query (`define` /
+  `undefine` / `redefine`) failed with `[TSV8]` and every data write (`insert` /
+  `delete` / `update` / `put`, including `match …; insert (…) isa rel;` relation
+  pipelines) failed with `[TSV9]`. Only read queries worked. `executeQuery` now
+  detects the required transaction type from the whole query buffer and opens a
+  `schema`, `write`, or `read` transaction accordingly (committing for
+  schema/write, closing for read). This unblocks creating schema and data —
+  including relations — through `spindb query` (and any GUI built on it, e.g.
+  Layerbase Desktop).
+- The detection lives in a new shared `detectTypedbTxType()` helper
+  (`engines/typedb/cli-utils.ts`): `define`/`undefine`/`redefine` → schema, a
+  data-mutation clause (`insert`/`delete`/`update`/`put`) anywhere → write,
+  otherwise read. It scans the full buffer (not just the leading keyword) so a
+  `match … insert` pipeline is correctly classified as a write, and strips `#` /
+  `//` line comments and string literals first (so a keyword inside a value like
+  `has title "define the roadmap"` doesn't cause a false match). `runScript`
+  (`spindb run`) now uses the same helper,
+  so `spindb run` and `spindb query` classify identically (and `run` gains
+  `redefine`/`update` recognition plus pure-read detection it lacked before; an
+  explicit `transactionType` still overrides). The logic mirrors
+  layerbase-cloud's `detectTypedbTxType` and the two are kept in lockstep.
+
 ## [0.51.6] - 2026-06-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `redefine`/`update` recognition plus pure-read detection it lacked before; an
   explicit `transactionType` still overrides). The logic mirrors
   layerbase-cloud's `detectTypedbTxType` and the two are kept in lockstep.
+- **TypeDB `spindb query -d <database>` is now honored.** TypeDB's `executeQuery`
+  read only the container's default database and ignored the `-d` / `--database`
+  flag, so queries always ran against the default. It now uses
+  `options.database || container.database`, matching every other engine.
 
 ## [0.51.6] - 2026-06-02
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.51.6'
+export const VERSION = '0.51.7'

--- a/engines/typedb/cli-utils.ts
+++ b/engines/typedb/cli-utils.ts
@@ -14,6 +14,40 @@ import { normalizeVersion } from './version-maps'
 export const TYPEDB_NOT_FOUND_ERROR =
   'TypeDB binary not found. Run: spindb engines download typedb <version>'
 
+/**
+ * Classify a TypeQL query into the TypeDB transaction type it requires.
+ *
+ * TypeDB 3.x has three transaction types and rejects a query run under the
+ * wrong one (`[TSV8]` for schema, `[TSV9]` for data). The whole query buffer
+ * is one transaction, so the classification must look at the *entire* query,
+ * not just the leading keyword - a `match $x ...; insert (...) isa rel;`
+ * pipeline starts with `match` but is a write.
+ *
+ *   - schema: contains define / undefine / redefine
+ *   - write:  contains a data-mutation clause (insert / delete / update / put)
+ *   - read:   anything else (match / fetch / reduce / sort / ...)
+ *
+ * Schema wins over write, and write wins over read. Line comments (`#` and
+ * `//`) and string literals are stripped first, so keywords inside a comment or
+ * a value (e.g. `insert ... has title "define the roadmap"`) don't trigger a
+ * false match.
+ *
+ * This mirrors layerbase-cloud's `detectTypedbTxType` - the two must stay in
+ * lockstep so the desktop (via spindb) and the cloud classify identically.
+ */
+export function detectTypedbTxType(query: string): 'read' | 'write' | 'schema' {
+  const stripped = query
+    .replace(/#[^\n]*/g, '') // strip `#` line comments
+    .replace(/\/\/[^\n]*/g, '') // strip `//` line comments
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""') // blank string literals so keywords
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''") // inside values don't trigger a match
+    .toUpperCase()
+
+  if (/\b(?:DEFINE|UNDEFINE|REDEFINE)\b/.test(stripped)) return 'schema'
+  if (/\b(?:INSERT|DELETE|UPDATE|PUT)\b/.test(stripped)) return 'write'
+  return 'read'
+}
+
 /** Default TypeDB credentials (TypeDB 3.x requires authentication) */
 export const TYPEDB_DEFAULT_USERNAME = 'admin'
 export const TYPEDB_DEFAULT_PASSWORD = 'password'

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -1041,7 +1041,9 @@ export class TypeDBEngine extends BaseEngine {
     options?: QueryOptions,
   ): Promise<QueryResult> {
     const { port, version } = container
-    const db = container.database
+    // Honor a caller-supplied database (the `-d` flag in `spindb query`); fall
+    // back to the container's default. Matches the other engines' executeQuery.
+    const db = options?.database || container.database
 
     if (!db) {
       throw new Error(

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -47,6 +47,7 @@ import {
   validateTypeDBIdentifier,
   requireTypeDBConsolePath,
   getConsoleBaseArgs,
+  detectTypedbTxType,
   TYPEDB_DEFAULT_USERNAME,
   TYPEDB_DEFAULT_PASSWORD,
 } from './cli-utils'
@@ -993,18 +994,10 @@ export class TypeDBEngine extends BaseEngine {
       // Run inline TypeQL via temp script file
       // TypeDB console --command mode doesn't support multi-step transaction flows;
       // each --command is a standalone top-level command. Transactions require --script.
-      const upperSql = options.sql.trim().toUpperCase()
-      let txType: 'read' | 'write' | 'schema'
-      if (options.transactionType) {
-        txType = options.transactionType
-      } else if (
-        upperSql.startsWith('DEFINE') ||
-        upperSql.startsWith('UNDEFINE')
-      ) {
-        txType = 'schema'
-      } else {
-        txType = 'write'
-      }
+      // Caller override wins; otherwise classify the buffer the same way the
+      // query path does, so `spindb run` and `spindb query` agree.
+      const txType: 'read' | 'write' | 'schema' =
+        options.transactionType ?? detectTypedbTxType(options.sql)
       const txEnd = txType === 'read' ? 'close' : 'commit'
       const scriptContent = `transaction ${txType} ${db}\n\n${options.sql}\n\n${txEnd}\n`
       const tempScript = join(
@@ -1060,7 +1053,12 @@ export class TypeDBEngine extends BaseEngine {
 
     // TypeDB console --command mode doesn't support multi-step transaction flows;
     // each --command is a standalone top-level command. Use temp script for queries.
-    const scriptContent = `transaction read ${db}\n\n${query}\n\nclose\n`
+    // The transaction type must match what the query needs - a read transaction
+    // rejects schema (`define`/`undefine`/`redefine`) and data writes
+    // (`insert`/`delete`/`update`/`put`), so detect it from the whole buffer.
+    const txType = detectTypedbTxType(query)
+    const txEnd = txType === 'read' ? 'close' : 'commit'
+    const scriptContent = `transaction ${txType} ${db}\n\n${query}\n\n${txEnd}\n`
     const tempScript = join(
       tmpdir(),
       `spindb-typedb-query-${Date.now()}-${Math.random().toString(36).slice(2)}.tqls`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.6",
+  "version": "0.51.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/typedb-cli-utils.test.ts
+++ b/tests/unit/typedb-cli-utils.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for TypeDB CLI utilities
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { detectTypedbTxType } from '../../engines/typedb/cli-utils'
+
+describe('TypeDB CLI Utils', () => {
+  describe('detectTypedbTxType', () => {
+    it('classifies define/undefine/redefine as schema', () => {
+      assert.strictEqual(
+        detectTypedbTxType('define entity person owns name;'),
+        'schema',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('undefine owns name from person;'),
+        'schema',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('redefine attribute name value string;'),
+        'schema',
+      )
+    })
+
+    it('classifies data-mutation clauses as write', () => {
+      assert.strictEqual(
+        detectTypedbTxType('insert $a isa person, has name "Alice";'),
+        'write',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('match $p isa person; delete $p;'),
+        'write',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('match $p isa person; update $p has age 30;'),
+        'write',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('put $a isa person, has name "Alice";'),
+        'write',
+      )
+    })
+
+    it('classifies match/fetch/reduce as read', () => {
+      assert.strictEqual(detectTypedbTxType('match $p isa person;'), 'read')
+      assert.strictEqual(
+        detectTypedbTxType('match $p isa person; fetch { "name": $p.name };'),
+        'read',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('match $p isa person; reduce $c = count;'),
+        'read',
+      )
+    })
+
+    it('treats a match...insert relation pipeline as write (not read)', () => {
+      // The headline bug: starts with `match` but is a write. Must not be read,
+      // or TypeDB rejects it with [TSV9] under a read transaction.
+      const rel =
+        'match $a isa person, has name "Alice"; $b isa person, has name "Bob"; insert (a: $a, b: $b) isa knows;'
+      assert.strictEqual(detectTypedbTxType(rel), 'write')
+    })
+
+    it('lets schema win over a write clause appearing later', () => {
+      assert.strictEqual(
+        detectTypedbTxType('define entity person; insert $a isa person;'),
+        'schema',
+      )
+    })
+
+    it('ignores keywords inside line comments', () => {
+      assert.strictEqual(
+        detectTypedbTxType('# this will insert nothing\nmatch $p isa person;'),
+        'read',
+      )
+      assert.strictEqual(
+        detectTypedbTxType('// define is mentioned here\nmatch $p isa person;'),
+        'read',
+      )
+    })
+
+    it('ignores keywords inside string values', () => {
+      // An insert whose value contains `define`/`redefine` must stay write -
+      // misclassifying it schema would open a schema txn and the insert fails.
+      assert.strictEqual(
+        detectTypedbTxType(
+          'insert $t isa task, has title "define the roadmap";',
+        ),
+        'write',
+      )
+      assert.strictEqual(
+        detectTypedbTxType(
+          'match $x isa note, has body "please insert later";',
+        ),
+        'read',
+      )
+    })
+
+    it('does not match keywords embedded in identifiers', () => {
+      // `insertion_date` / `updated` must not flip a read to a write.
+      assert.strictEqual(
+        detectTypedbTxType('match $p isa person, has insertion_date $d;'),
+        'read',
+      )
+    })
+
+    it('is case-insensitive', () => {
+      assert.strictEqual(detectTypedbTxType('DEFINE entity person;'), 'schema')
+      assert.strictEqual(detectTypedbTxType('INSERT $a isa person;'), 'write')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

TypeDB's `executeQuery` — the code path behind `spindb query` — hardcoded `transaction read`, so through `spindb query` (and any GUI built on it, e.g. Layerbase Desktop):

- schema queries (`define` / `undefine` / `redefine`) failed with `[TSV8]`
- data writes (`insert` / `delete` / `update` / `put`, including `match …; insert (…) isa rel;` relation pipelines) failed with `[TSV9]`
- only read queries worked

`executeQuery` now classifies the whole query buffer and opens a `schema`, `write`, or `read` transaction accordingly (commit for schema/write, close for read).

## Changes

- New shared `detectTypedbTxType()` helper in `engines/typedb/cli-utils.ts`:
  - `define`/`undefine`/`redefine` → **schema**, a data-mutation clause (`insert`/`delete`/`update`/`put`) anywhere → **write**, otherwise → **read** (schema > write > read precedence).
  - Scans the full buffer (not just the leading keyword) so `match … insert` is correctly a write.
  - Strips `#` / `//` line comments **and** string literals first, so a keyword inside a value like `has title "define the roadmap"` doesn't cause a false match.
  - Mirrors layerbase-cloud's `detectTypedbTxType` and is kept in lockstep.
- `executeQuery` uses the helper (the actual bug fix).
- `runScript` (`spindb run`) now uses the same helper, so `spindb run` and `spindb query` classify identically (gains `redefine`/`update` recognition + pure-read detection; explicit `transactionType` still overrides).
- New unit test `tests/unit/typedb-cli-utils.test.ts` (9 cases).
- Version bump `0.51.6 → 0.51.7` + CHANGELOG entry.

## Validation

- `pnpm check` clean; full unit suite **1609/1609** pass.
- Verified end-to-end against a live TypeDB 3.8.0 container via `spindb query`: `define` (schema), `insert` (write), `match…fetch` / `reduce` (read), and a `match…insert` relation all open the correct transaction; an `insert` whose value contains `"define …"` correctly opens a **write** transaction (was misclassified before string-literal stripping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `spindb query` for TypeDB. Schema operations (define, undefine, redefine) and data modification commands, which previously failed with TypeDB errors, now execute correctly.
  * Enhanced TypeDB transaction handling in both `spindb query` and `spindb run` commands to improve detection and classification of operations for more reliable execution.

* **Chores**
  * Version bumped to 0.51.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->