### PR TITLE
chore(deps): pin hostdb 0.33.1 - minimal mysql linux-x64 (0.54.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.1] - 2026-06-05
+
+### Changed
+
+- **Pin `hostdb` to `0.33.1`.** Picks up the re-hosted MySQL 8.4.9 and 9.6.0 `linux-x64` binaries, now MySQL's official `-minimal` build (~872 MB → 135 MB and ~1042 MB → 138 MB). Same `mysqld`/`mysql`/`mysqldump`/`mysqladmin` binaries and the same resolved versions — only the `linux-x64` download payload shrinks. Verified end-to-end (`spindb create → seed → backup → restore`) against the minimal build.
+
 ## [0.54.0] - 2026-06-03
 
 ### Added

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.53.0'
+export const VERSION = '0.54.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.33.0",
+    "hostdb": "0.33.1",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.33.0
-        version: 0.33.0
+        specifier: 0.33.1
+        version: 0.33.1
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.33.0:
-    resolution: {integrity: sha512-KRC+YiN+6eWguzXfECu5EahtNomA2uXBadpW7rrarFddSY0mGms48BD6VgsN86cNoWMcU6Q8xQ6CKVv+Fu4SWw==}
+  hostdb@0.33.1:
+    resolution: {integrity: sha512-J5RcXY8qNwEVZBK21AKjlACqO3SRlzfQrW+1WYEO03mJJXPQOHmv6WXSPU/hjx7tH2WN0AegthWhwZ+u71lZNQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.33.0: {}
+  hostdb@0.33.1: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## What

Bumps the `hostdb` pin `0.33.0` → `0.33.1` (spindb → `0.54.1`).

hostdb 0.33.1 re-hosts **MySQL 8.4.9 and 9.6.0 `linux-x64`** as MySQL's official `-minimal` build:

| Version | Before | After |
|---|---|---|
| `mysql-8.4.9` linux-x64 | 872 MB | **135 MB** |
| `mysql-9.6.0` linux-x64 | 1042 MB | **138 MB** |

Same `mysqld`/`mysql`/`mysqldump`/`mysqladmin` binaries and the same resolved versions — only the `linux-x64` download payload shrinks (~84%). No spindb code changes; the version-map wrappers rebuild from hostdb's snapshot automatically.

## Validation

- 1615 unit tests pass locally; build + lint + typecheck clean.
- A full `spindb create → seed → backup → restore → verify` e2e against the minimal build passed (real published spindb driving the minimal binary).
- This PR's **CI matrix** downloads the live minimal `linux-x64` from R2 and exercises it across the integration suite — the gate macOS-local runs can't cover (macOS pulls the unchanged darwin binary).

## Scope

`linux-x64` only — arm64/macOS/Windows binaries are unchanged (MySQL publishes no `-minimal` for them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to v0.54.1
  * Updated MySQL binaries (versions 8.4.9 and 9.6.0) for Linux x64
  * Reduced download payload sizes with verified binary compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->