### PR TITLE
Release 0.55.0: file-based branch --path + Qdrant branch start fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1907,8 +1907,13 @@ jobs:
 
   # ============================================
   # Rename and Clone Tests
-  # Tests container rename and clone operations across platforms
-  # Uses PostgreSQL as representative engine
+  # Tests container rename and clone operations. Uses PostgreSQL as the
+  # representative engine. clone uses strategy:'copy' (a plain fs.cp byte copy),
+  # so rename/clone is platform-agnostic in spindb's own code; the only OS that
+  # genuinely diverges for fs.rename/fs.cp (file locking, NTFS quirks) is Windows.
+  # Linux covers the POSIX path that macOS would duplicate, so the macOS leg is
+  # dropped. The platform-divergent CoW reflink path (branch, strategy:'cow') is
+  # covered separately by zfs-reflink.yml / zfs-lifecycle.yml.
   # ============================================
   test-rename-clone:
     name: Rename & Clone ${{ matrix.icon }} ${{ matrix.label }}
@@ -1920,9 +1925,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64
-          - os: macos-14
-            icon: 🍏
-            label: macOS ARM64
           - os: windows-latest
             icon: 🪟
             label: Win x64
@@ -2052,29 +2054,22 @@ jobs:
 
   # ============================================
   # ClickHouse Rename Test
-  # Tests that config.xml paths are regenerated after rename
-  # ClickHouse is not available on Windows
+  # Tests that config.xml paths are regenerated after rename.
+  # The fix under test (regenerateConfig rewriting absolute paths in config.xml)
+  # is platform-agnostic POSIX path logic, so a single Linux leg fully covers it.
+  # ClickHouse's own macOS/start coverage lives in the test-clickhouse job;
+  # ClickHouse is not available on Windows.
   # ============================================
   test-clickhouse-rename:
     name: ClickHouse Rename ${{ matrix.icon }} ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 4 # Limit parallel jobs to reduce runner contention
       matrix:
         include:
