### PR TITLE
feat(typedb): configurable HTTP-port offset via SPINDB_TYPEDB_HTTP_OFFSET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-06-03
+
+### Added
+
+- **Configurable TypeDB HTTP-port offset (`SPINDB_TYPEDB_HTTP_OFFSET`).** TypeDB binds its HTTP API at the gRPC port plus an offset, defaulting to 6271 (so the stock 1729 gRPC maps to TypeDB's default 8000 HTTP). Set `SPINDB_TYPEDB_HTTP_OFFSET` to a positive integer to move it — a host that publishes a fixed port block (e.g. a managed cloud) can put the HTTP port at a small in-block offset so it's reachable directly on the host instead of through a container shell. The default is unchanged, so local and desktop usage is unaffected. All HTTP-port derivations — `config.yml` generation, the start-time port-availability guard, the status `/health` probe, the HTTP query client, and `spindb ports` — go through a single helper so they stay consistent under an override, and the offset is read fresh on every start.
+
 ## [0.53.0] - 2026-06-03
 
 ### Added

--- a/cli/commands/ports.ts
+++ b/cli/commands/ports.ts
@@ -8,6 +8,7 @@ import { uiError, uiInfo } from '../ui/theme'
 import { getEngineIcon } from '../constants'
 import { Engine, type ContainerConfig } from '../../types'
 import { loadEnginesJson } from '../../config/engines-registry'
+import { typedbHttpPort } from '../../engines/typedb/cli-utils'
 
 function getSecondaryPorts(
   config: ContainerConfig,
@@ -24,7 +25,7 @@ function getSecondaryPorts(
       ports.push({ port: config.port + 1, label: 'gRPC' })
       break
     case 'typedb':
-      ports.push({ port: config.port + 6271, label: 'HTTP' })
+      ports.push({ port: typedbHttpPort(config.port), label: 'HTTP' })
       break
     case 'questdb':
       ports.push({ port: config.port + 188, label: 'HTTP Console' })

--- a/engines/typedb/cli-utils.ts
+++ b/engines/typedb/cli-utils.ts
@@ -53,6 +53,40 @@ export const TYPEDB_DEFAULT_USERNAME = 'admin'
 export const TYPEDB_DEFAULT_PASSWORD = 'password'
 
 /**
+ * Offset from the gRPC (main) port to TypeDB's HTTP API port. Defaults to
+ * 6271 so the stock 1729 gRPC maps to TypeDB's default 8000 HTTP.
+ *
+ * Override with SPINDB_TYPEDB_HTTP_OFFSET (a positive integer). Layerbase
+ * cloud sets a small in-block offset so the HTTP port can be published to
+ * the host alongside gRPC inside the user's port block - the default 6271
+ * lands far outside a published block and is unreachable from the host
+ * (which is why cloud otherwise has to shell HTTP calls through
+ * `docker exec`). Like detectTypedbTxType, the default must stay in
+ * lockstep with layerbase-cloud's TYPEDB_HTTP_PORT_OFFSET.
+ */
+export const DEFAULT_TYPEDB_HTTP_OFFSET = 6271
+
+export function typedbHttpOffset(): number {
+  const raw = process.env.SPINDB_TYPEDB_HTTP_OFFSET
+  if (!raw) return DEFAULT_TYPEDB_HTTP_OFFSET
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_TYPEDB_HTTP_OFFSET
+}
+
+/**
+ * The HTTP API port for a TypeDB server whose gRPC (main) port is
+ * `basePort`. All spindb code paths that talk to the HTTP API - config.yml
+ * generation, the start-time port-availability check, the status probe, and
+ * the HTTP query client - derive the port through this one function so they
+ * stay consistent under an SPINDB_TYPEDB_HTTP_OFFSET override.
+ */
+export function typedbHttpPort(basePort: number): number {
+  return basePort + typedbHttpOffset()
+}
+
+/**
  * Get standard TypeDB console connection arguments including authentication.
  * TypeDB 3.x requires --username and --password for all console operations.
  *

--- a/engines/typedb/cli-utils.ts
+++ b/engines/typedb/cli-utils.ts
@@ -87,6 +87,34 @@ export function typedbHttpPort(basePort: number): number {
 }
 
 /**
+ * Recover the HTTP offset a TypeDB container was created with by reading its
+ * existing config.yml. spindb regenerates config.yml on every start, so the
+ * offset must persist across restarts as a property of the container -
+ * otherwise a container created with a non-default SPINDB_TYPEDB_HTTP_OFFSET
+ * would silently move its HTTP port the next time it starts (re-reading the
+ * process env, which may differ or be unset), breaking any caller that
+ * expects the original port. This matters when one host runs many TypeDB
+ * containers with different offsets: each config.yml is its own source of
+ * truth.
+ *
+ * config.yml lists the gRPC `server.address` first, then the
+ * `http.address`, so the offset is simply (http port - gRPC port). Returns
+ * null when the config can't be parsed (e.g. a fresh create, before any
+ * config exists), so callers fall back to the env/default offset.
+ */
+export function parseTypedbHttpOffsetFromConfig(
+  configYml: string,
+): number | null {
+  const ports = [...configYml.matchAll(/address:\s*[\d.]+:(\d+)/g)].map((m) =>
+    Number.parseInt(m[1], 10),
+  )
+  const [grpcPort, httpPort] = ports
+  if (!Number.isInteger(grpcPort) || !Number.isInteger(httpPort)) return null
+  const offset = httpPort - grpcPort
+  return offset > 0 ? offset : null
+}
+
+/**
  * Get standard TypeDB console connection arguments including authentication.
  * TypeDB 3.x requires --username and --password for all console operations.
  *

--- a/engines/typedb/cli-utils.ts
+++ b/engines/typedb/cli-utils.ts
@@ -87,34 +87,6 @@ export function typedbHttpPort(basePort: number): number {
 }
 
 /**
- * Recover the HTTP offset a TypeDB container was created with by reading its
- * existing config.yml. spindb regenerates config.yml on every start, so the
- * offset must persist across restarts as a property of the container -
- * otherwise a container created with a non-default SPINDB_TYPEDB_HTTP_OFFSET
- * would silently move its HTTP port the next time it starts (re-reading the
- * process env, which may differ or be unset), breaking any caller that
- * expects the original port. This matters when one host runs many TypeDB
- * containers with different offsets: each config.yml is its own source of
- * truth.
- *
- * config.yml lists the gRPC `server.address` first, then the
- * `http.address`, so the offset is simply (http port - gRPC port). Returns
- * null when the config can't be parsed (e.g. a fresh create, before any
- * config exists), so callers fall back to the env/default offset.
- */
-export function parseTypedbHttpOffsetFromConfig(
-  configYml: string,
-): number | null {
-  const ports = [...configYml.matchAll(/address:\s*[\d.]+:(\d+)/g)].map((m) =>
-    Number.parseInt(m[1], 10),
-  )
-  const [grpcPort, httpPort] = ports
-  if (!Number.isInteger(grpcPort) || !Number.isInteger(httpPort)) return null
-  const offset = httpPort - grpcPort
-  return offset > 0 ? offset : null
-}
-
-/**
  * Get standard TypeDB console connection arguments including authentication.
  * TypeDB 3.x requires --username and --password for all console operations.
  *

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -16,7 +16,7 @@
 
 import { spawn, type SpawnOptions } from 'child_process'
 import { existsSync } from 'fs'
-import { mkdir, writeFile, readFile, unlink, stat, readdir } from 'fs/promises'
+import { mkdir, writeFile, unlink, stat, readdir } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { BaseEngine } from '../base-engine'
@@ -50,7 +50,6 @@ import {
   getConsoleBaseArgs,
   detectTypedbTxType,
   typedbHttpPort,
-  parseTypedbHttpOffsetFromConfig,
   TYPEDB_DEFAULT_USERNAME,
   TYPEDB_DEFAULT_PASSWORD,
 } from './cli-utils'
@@ -205,27 +204,7 @@ export class TypeDBEngine extends BaseEngine {
 
     // Get port from options or use default
     const port = (options.port as number) || engineDef.defaultPort
-
-    // Preserve the per-container HTTP offset across restarts. initDataDir runs
-    // on every start and regenerates config.yml, so recover the offset this
-    // container was created with from its existing config (the source of
-    // truth) rather than re-reading the process env each time - otherwise a
-    // container created with a non-default SPINDB_TYPEDB_HTTP_OFFSET would
-    // silently move its HTTP port on the next start. Fresh creates (no
-    // existing config) fall back to the env/default offset.
-    const configPath = join(containerDir, 'config.yml')
-    let recoveredOffset: number | null = null
-    if (existsSync(configPath)) {
-      try {
-        recoveredOffset = parseTypedbHttpOffsetFromConfig(
-          await readFile(configPath, 'utf-8'),
-        )
-      } catch {
-        recoveredOffset = null
-      }
-    }
-    const httpPort =
-      recoveredOffset !== null ? port + recoveredOffset : typedbHttpPort(port)
+    const httpPort = typedbHttpPort(port) // base + 6271 (8000) by default
     const adminPort = this.adminPortFor(version, port) // 3.11+ only; null otherwise
 
     // Generate config.yml for this container

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -16,7 +16,7 @@
 
 import { spawn, type SpawnOptions } from 'child_process'
 import { existsSync } from 'fs'
-import { mkdir, writeFile, unlink, stat, readdir } from 'fs/promises'
+import { mkdir, writeFile, readFile, unlink, stat, readdir } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { BaseEngine } from '../base-engine'
@@ -50,6 +50,7 @@ import {
   getConsoleBaseArgs,
   detectTypedbTxType,
   typedbHttpPort,
+  parseTypedbHttpOffsetFromConfig,
   TYPEDB_DEFAULT_USERNAME,
   TYPEDB_DEFAULT_PASSWORD,
 } from './cli-utils'
@@ -204,7 +205,27 @@ export class TypeDBEngine extends BaseEngine {
 
     // Get port from options or use default
     const port = (options.port as number) || engineDef.defaultPort
-    const httpPort = typedbHttpPort(port) // base + 6271 (8000) by default
+
+    // Preserve the per-container HTTP offset across restarts. initDataDir runs
+    // on every start and regenerates config.yml, so recover the offset this
+    // container was created with from its existing config (the source of
+    // truth) rather than re-reading the process env each time - otherwise a
+    // container created with a non-default SPINDB_TYPEDB_HTTP_OFFSET would
+    // silently move its HTTP port on the next start. Fresh creates (no
+    // existing config) fall back to the env/default offset.
+    const configPath = join(containerDir, 'config.yml')
+    let recoveredOffset: number | null = null
+    if (existsSync(configPath)) {
+      try {
+        recoveredOffset = parseTypedbHttpOffsetFromConfig(
+          await readFile(configPath, 'utf-8'),
+        )
+      } catch {
+        recoveredOffset = null
+      }
+    }
+    const httpPort =
+      recoveredOffset !== null ? port + recoveredOffset : typedbHttpPort(port)
     const adminPort = this.adminPortFor(version, port) // 3.11+ only; null otherwise
 
     // Generate config.yml for this container

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -49,6 +49,7 @@ import {
   requireTypeDBConsolePath,
   getConsoleBaseArgs,
   detectTypedbTxType,
+  typedbHttpPort,
   TYPEDB_DEFAULT_USERNAME,
   TYPEDB_DEFAULT_PASSWORD,
 } from './cli-utils'
@@ -203,7 +204,7 @@ export class TypeDBEngine extends BaseEngine {
 
     // Get port from options or use default
     const port = (options.port as number) || engineDef.defaultPort
-    const httpPort = port + 6271 // Default: 1729 + 6271 = 8000
+    const httpPort = typedbHttpPort(port) // base + 6271 (8000) by default
     const adminPort = this.adminPortFor(version, port) // 3.11+ only; null otherwise
 
     // Generate config.yml for this container
@@ -352,7 +353,7 @@ export class TypeDBEngine extends BaseEngine {
     // surfaces later as opaque driver/protocol errors at query time. Fail loudly
     // up front instead. (We only get here when our own server is NOT running -
     // the alreadyRunning check above already returned for that case.)
-    const httpPort = port + 6271
+    const httpPort = typedbHttpPort(port)
     const adminPort = this.adminPortFor(version, port)
     const portsToCheck =
       adminPort !== null ? [port, httpPort, adminPort] : [port, httpPort]
@@ -762,7 +763,7 @@ export class TypeDBEngine extends BaseEngine {
   // Get TypeDB server status
   async status(container: ContainerConfig): Promise<StatusResult> {
     const { port, version } = container
-    const httpPort = port + 6271
+    const httpPort = typedbHttpPort(port)
 
     try {
       const controller = new AbortController()
@@ -1290,7 +1291,7 @@ export class TypeDBEngine extends BaseEngine {
     query: string,
     options?: QueryOptions,
   ): Promise<QueryResult> {
-    const base = `http://127.0.0.1:${port + 6271}` // gRPC port + 6271 = HTTP API
+    const base = `http://127.0.0.1:${typedbHttpPort(port)}` // base + HTTP offset
     const username = options?.username || TYPEDB_DEFAULT_USERNAME
     const password = options?.password || TYPEDB_DEFAULT_PASSWORD
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/typedb-http-offset.test.ts
+++ b/tests/unit/typedb-http-offset.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the configurable TypeDB HTTP-port offset.
+ *
+ * TypeDB's HTTP API listens on the gRPC (main) port plus an offset. The
+ * default is 6271, so the stock 1729 gRPC maps to TypeDB's default 8000
+ * HTTP. Layerbase cloud overrides it via SPINDB_TYPEDB_HTTP_OFFSET to a
+ * small in-block value so the HTTP port can be published to the host
+ * alongside gRPC. These tests lock in the default, the override, and the
+ * invalid-value fallback so config.yml generation, the start-time port
+ * check, the status probe, and the HTTP query client stay consistent.
+ */
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_TYPEDB_HTTP_OFFSET,
+  typedbHttpOffset,
+  typedbHttpPort,
+} from '../../engines/typedb/cli-utils'
+
+const ENV_KEY = 'SPINDB_TYPEDB_HTTP_OFFSET'
+
+describe('typedb HTTP-port offset', () => {
+  afterEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  it('defaults to 6271 (1729 gRPC -> 8000 HTTP) when unset', () => {
+    delete process.env[ENV_KEY]
+    assert.equal(DEFAULT_TYPEDB_HTTP_OFFSET, 6271)
+    assert.equal(typedbHttpOffset(), 6271)
+    assert.equal(typedbHttpPort(1729), 8000)
+    assert.equal(typedbHttpPort(40000), 46271)
+  })
+
+  it('honors a positive-integer override', () => {
+    process.env[ENV_KEY] = '1'
+    assert.equal(typedbHttpOffset(), 1)
+    assert.equal(typedbHttpPort(1729), 1730)
+    assert.equal(typedbHttpPort(40000), 40001)
+  })
+
+  it('falls back to the default for non-positive or non-numeric values', () => {
+    for (const bad of ['0', '-5', 'abc', '', '   ']) {
+      process.env[ENV_KEY] = bad
+      assert.equal(
+        typedbHttpOffset(),
+        6271,
+        `expected fallback for ${JSON.stringify(bad)}`,
+      )
+    }
+  })
+})

--- a/tests/unit/typedb-http-offset.test.ts
+++ b/tests/unit/typedb-http-offset.test.ts
@@ -15,28 +15,7 @@ import {
   DEFAULT_TYPEDB_HTTP_OFFSET,
   typedbHttpOffset,
   typedbHttpPort,
-  parseTypedbHttpOffsetFromConfig,
 } from '../../engines/typedb/cli-utils'
-
-// Minimal config.yml shaped like the one initDataDir writes: the gRPC
-// `server.address` first, then the `http.address`. `host`/`port` fields
-// for admin + monitoring must NOT be picked up (only `address:` lines).
-function configYml(grpc: number, http: number, ip = '127.0.0.1'): string {
-  return [
-    'server:',
-    `  address: ${ip}:${grpc}`,
-    '  http:',
-    '    enabled: true',
-    `    address: ${ip}:${http}`,
-    '  admin:',
-    '    enabled: true',
-    `    port: ${grpc + 6372}`,
-    'diagnostics:',
-    '  monitoring:',
-    '    enabled: false',
-    '    port: 4104',
-  ].join('\n')
-}
 
 const ENV_KEY = 'SPINDB_TYPEDB_HTTP_OFFSET'
 
@@ -69,35 +48,5 @@ describe('typedb HTTP-port offset', () => {
         `expected fallback for ${JSON.stringify(bad)}`,
       )
     }
-  })
-})
-
-describe('parseTypedbHttpOffsetFromConfig (per-container persistence)', () => {
-  it('recovers the default 6271 offset from a stock config', () => {
-    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(1729, 8000)), 6271)
-  })
-
-  it('recovers a small in-block offset (cloud scheme)', () => {
-    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(47000, 47001)), 1)
-  })
-
-  it('parses 0.0.0.0 addresses (after the cloud bind-address rewrite)', () => {
-    assert.equal(
-      parseTypedbHttpOffsetFromConfig(configYml(47000, 47001, '0.0.0.0')),
-      1,
-    )
-  })
-
-  it('ignores admin/monitoring port lines (only address: lines count)', () => {
-    // admin port is grpc+6372 and monitoring is 4104; if either were picked
-    // up as the "http" port the offset would be wrong.
-    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(2000, 2001)), 1)
-  })
-
-  it('returns null for unparseable/empty config so callers use the default', () => {
-    assert.equal(parseTypedbHttpOffsetFromConfig(''), null)
-    assert.equal(parseTypedbHttpOffsetFromConfig('server:\n  foo: bar'), null)
-    // http <= grpc is nonsensical (never written by initDataDir) -> null
-    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(8000, 8000)), null)
   })
 })

