### PR TITLE
feat(typedb): 3.11.5 (hostdb 0.33.0) + server-startup hardening (v0.52.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.51.7] - 2026-06-03
+## [0.52.0] - 2026-06-03
+
+### Added
+
+- **TypeDB 3.11.5** (via hostdb 0.33.0). `defaults["3"]` now resolves to 3.11.5, so new `typedb 3` containers provision the current release. TypeDB 3.11 raised the network protocol version from 7 to 8, so the previously bundled 3.8.0 (protocol 7) could not interoperate with current TypeDB 3.11.x servers/drivers. 3.8.0 remains resolvable + downloadable for existing containers (deprecated in hostdb).
+
+### Fixed
+
+- **TypeDB start no longer adopts a foreign server on the port.** `start()` previously decided the server was up using only `GET /health`, so if a different TypeDB process already held the gRPC/HTTP port (e.g. a developer's own TypeDB on the default 1729 / 8000), spindb's console silently talked to *that* server. Combined with the old 3.8.0 (protocol 7) vs current 3.11.x (protocol 8) split, this surfaced as opaque "incompatible driver version" errors. Now: a **pre-spawn port guard** refuses to start when the port is already in use (reporting the occupant), a **post-spawn PID-ownership check** confirms the listening process is the one spindb launched, and **`waitForReady()` / `status()` verify `GET /v1/version`** matches the container's expected version before reporting ready/running.
+- **Multiple TypeDB 3.11+ containers can run concurrently.** TypeDB 3.11 added a mandatory localhost admin port that defaults to a fixed 1728 for every server, so a second 3.11 container failed to bind it. spindb now writes a unique per-container `server.admin` port (derived from the container port) for 3.11+, and includes it in the start-time port guard. Containers < 3.11 are unaffected (no `server.admin` block, so existing 3.8.x configs stay valid when regenerated).
+
+### Changed
+
+- Bumped `hostdb` 0.32.0 → 0.33.0.
 
 ### Fixed
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.51.7'
+export const VERSION = '0.52.0'

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -659,37 +659,44 @@ export class TypeDBEngine extends BaseEngine {
     let attempt = 0
     while (Date.now() - startTime < timeoutMs) {
       attempt++
+      let healthy = false
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), 5000)
       try {
         const response = await fetch(`http://127.0.0.1:${httpPort}/health`, {
           signal: controller.signal,
         })
-        clearTimeout(timer)
-
-        if (response.ok) {
-          // Confirm this is the server we started, not a foreign TypeDB that
-          // happens to hold the port. A version mismatch means we're talking to
-          // someone else's server (the protocol-7-vs-8 incident's root cause) -
-          // looping won't fix that, so fail loudly. A null reading is transient;
-          // keep polling.
-          const serverVersion = await this.fetchServerVersion(httpPort)
-          if (serverVersion && serverVersion !== expectedVersion) {
-            throw new Error(
-              `Port ${httpPort} is serving TypeDB ${serverVersion}, but this ` +
-                `container expects ${expectedVersion}. A different TypeDB server ` +
-                `is running on this port - stop it, or recreate the container on ` +
-                `a different port.`,
-            )
-          }
-          logDebug(`TypeDB ready on HTTP port ${httpPort}`)
-          return true
-        }
+        healthy = response.ok
       } catch {
-        clearTimeout(timer)
+        // Transport/timeout errors are transient - keep polling. Only the
+        // /health fetch is retried here; the version check below must NOT be,
+        // or its mismatch error would be swallowed and surface as a generic
+        // start timeout.
         if (attempt <= 3 || attempt % 10 === 0) {
           logDebug(`Health check attempt ${attempt} failed`)
         }
+      } finally {
+        clearTimeout(timer)
+      }
+
+      if (healthy) {
+        // Confirm this is the server we started, not a foreign TypeDB that
+        // happens to hold the port. A version mismatch means we're talking to
+        // someone else's server (the protocol-7-vs-8 incident's root cause) -
+        // looping won't fix that, so fail loudly. This throw is deliberately
+        // OUTSIDE the fetch try/catch so it propagates to start() instead of
+        // being retried. A null reading is transient; keep polling.
+        const serverVersion = await this.fetchServerVersion(httpPort)
+        if (serverVersion && serverVersion !== expectedVersion) {
+          throw new Error(
+            `Port ${httpPort} is serving TypeDB ${serverVersion}, but this ` +
+              `container expects ${expectedVersion}. A different TypeDB server ` +
+              `is running on this port - stop it, or recreate the container on ` +
+              `a different port.`,
+          )
+        }
+        logDebug(`TypeDB ready on HTTP port ${httpPort}`)
+        return true
       }
       await new Promise((resolve) => setTimeout(resolve, checkInterval))
     }

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -30,6 +30,7 @@ import {
   assertValidUsername,
 } from '../../core/error-handler'
 import { processManager } from '../../core/process-manager'