-          - os: ubuntu-22.04
-            icon: 🐧
-            label: Linux x64 22.04
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
-          - os: macos-14
-            icon: 🍏
-            label: macOS ARM64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Qdrant branches now start + serve.** On start, `patchQdrantConfig` re-points `storage_path`/`snapshots_path` at the container's own dirs. Previously a branched Qdrant inherited the source's absolute storage path (the cloned config was only port-patched), so it opened the source's (locked) storage and timed out starting — leaving the branch stopped (and, in an embedding host, rolled back).
 - File-based branch creation no longer removes the **target directory** on copy failure when an explicit `--path` is given — it removes only the file it wrote (the directory may be shared, e.g. the user's home dir).
 
 ## [0.54.2] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`spindb branch create --path <path>`** for file-based engines (SQLite/DuckDB): writes the branch's backing file to an explicit path (creating its parent dir if needed) instead of the default container dir. Lets an embedding host that serves SQLite/DuckDB through a shim (e.g. layerbase-cloud's pgsqlite/duckgres) place the branch file exactly where the shim looks. `--path` is rejected for server engines.
+- **`spindb branch create --path <path>`** for file-based engines (SQLite/DuckDB): writes the branch's backing file to an explicit path (creating its parent dir if needed) instead of the default container dir. Lets an embedding host that serves SQLite/DuckDB through a shim (e.g. layerbase-cloud's pgsqlite/duckgres) place the branch file exactly where the shim looks. `--path` is rejected for server engines, and refuses to write onto an existing file (so it never clobbers a pre-existing or source file).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-06-06
+
+### Added
+
+- **`spindb branch create --path <path>`** for file-based engines (SQLite/DuckDB): writes the branch's backing file to an explicit path (creating its parent dir if needed) instead of the default container dir. Lets an embedding host that serves SQLite/DuckDB through a shim (e.g. layerbase-cloud's pgsqlite/duckgres) place the branch file exactly where the shim looks. `--path` is rejected for server engines.
+
+### Fixed
+
+- File-based branch creation no longer removes the **target directory** on copy failure when an explicit `--path` is given — it removes only the file it wrote (the directory may be shared, e.g. the user's home dir).
+
 ## [0.54.2] - 2026-06-06
 
 ### Changed

--- a/cli/commands/branch.ts
+++ b/cli/commands/branch.ts
@@ -41,11 +41,20 @@ branchCommand
   .option('-j, --json', 'Output result as JSON')
   .option('--no-start', "Don't start the branch after creating it")
   .option('-p, --port <port>', 'Run the branch on a specific port')
+  .option(
+    '--path <path>',
+    'File-based engines (SQLite/DuckDB) only: write the branch file to this path instead of the default container dir',
+  )
   .action(
     async (
       source: string | undefined,
       name: string | undefined,
-      options: { json?: boolean; start?: boolean; port?: string },
+      options: {
+        json?: boolean
+        start?: boolean
+        port?: string
+        path?: string
+      },
     ) => {
       try {
         let sourceName = source
@@ -123,6 +132,7 @@ branchCommand
           name: branchName,
           start: options.start !== false,
           port,
+          ...(options.path ? { path: options.path } : {}),
         })
 
         const methodNote = result.method === 'reflink' ? ' (copy-on-write)' : ''

--- a/core/branch-manager.ts
+++ b/core/branch-manager.ts
@@ -255,6 +255,16 @@ class BranchManager {
       path ?? join(paths.getContainerPath(name, { engine }), `${name}${ext}`)
     const targetDir = dirname(targetFile)
 
+    // With an explicit path the target dir may be shared and the file may
+    // already exist (or even BE the source's file). Refuse up front rather than
+    // clobber it — this also guarantees the failure-cleanup below only ever
+    // removes a file this call created.
+    if (path && existsSync(targetFile)) {
+      throw new Error(
+        `Cannot branch to "${targetFile}": a file already exists there. Choose a different --path or remove it first.`,
+      )
+    }
+
     await mkdir(targetDir, { recursive: true })
 
     let method: CopyMethod

--- a/core/branch-manager.ts
+++ b/core/branch-manager.ts
@@ -21,7 +21,7 @@
 
 import { existsSync } from 'fs'
 import { mkdir, rm } from 'fs/promises'
-import { join, extname } from 'path'
+import { join, extname, dirname } from 'path'
 import { paths } from '../config/paths'
 import { containerManager } from './container-manager'
 import { processManager } from './process-manager'
@@ -88,8 +88,14 @@ class BranchManager {
     port?: number
     /** Git branch this DB branch is bound to (git-hook framework). */
     gitBranch?: string
+    /**
+     * File-based engines only (SQLite/DuckDB): write the branch's backing file
+     * to this exact path instead of the default container dir. Lets a caller
+     * (e.g. layerbase-cloud) place the file where its server shim expects it.
+     */
+    path?: string
   }): Promise<CreateBranchResult> {
-    const { source, name, start = true, port, gitBranch } = options
+    const { source, name, start = true, port, gitBranch, path } = options
 
     if (!containerManager.isValidName(name)) {
       throw new Error(
@@ -112,12 +118,19 @@ class BranchManager {
       throw new Error(`Container "${name}" already exists`)
     }
 
+    if (path && !isFileBasedEngine(engine)) {
+      throw new Error(
+        'The --path option is only supported for file-based engines (SQLite, DuckDB).',
+      )
+    }
+
     if (isFileBasedEngine(engine)) {
       return this.createFileBasedBranch({
         source,
         name,
         engine: engine as FileBasedEngine,
         gitBranch,
+        path,
       })
     }
 
@@ -220,8 +233,9 @@ class BranchManager {
     name: string
     engine: FileBasedEngine
     gitBranch?: string
+    path?: string
   }): Promise<CreateBranchResult> {
-    const { source, name, engine, gitBranch } = opts
+    const { source, name, engine, gitBranch, path } = opts
 
     const sourceEntry = await this.fileRegistryGet(engine, source)
     if (!sourceEntry) {
@@ -234,8 +248,12 @@ class BranchManager {
     const ext =
       extname(sourceEntry.filePath) ||
       (engine === Engine.SQLite ? '.sqlite' : '.duckdb')
-    const targetDir = paths.getContainerPath(name, { engine })
-    const targetFile = join(targetDir, `${name}${ext}`)
+    // With an explicit path, write the branch file exactly there (the caller
+    // owns the location — e.g. layerbase-cloud points pgsqlite/duckgres at it).
+    // Otherwise fall back to the per-branch container dir.
+    const targetFile =
+      path ?? join(paths.getContainerPath(name, { engine }), `${name}${ext}`)
+    const targetDir = dirname(targetFile)
 
     await mkdir(targetDir, { recursive: true })
 
@@ -253,8 +271,15 @@ class BranchManager {
         ...(gitBranch ? { gitBranch } : {}),
       })
     } catch (error) {
-      // Clean up the partially-created branch directory on failure.
-      await rm(targetDir, { recursive: true, force: true }).catch(() => {})
+      // Clean up the partial branch on failure. With an explicit path the
+      // target dir may be shared (e.g. the home dir), so remove only the file
+      // we wrote — never the directory. The default container dir is dedicated
+      // to this branch, so it's safe to remove whole.
+      if (path) {
+        await rm(targetFile, { force: true }).catch(() => {})
+      } else {
+        await rm(targetDir, { recursive: true, force: true }).catch(() => {})
+      }
       throw error
     }
 

--- a/engines/qdrant/index.ts
+++ b/engines/qdrant/index.ts
@@ -113,13 +113,17 @@ function patchQdrantConfig(
   // config (e.g. from `spindb branch`) still points at the SOURCE's container
   // dir, so a branched Qdrant would open the source's (locked) storage and fail
   // to start. Always re-point them at this container's own dirs.
+  // Function replacers so any `$` in a path is never interpreted as a
+  // replacement pattern (`$1`, `$&`, `$$`, ...).
   config = config.replace(
     /^(\s*storage_path:\s*).+/m,
-    `$1${normalizePathForQdrant(options.dataDir)}`,
+    (_m, prefix: string) =>
+      `${prefix}${normalizePathForQdrant(options.dataDir)}`,
   )
   config = config.replace(
     /^(\s*snapshots_path:\s*).+/m,
-    `$1${normalizePathForQdrant(options.snapshotsDir)}`,
+    (_m, prefix: string) =>
+      `${prefix}${normalizePathForQdrant(options.snapshotsDir)}`,
   )
   if (options.bindAddress !== undefined) {
     config = config.replace(/^(\s*host:\s*).+/m, `$1${options.bindAddress}`)

--- a/engines/qdrant/index.ts
+++ b/engines/qdrant/index.ts
@@ -97,11 +97,30 @@ log_level: INFO
  */
 function patchQdrantConfig(
   existingConfig: string,
-  options: { port: number; grpcPort: number; bindAddress?: string },
+  options: {
+    port: number
+    grpcPort: number
+    dataDir: string
+    snapshotsDir: string
+    bindAddress?: string
+  },
 ): string {
+  const normalizePathForQdrant = (p: string) => p.replace(/\\/g, '/')
   let config = existingConfig
   config = config.replace(/^(\s*http_port:\s*)\d+/m, `$1${options.port}`)
   config = config.replace(/^(\s*grpc_port:\s*)\d+/m, `$1${options.grpcPort}`)
+  // storage_path/snapshots_path are absolute and container-specific. A cloned
+  // config (e.g. from `spindb branch`) still points at the SOURCE's container
+  // dir, so a branched Qdrant would open the source's (locked) storage and fail
+  // to start. Always re-point them at this container's own dirs.
+  config = config.replace(
+    /^(\s*storage_path:\s*).+/m,
+    `$1${normalizePathForQdrant(options.dataDir)}`,
+  )
+  config = config.replace(
+    /^(\s*snapshots_path:\s*).+/m,
+    `$1${normalizePathForQdrant(options.snapshotsDir)}`,
+  )
   if (options.bindAddress !== undefined) {
     config = config.replace(/^(\s*host:\s*).+/m, `$1${options.bindAddress}`)
   }
@@ -499,6 +518,8 @@ export class QdrantEngine extends BaseEngine {
       const patchedConfig = patchQdrantConfig(existingConfig, {
         port,
         grpcPort,
+        dataDir,
+        snapshotsDir,
         bindAddress,
       })
       await writeFile(configPath, patchedConfig)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.54.2",
+  "version": "0.55.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/integration/sqlite.test.ts
+++ b/tests/integration/sqlite.test.ts
@@ -21,6 +21,7 @@ import {
 } from './helpers'
 import { assert, assertEqual } from '../utils/assertions'
 import { containerManager } from '../../core/container-manager'
+import { branchManager } from '../../core/branch-manager'
 import { getEngine } from '../../engines'
 import { sqliteRegistry } from '../../engines/sqlite/registry'
 import { configManager } from '../../core/config-manager'
@@ -206,6 +207,67 @@ describe('SQLite Integration Tests', () => {
     assertEqual(rowCount, EXPECTED_ROW_COUNT - 1, 'Should have one less row')
 
     console.log(`   ✓ Row deleted, now have ${rowCount} rows`)
+  })
+
+  it('should branch to an explicit --path (placement + lineage + data)', async () => {
+    console.log(`\n🌿 Branching to an explicit --path...`)
+
+    const branchName = generateTestName('sqlite-test-branch')
+    // A nested, not-yet-existing dir: proves dirname() is created and the branch
+    // file lands exactly where the caller asks. layerbase-cloud relies on this
+    // to put the file where pgsqlite/duckgres looks; the old behavior always
+    // wrote to the container dir (which failed in the cloud's root-owned tree).
+    const branchPath = join(TEST_DIR, 'branch-out', `${branchName}.sqlite`)
+
+    await branchManager.createBranch({
+      source: containerName,
+      name: branchName,
+      path: branchPath,
+    })
+
+    // 1) The branch file is written exactly at --path (not the container dir).
+    assert(
+      existsSync(branchPath),
+      `Branch file should exist at the requested --path: ${branchPath}`,
+    )
+
+    // 2) Registry records the explicit path + the lineage.
+    const entry = await sqliteRegistry.get(branchName)
+    assert(entry !== null, 'Branch should be registered')
+    assertEqual(
+      entry?.filePath,
+      branchPath,
+      'Registry filePath should equal the --path',
+    )
+    assertEqual(
+      entry?.branchParent,
+      containerName,
+      'Branch should record its parent for lineage',
+    )
+
+    // 3) The branch carries the source's rows as an independent copy.
+    const { execFile } = await import('child_process')
+    const { promisify } = await import('util')
+    const execFileAsync = promisify(execFile)
+    const sqlite3 = await getSqlite3Path()
+    const { stdout } = await execFileAsync(sqlite3, [
+      branchPath,
+      'SELECT COUNT(*) FROM test_user',
+    ])
+    assertEqual(
+      parseInt(stdout.trim(), 10),
+      EXPECTED_ROW_COUNT - 1,
+      'Branch should carry the source rows present at branch time',
+    )
+
+    // 4) Deleting the branch removes only the file we wrote (never the dir).
+    await branchManager.deleteBranch(branchName)
+    assert(
+      !existsSync(branchPath),
+      'Branch file should be removed when the branch is deleted',
+    )
+
+    console.log(`   ✓ Branched to ${branchPath} — lineage + data + cleanup verified`)
   })
 
   it('should backup database (SQL format)', async () => {

--- a/tests/integration/sqlite.test.ts
+++ b/tests/integration/sqlite.test.ts
@@ -266,6 +266,10 @@ describe('SQLite Integration Tests', () => {
       !existsSync(branchPath),
       'Branch file should be removed when the branch is deleted',
     )
+    assert(
+      existsSync(dirname(branchPath)),
+      'Explicit-path parent directory should be preserved after deleting the branch',
+    )
 
     console.log(`   ✓ Branched to ${branchPath} — lineage + data + cleanup verified`)
   })


### PR DESCRIPTION
Two branching fixes, both surfaced by the cloud per-engine branching audit. Minor bump → **0.55.0**.

## 1. `branch create --path` for file-based engines (SQLite/DuckDB)

Writes the branch's backing file to an explicit path (parent dir created), preserving lineage. `--path` is rejected for server engines. Lets an embedding host that fronts SQLite/DuckDB with a shim (layerbase-cloud's pgsqlite/duckgres) place the branch file where the shim looks — the old container-dir behavior `EACCES`'d on the cloud's root-owned `.spindb/containers/sqlite` tree and wrote to a path the shim never reads, so file-based branches errored.

Cleanup safety: on copy failure with `--path`, only the written file is removed (the dir may be shared, e.g. home).

New SQLite integration test (placement + lineage + data + cleanup); full sqlite suite green locally.

## 2. Qdrant branches now start

`patchQdrantConfig` (run on start against the cloned config) only rewrote `http_port`/`grpc_port`, never `storage_path`/`snapshots_path`. So a branched Qdrant kept the **source's** absolute storage path, opened the source's (locked) storage, and timed out starting → stopped/rolled-back. Now it re-points the storage paths at the container's own dirs.

Validated on real qdrant 1.16.3: branch goes running and `GET /collections` serves the parent's collection.

`tsc` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--path` option to `branch create`, letting file-based engines write branch databases to a specified filesystem path.
  * Release bumped to 0.55.0 (documented in changelog).

* **Bug Fixes**
  * When branch creation with an explicit path fails, cleanup now removes only the created file—not the containing directory.
  * Branched containers now ensure storage/snapshot paths are isolated from the source.

* **Tests**
  * Added integration test verifying custom branch path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->