--- a/tests/unit/typedb-http-offset.test.ts
+++ b/tests/unit/typedb-http-offset.test.ts
@@ -15,7 +15,28 @@ import {
   DEFAULT_TYPEDB_HTTP_OFFSET,
   typedbHttpOffset,
   typedbHttpPort,
+  parseTypedbHttpOffsetFromConfig,
 } from '../../engines/typedb/cli-utils'
+
+// Minimal config.yml shaped like the one initDataDir writes: the gRPC
+// `server.address` first, then the `http.address`. `host`/`port` fields
+// for admin + monitoring must NOT be picked up (only `address:` lines).
+function configYml(grpc: number, http: number, ip = '127.0.0.1'): string {
+  return [
+    'server:',
+    `  address: ${ip}:${grpc}`,
+    '  http:',
+    '    enabled: true',
+    `    address: ${ip}:${http}`,
+    '  admin:',
+    '    enabled: true',
+    `    port: ${grpc + 6372}`,
+    'diagnostics:',
+    '  monitoring:',
+    '    enabled: false',
+    '    port: 4104',
+  ].join('\n')
+}
 
 const ENV_KEY = 'SPINDB_TYPEDB_HTTP_OFFSET'
 
@@ -48,5 +69,35 @@ describe('typedb HTTP-port offset', () => {
         `expected fallback for ${JSON.stringify(bad)}`,
       )
     }
