### PR TITLE
chore(deps): bump hostdb 0.33.2 - drop disabled mysql 8.4.3 (v0.54.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.2] - 2026-06-06
+
+### Changed
+
+- **Pin `hostdb` to `0.33.2`.** hostdb 0.33.2 disables MySQL **8.4.3** (`enabled: false`) - it is superseded by 8.4.9 (the current 8.4 LTS patch, a minimal build). The MySQL version-map wrappers rebuild from hostdb's snapshot, so 8.4.3 is automatically dropped from the resolvable/listed versions; `'8.4'` continues to resolve to 8.4.9. No functional change to any other version.
+
 ## [0.54.1] - 2026-06-05
 
 ### Changed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.54.1'
+export const VERSION = '0.54.2'

--- a/engines/mysql/README.md
+++ b/engines/mysql/README.md
@@ -39,8 +39,8 @@ The `version-maps.ts` file must stay synchronized with hostdb's `releases.json`:
 ```typescript
 export const MYSQL_VERSION_MAP: Record<string, string> = {
   '8.0': '8.0.40',
-  '8.4': '8.4.3',
-  '9': '9.5.0',
+  '8.4': '8.4.9',
+  '9': '9.6.0',
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.33.1",
+    "hostdb": "0.33.2",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.33.1
-        version: 0.33.1
+        specifier: 0.33.2
+        version: 0.33.2
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.33.1:
-    resolution: {integrity: sha512-J5RcXY8qNwEVZBK21AKjlACqO3SRlzfQrW+1WYEO03mJJXPQOHmv6WXSPU/hjx7tH2WN0AegthWhwZ+u71lZNQ==}
+  hostdb@0.33.2:
+    resolution: {integrity: sha512-hoRWVCDiZ6scWvGa/1zEQZgq4N4FKjPXR4uP1fYKCe1l3h59Q0V/ju9tI/fCH0QTI0FGKjXDSiquCiwIHEx8qA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.33.1: {}
+  hostdb@0.33.2: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## What

Bumps the `hostdb` pin `0.33.1` → `0.33.2` (spindb → `0.54.2`).

hostdb 0.33.2 **disables MySQL 8.4.3** (`enabled: false`) — it's superseded by **8.4.9** (the current 8.4 LTS patch, a minimal build). spindb's MySQL version-map wrappers rebuild from hostdb's snapshot, so 8.4.3 is automatically dropped:

- `resolveVersion('mysql','8.4.3')` → **null**; 8.4.3 no longer appears in `listVersions`
- `'8.4'` continues to resolve to **8.4.9** — no change for any consumer that uses the `'8.4'` major (layerbase does)

No functional change to any other version.

## Also

- Fixed a stale example in `engines/mysql/README.md` (`MYSQL_VERSION_MAP` showed `'8.4': '8.4.3'` and `'9': '9.5.0'` → now `8.4.9` / `9.6.0`).

## Validation

- **1615 unit tests pass, 0 fail**; build + `tsc --noEmit` clean.
- Confirmed against the installed hostdb 0.33.2: `8.4.3 → null`, `'8.4' → 8.4.9`, and `listVersions('mysql')` = `9.6.0, 9.5.0, 9.1.0, 8.4.9, 8.0.40` (no 8.4.3).
- The full CI matrix on this PR exercises the engines end-to-end on real Linux runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.54.2

* **Chores**
  * Version bumped to 0.54.2
  * Updated MySQL version mappings: version 8.4.9 now used instead of 8.4.3; version 9.6.0 now used instead of 9.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->