+import { portManager } from '../../core/port-manager'
 import { typedbBinaryManager } from './binary-manager'
 import { getBinaryUrl } from './binary-urls'
 import {
@@ -173,9 +174,21 @@ export class TypeDBEngine extends BaseEngine {
    * Initialize a new TypeDB data directory
    * Creates the directory structure and config.yml for TypeDB
    */
+  // TypeDB 3.11+ binds a dedicated localhost admin port (default 1728, the same
+  // for every server). To let multiple TypeDB containers run at once, give each
+  // its own admin port derived from the container port and offset clear of the
+  // gRPC (port) and HTTP (port + 6271) bands. Returns null for < 3.11, whose
+  // config schema has no `server.admin` block - so existing 3.8.x containers are
+  // left untouched when their config is regenerated.
+  private adminPortFor(version: string, port: number): number | null {
+    const [major, minor] = normalizeVersion(version).split('.').map(Number)
+    const supportsAdmin = major > 3 || (major === 3 && minor >= 11)
+    return supportsAdmin ? port + 6372 : null
+  }
+
   async initDataDir(
     containerName: string,
-    _version: string,
+    version: string,
     options: Record<string, unknown> = {},
   ): Promise<string> {
     const containerDir = paths.getContainerPath(containerName, {
@@ -191,6 +204,7 @@ export class TypeDBEngine extends BaseEngine {
     // Get port from options or use default
     const port = (options.port as number) || engineDef.defaultPort
     const httpPort = port + 6271 // Default: 1729 + 6271 = 8000
+    const adminPort = this.adminPortFor(version, port) // 3.11+ only; null otherwise
 
     // Generate config.yml for this container
     // Must include all required sections: server (with authentication, encryption), storage, logging, diagnostics
@@ -204,6 +218,13 @@ export class TypeDBEngine extends BaseEngine {
       '  http:',
       '    enabled: true',
       `    address: ${(options.bindAddress as string) ?? '127.0.0.1'}:${httpPort}`,
+      // TypeDB 3.11+ requires a `server.admin` block (the `port` field is
+      // mandatory). Give each container a unique admin port so concurrent
+      // TypeDB containers don't all fight over the default 1728. Omitted for
+      // < 3.11, which doesn't understand this block.
+      ...(adminPort !== null
+        ? ['  admin:', '    enabled: true', `    port: ${adminPort}`]
+        : []),
       '  authentication:',
       '    token-expiration-seconds: 5000',
       '  encryption:',
@@ -321,6 +342,32 @@ export class TypeDBEngine extends BaseEngine {
       return {
         port,
         connectionString: this.getConnectionString(container),
+      }
+    }
+
+    // Refuse to start if our gRPC or HTTP port is already held by another
+    // process. TypeDB's readiness check and console both address the server by
+    // port alone, so a foreign server here (e.g. a different TypeDB version on
+    // the default 1729 / 8000) would be silently used instead of ours - which
+    // surfaces later as opaque driver/protocol errors at query time. Fail loudly
+    // up front instead. (We only get here when our own server is NOT running -
+    // the alreadyRunning check above already returned for that case.)
+    const httpPort = port + 6271
+    const adminPort = this.adminPortFor(version, port)
+    const portsToCheck =
+      adminPort !== null ? [port, httpPort, adminPort] : [port, httpPort]
+    for (const p of portsToCheck) {
+      if (!(await portManager.isPortAvailable(p))) {
+        const user = await portManager.getPortUser(p)
+        const label =
+          p === httpPort ? ' (HTTP)' : p === adminPort ? ' (admin)' : ''
+        throw new Error(
+          `Cannot start TypeDB "${name}": port ${p}${label}` +
+            ` is already in use by another process - likely a different TypeDB ` +
+            `server. Stop it, or recreate this container on a different port ` +
+            `(spindb create ... --port <n>).` +
+            (user ? `\n  ${user.replace(/\n/g, '\n  ')}` : ''),
+        )
       }
     }
 
@@ -517,17 +564,44 @@ export class TypeDBEngine extends BaseEngine {
     }
 
     // Wait for server to be ready
-    const httpPort = port + 6271
     logDebug(
       `Waiting for TypeDB server to be ready on port ${port} (HTTP: ${httpPort})...`,
     )
-    const ready = await this.waitForReady(httpPort, port)
+    const ready = await this.waitForReady(
+      httpPort,
+      port,
+      normalizeVersion(version),
+    )
     logDebug(`waitForReady returned: ${ready}`)
 
     if (!ready) {
       throw new Error(
         `TypeDB failed to start within timeout. Container: ${name}`,
       )
+    }
+
+    // Confirm the server that answered is the one we launched, not a foreign
+    // process that grabbed the port between the pre-flight check and bind. The
+    // launcher execs the server binary, so proc.pid is the listening pid on
+    // macOS/Linux. If a different pid owns the port, our server didn't bind -
+    // stop our orphan and fail loudly instead of using someone else's server.
+    // (Empty result = lookup unavailable; don't false-fail on it.)
+    if (!isWindows && proc.pid) {
+      const owners = await platformService
+        .findProcessByPort(port)
+        .catch(() => [] as number[])
+      if (owners.length > 0 && !owners.includes(proc.pid)) {
+        try {
+          process.kill(proc.pid, 'SIGTERM')
+        } catch {
+          // our process already exited
+        }
+        throw new Error(
+          `Cannot start TypeDB "${name}": port ${port} is held by another ` +
+            `process (pid ${owners.join(', ')}), not the server we launched ` +
+            `(pid ${proc.pid}). A different TypeDB server is using this port.`,
+        )
+      }
     }
 
     // On Windows with .bat launcher, the recorded PID is cmd.exe (not the actual server).
@@ -552,10 +626,30 @@ export class TypeDBEngine extends BaseEngine {
     }
   }
 
+  // Fetch the version the server on this HTTP port reports. TypeDB exposes
+  // GET /v1/version -> { "version": "3.11.5", ... }. Returns null if the
+  // endpoint is unreachable or doesn't report a version.
+  private async fetchServerVersion(httpPort: number): Promise<string | null> {
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 5000)
+      const response = await fetch(`http://127.0.0.1:${httpPort}/v1/version`, {
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+      if (!response.ok) return null
+      const body = (await response.json()) as { version?: unknown }
+      return typeof body.version === 'string' ? body.version : null
+    } catch {
+      return null
+    }
+  }
+
   // Wait for TypeDB to be ready via HTTP health check
   private async waitForReady(
     httpPort: number,
     _mainPort: number,
+    expectedVersion: string,
     timeoutMs = 60000,
   ): Promise<boolean> {
     logDebug(`waitForReady called for HTTP port ${httpPort}`)
@@ -574,6 +668,20 @@ export class TypeDBEngine extends BaseEngine {
         clearTimeout(timer)
 
         if (response.ok) {
+          // Confirm this is the server we started, not a foreign TypeDB that
+          // happens to hold the port. A version mismatch means we're talking to
+          // someone else's server (the protocol-7-vs-8 incident's root cause) -
+          // looping won't fix that, so fail loudly. A null reading is transient;
+          // keep polling.
+          const serverVersion = await this.fetchServerVersion(httpPort)
+          if (serverVersion && serverVersion !== expectedVersion) {
+            throw new Error(
+              `Port ${httpPort} is serving TypeDB ${serverVersion}, but this ` +
+                `container expects ${expectedVersion}. A different TypeDB server ` +
+                `is running on this port - stop it, or recreate the container on ` +
+                `a different port.`,
+            )
+          }
           logDebug(`TypeDB ready on HTTP port ${httpPort}`)
           return true
         }
@@ -646,7 +754,7 @@ export class TypeDBEngine extends BaseEngine {
 
   // Get TypeDB server status
   async status(container: ContainerConfig): Promise<StatusResult> {
-    const { port } = container
+    const { port, version } = container
     const httpPort = port + 6271
 
     try {
@@ -659,6 +767,16 @@ export class TypeDBEngine extends BaseEngine {
       clearTimeout(timer)
 
       if (response.ok) {
+        // A healthy server on the port isn't necessarily ours - guard against a
+        // foreign TypeDB on the same port being reported as this container.
+        const expected = normalizeVersion(version)
+        const serverVersion = await this.fetchServerVersion(httpPort)
+        if (serverVersion && serverVersion !== expected) {
+          return {
+            running: false,
+            message: `A different TypeDB version (${serverVersion}) is running on port ${port}; this container expects ${expected}.`,
+          }
+        }
         return { running: true, message: 'TypeDB is running' }
       }
       return { running: false, message: 'TypeDB is not running' }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.51.7",
+  "version": "0.52.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.32.0",
+    "hostdb": "0.33.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.32.0
-        version: 0.32.0
+        specifier: 0.33.0
+        version: 0.33.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.32.0:
-    resolution: {integrity: sha512-KCSiXEQzVEhI6eq3duYGCrkNOKZc9eDCJ8qRPKv7zhWjtNQrhgBe2Q5C7+P/Ip7gDRnwWnntlQTwp+EtuVHglw==}
+  hostdb@0.33.0:
+    resolution: {integrity: sha512-KRC+YiN+6eWguzXfECu5EahtNomA2uXBadpW7rrarFddSY0mGms48BD6VgsN86cNoWMcU6Q8xQ6CKVv+Fu4SWw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.32.0: {}
+  hostdb@0.33.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/tests/unit/typedb-port-ownership.test.ts
+++ b/tests/unit/typedb-port-ownership.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression test for the TypeDB foreign-server hijack.
+ *
+ * Bug: spindb's TypeDB engine identified "the server" purely by port + an
+ * HTTP `/health` probe. If a different TypeDB process already held the port
+ * (e.g. a developer's own TypeDB on the default 1729 / HTTP 8000), spindb's
+ * health check saw it as "ready" and the bundled console then talked to that
+ * foreign server. With spindb on 3.8.0 (network protocol 7) and the foreign
+ * server on 3.11.x (protocol 8), every operation failed with an opaque
+ * "incompatible driver version" error.
+ *
+ * Fix: readiness/status now also read GET /v1/version and require it to match
+ * the container's expected version, so a foreign server is detected instead of
+ * silently used. This test drives the public status() against a stub HTTP
+ * listener (no real TypeDB) standing in for whatever is bound to the port.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import { Engine, type ContainerConfig } from '../../types/index'
+import { typedbEngine } from '../../engines/typedb/index'
+
+// status() probes http://127.0.0.1:<port + 6271>; mirror that offset so a
+// listener on `httpPort` maps back to a container `port`.
+const HTTP_OFFSET = 6271
+
+type Stub = { httpPort: number; server: Server }
+
+// Start a stub that answers /health 200 and /v1/version with `reportedVersion`
+// (or 404 on /v1/version when null, to simulate a server lacking the endpoint).
+function startStub(reportedVersion: string | null): Promise<Stub> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'text/plain' })
+        res.end('ok')
+        return
+      }
+      if (req.url === '/v1/version') {
+        if (reportedVersion === null) {
+          res.writeHead(404)
+          res.end()
+          return
+        }
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            distribution: 'TypeDB CE',
+            version: reportedVersion,
+          }),
+        )
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (typeof address === 'object' && address) {
+        resolve({ httpPort: address.port, server })
+      } else {
+        reject(new Error('No address bound'))
+      }
+    })
+  })
+}
+
+function closeStub(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+function containerForHttpPort(
+  httpPort: number,
+  version: string,
+): ContainerConfig {
+  return {
+    name: 'typedb-ownership-test',
+    engine: Engine.TypeDB,
+    version,
+    port: httpPort - HTTP_OFFSET,
+    database: 'test',
+    created: '2026-01-01T00:00:00.000Z',
+    status: 'running',
+  }
+}
+
+describe('TypeDB status() server-identity guard', () => {
+  let foreign: Stub
+  let own: Stub
+  let healthOnly: Stub
+
+  before(async () => {
+    foreign = await startStub('3.11.5')
+    own = await startStub('3.8.0')
+    healthOnly = await startStub(null)
+  })
+
+  after(async () => {
+    await closeStub(foreign.server)
+    await closeStub(own.server)
+    await closeStub(healthOnly.server)
+  })
+
+  it('reports not-running when a different TypeDB version holds the port', async () => {
+    const status = await typedbEngine.status(
+      containerForHttpPort(foreign.httpPort, '3.8.0'),
+    )
+    assert.equal(status.running, false)
+    assert.match(status.message ?? '', /different TypeDB version/i)
+    assert.match(status.message ?? '', /3\.11\.5/)
+  })
+
+  it('reports running when the version on the port matches', async () => {
+    const status = await typedbEngine.status(
+      containerForHttpPort(own.httpPort, '3.8.0'),
+    )
+    assert.equal(status.running, true)
+  })
+
+  it('does not false-fail when the server lacks /v1/version (health only)', async () => {
+    const status = await typedbEngine.status(
+      containerForHttpPort(healthOnly.httpPort, '3.8.0'),
+    )
+    assert.equal(status.running, true)
+  })
+})


### PR DESCRIPTION
## Summary

Brings spindb up to **TypeDB 3.11.5** (via hostdb 0.33.0) and hardens TypeDB startup so it can never silently adopt a foreign server on the port — the root cause of the "incompatible driver version (protocol 7 vs 8)" failure a user hit.

TypeDB 3.11 raised the network protocol version **7 → 8**, so the previously bundled 3.8.0 (protocol 7) couldn't talk to current TypeDB 3.11.x. 3.8.0 stays resolvable/downloadable for existing containers (deprecated in hostdb).

## Changes

- **Bump `hostdb` 0.32.0 → 0.33.0** → `typedb 3` now resolves to **3.11.5**.
- **Foreign-server hardening in `engines/typedb/index.ts`:**
  - **Pre-spawn port guard** — refuse to start if the gRPC/HTTP (and 3.11+ admin) port is already held, reporting the occupant.
  - **Post-spawn PID-ownership check** — confirm the port is owned by the server we launched (the launcher `exec`s, so `proc.pid` is the server).
  - **Version-identity check** — `waitForReady()` and `status()` read `GET /v1/version` and require it to match the container's expected version.
- **Multi-container TypeDB 3.11+** — 3.11 added a mandatory localhost admin port defaulting to a fixed **1728**; a second 3.11 container couldn't bind it. spindb now writes a unique per-container `server.admin` port (derived from the container port) for ≥3.11, and includes it in the start guard. < 3.11 configs are untouched (so existing 3.8.x containers stay valid when regenerated).
- New `tests/unit/typedb-port-ownership.test.ts`; version → **0.52.0** + CHANGELOG.

## Validation (local, against real binaries)

- `lint` + `test:unit` (1612) + `test:hostdb-sync` (23) green.
- hostdb 0.33.0 installed; resolver returns `typedb 3 → 3.11.5`.
- Created a real **3.11.5** container (downloaded from R2) and ran all of: `define` (schema), `insert` (write), `match…fetch`, `reduce count`, and a `match…insert` relation — all commit.
- **Two concurrent 3.11.5 containers** start cleanly with distinct admin ports (8102 / 8103) — the previously-broken case.
- Confirmed the real 3.11.5 server accepts spindb's generated `config.yml`.

## After merge
Publishes spindb **0.52.0** to npm → consumed by layerbase-desktop and layerbase-cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for running multiple TypeDB 3.11+ containers concurrently with unique per-container admin ports
  * Enhanced version verification during startup and health checks to prevent connecting to incompatible servers
  * TypeDB 3.11.5 resolution support for newly provisioned containers

* **Bug Fixes**
  * Improved port-ownership validation to guard against connecting to foreign TypeDB servers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->