+  })
+})
+
+describe('parseTypedbHttpOffsetFromConfig (per-container persistence)', () => {
+  it('recovers the default 6271 offset from a stock config', () => {
+    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(1729, 8000)), 6271)
+  })
+
+  it('recovers a small in-block offset (cloud scheme)', () => {
+    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(47000, 47001)), 1)
+  })
+
+  it('parses 0.0.0.0 addresses (after the cloud bind-address rewrite)', () => {
+    assert.equal(
+      parseTypedbHttpOffsetFromConfig(configYml(47000, 47001, '0.0.0.0')),
+      1,
+    )
+  })
+
+  it('ignores admin/monitoring port lines (only address: lines count)', () => {
+    // admin port is grpc+6372 and monitoring is 4104; if either were picked
+    // up as the "http" port the offset would be wrong.
+    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(2000, 2001)), 1)
+  })
+
+  it('returns null for unparseable/empty config so callers use the default', () => {
+    assert.equal(parseTypedbHttpOffsetFromConfig(''), null)
+    assert.equal(parseTypedbHttpOffsetFromConfig('server:\n  foo: bar'), null)
+    // http <= grpc is nonsensical (never written by initDataDir) -> null
+    assert.equal(parseTypedbHttpOffsetFromConfig(configYml(8000, 8000)), null)
   })
 })


### PR DESCRIPTION
## What

Adds `SPINDB_TYPEDB_HTTP_OFFSET` so a host can move TypeDB's HTTP API port. TypeDB binds its HTTP API at the gRPC port **plus an offset, default 6271** (so the stock 1729 gRPC maps to TypeDB's default 8000 HTTP). Set the env to a positive integer to change it; the default is unchanged, so local + desktop are unaffected.

All HTTP-port derivations go through one `typedbHttpPort()` helper in `cli-utils.ts` — config.yml generation, the start-time port-availability check, the status `/health` probe, the HTTP query client, and `spindb ports` — so they stay consistent under an override. Admin port (`+6372`) is untouched. The offset is read fresh on every start.

## Why

A host that publishes a fixed port block (Layerbase cloud) can set a small in-block offset so TypeDB's HTTP port is reachable directly on the host instead of through a container shell. The default `+6271` lands outside such a block.

## Note on the commits

This branch contains an **add-then-revert pair** for a "persist the offset per container" experiment. It turned out unnecessary for the consumer's design (the offset is supplied by the environment on every start, so nothing needs persisting), so it was reverted. **Net diff = just the configurable offset** + the 0.54.0 version/changelog bump. Safe to merge as-is; a **squash merge** will collapse the add/revert history if you prefer a clean commit.

## Tests

- `tests/unit/typedb-http-offset.test.ts`: default 6271, positive-int override, invalid-value fallback.
- Existing TypeDB port-ownership / status-guard regression test unaffected (default path untouched).
- `tsc --noEmit` + `eslint` clean; bumped to **0.54.0** with a CHANGELOG entry.