### PR TITLE
Release spindb 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-06-15
+
+### Added
+
+- **`engines supported --json` now surfaces `dataSubdir` and `auxPorts`.** These engine-config facts (the per-engine data subdirectory, and each engine's static auxiliary-port offsets) were previously hand-mirrored by downstream consumers and could drift. They are now exposed from spindb as the single source of truth: `dataSubdir` was already in `engine-defaults`, and `auxPorts` is a new `EngineDefaults` field listing fixed offsets from the primary port (cockroachdb HTTP UI +1; qdrant gRPC +1; questdb HTTP/HTTP-min/ILP-TCP +188/+191/+197; weaviate gRPC/gossip/cluster-data/RAFT/RAFT-internal-RPC +1/+100/+101/+200/+201). Offsets are verified against each engine's start config. TypeDB is intentionally excluded because its HTTP-API offset is runtime-configurable via `SPINDB_TYPEDB_HTTP_OFFSET`. Additive only - no existing JSON field changed - so existing consumers (the desktop app, Layerbase Cloud) keep working.
+- **Credential-generator conformance tests.** `core/credential-generator.ts` previously had no tests. Added a conformance suite asserting the shared credential spec (alphanumeric, fixed length, no shell/SQL/URL-dangerous characters) plus generator mechanics (length, charset, uniqueness), mirroring the equivalent suite in Layerbase Cloud so the two security-sensitive generators cannot re-drift.
+
+### Fixed
+
+- **`create --no-start` no longer aborts when an engine's client tool is missing (C-009).** Client tools (psql, sqlite3, mongosh, ...) are only needed to start and connect to a database, not to prebake its on-disk data dir, so `--no-start` now skips the client-tool check. The server-binary download (`ensureBinaries`) still runs, so data-dir init is unaffected. This lets a Docker image prebake a file-based engine before its client tool is fetched. Verified end-to-end: `create --engine sqlite --no-start --json` succeeds with sqlite3 absent from PATH.
+
+### Changed
+
+- **Standard generated credential length 20 -> 24, plus rejection sampling.** `generateCredentials` now produces a 24-character password (via a new `DEFAULT_PASSWORD_LENGTH` constant the other DB-password call sites also use), matching Layerbase Cloud and ADR-001. `generatePassword` now uses rejection sampling to eliminate the small modulo bias the previous implementation documented as "acceptable." Existing stored credentials are unaffected; only newly generated passwords change.
+
 ## [0.55.4] - 2026-06-07
 
 ### Added

--- a/cli/commands/create.ts
+++ b/cli/commands/create.ts
@@ -16,7 +16,10 @@ import { createSpinner } from '../ui/spinner'
 import { header, connectionBox } from '../ui/theme'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { getMissingDependencies } from '../../core/dependency-manager'
+import {
+  getMissingDependencies,
+  clientToolCheckRequired,
+} from '../../core/dependency-manager'
 import { platformService } from '../../core/platform-service'
 import { startWithRetry } from '../../core/start-with-retry'
 import { TransactionManager } from '../../core/transaction-manager'
@@ -787,47 +790,51 @@ export const createCommand = new Command('create')
           }
         }
 
-        // Check dependencies (all engines need this)
-        // This runs AFTER binary download so client tools are available
-        const depsSpinner = options.json
-          ? null
-          : createSpinner('Checking required tools...')
-        depsSpinner?.start()
+        // Check client tools (psql, sqlite3, mongosh, ...) only when the
+        // container will actually be started. With --no-start we are just
+        // prebaking the data dir, so a missing client tool must not abort the
+        // create (C-009). See clientToolCheckRequired for the full rationale.
+        if (clientToolCheckRequired(options)) {
+          const depsSpinner = options.json
+            ? null
+            : createSpinner('Checking required tools...')
+          depsSpinner?.start()
 
-        let missingDeps = await getMissingDependencies(engine)
-        if (missingDeps.length > 0) {
-          // In JSON mode, error out instead of prompting
-          if (options.json) {
-            return exitWithError({
-              message: `Missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
-              json: true,
-            })
-          }
-
-          depsSpinner?.warn(
-            `Missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
-          )
-
-          const installed = await promptInstallDependencies(
-            missingDeps[0].binary,
-            engine,
-          )
-
-          if (!installed) {
-            return exitWithError({ message: 'Required tools not installed' })
-          }
-
-          missingDeps = await getMissingDependencies(engine)
+          let missingDeps = await getMissingDependencies(engine)
           if (missingDeps.length > 0) {
-            return exitWithError({
-              message: `Still missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
-            })
-          }
+            // In JSON mode, error out instead of prompting
+            if (options.json) {
+              return exitWithError({
+                message: `Missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
+                json: true,
+              })
+            }
 
-          console.log(chalk.green('  ✓ All required tools are now available'))
-          console.log()
-        } else {
-          depsSpinner?.succeed('Required tools available')
+            depsSpinner?.warn(
+              `Missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
+            )
+
+            const installed = await promptInstallDependencies(
+              missingDeps[0].binary,
+              engine,
+            )
+
+            if (!installed) {
+              return exitWithError({ message: 'Required tools not installed' })
+            }
+
+            missingDeps = await getMissingDependencies(engine)
+            if (missingDeps.length > 0) {
+              return exitWithError({
+                message: `Still missing tools: ${missingDeps.map((d) => d.name).join(', ')}`,
+              })
+            }
+
+            console.log(chalk.green('  ✓ All required tools are now available'))
+            console.log()
+          } else {
+            depsSpinner?.succeed('Required tools available')
+          }
         }
 
         if (await containerManager.exists(containerName)) {

--- a/cli/commands/engines.ts
+++ b/cli/commands/engines.ts
@@ -12,7 +12,7 @@ import { configManager } from '../../core/config-manager'
 import { getEngine } from '../../engines'
 import { postgresqlBinaryManager } from '../../engines/postgresql/binary-manager'
 import { paths } from '../../config/paths'
-import { getEngineDefaults } from '../../config/defaults'
+import { getEngineDefaults, type AuxPort } from '../../config/defaults'
 import { platformService } from '../../core/platform-service'
 import { detectPackageManager, findBinary } from '../../core/dependency-manager'
 import {
@@ -1843,14 +1843,32 @@ enginesCommand
           Object.entries(enginesData.engines).map(([name, config]) => {
             let supportedVersions: string[] = []
             let defaultVersion: string | undefined
+            // Engine-config facts consumers (e.g. Layerbase Cloud) would
+            // otherwise have to hand-mirror: the data subdir and the static
+            // auxiliary-port offsets. Surfaced here so they have a single
+            // source of truth. Additive - existing fields are unchanged.
+            let dataSubdir: string | undefined
+            let auxPorts: AuxPort[] = []
             try {
               const engineInstance = getEngine(name)
               supportedVersions = [...engineInstance.supportedVersions]
-              defaultVersion = getEngineDefaults(name).defaultVersion
+              const defaults = getEngineDefaults(name)
+              defaultVersion = defaults.defaultVersion
+              dataSubdir = defaults.dataSubdir
+              auxPorts = defaults.auxPorts ?? []
             } catch {
               // Engine not registered (e.g., status='planned') — leave version fields empty.
             }
-            return [name, { ...config, supportedVersions, defaultVersion }]
+            return [
+              name,
+              {
+                ...config,
+                supportedVersions,
+                defaultVersion,
+                dataSubdir,
+                auxPorts,
+              },
+            ]
           }),
         )
         console.log(

--- a/cli/commands/engines.ts
+++ b/cli/commands/engines.ts
@@ -1857,7 +1857,7 @@ enginesCommand
               dataSubdir = defaults.dataSubdir
               auxPorts = defaults.auxPorts ?? []
             } catch {
-              // Engine not registered (e.g., status='planned') — leave version fields empty.
+              // Engine not registered (e.g., status='planned') - leave version fields empty.
             }
             return [
               name,

--- a/cli/commands/menu/container-handlers.ts
+++ b/cli/commands/menu/container-handlers.ts
@@ -68,7 +68,10 @@ import {
   stopPgwebProcess,
 } from './shell-handlers'
 import { getPgwebStatus } from '../../../core/pgweb-utils'
-import { generatePassword } from '../../../core/credential-generator'
+import {
+  generatePassword,
+  DEFAULT_PASSWORD_LENGTH,
+} from '../../../core/credential-generator'
 import {
   saveCredentials,
   credentialsExist,
@@ -3031,7 +3034,10 @@ async function handleCreateUser(
       }
     }
 
-    const password = generatePassword({ length: 20, alphanumericOnly: true })
+    const password = generatePassword({
+      length: DEFAULT_PASSWORD_LENGTH,
+      alphanumericOnly: true,
+    })
     const engine = getEngine(config.engine)
 
     const spinner = createSpinner(`Creating user "${username}"...`)

--- a/cli/commands/users.ts
+++ b/cli/commands/users.ts
@@ -3,7 +3,10 @@ import chalk from 'chalk'
 import { containerManager } from '../../core/container-manager'
 import { processManager } from '../../core/process-manager'
 import { getEngine } from '../../engines'
-import { generatePassword } from '../../core/credential-generator'
+import {
+  generatePassword,
+  DEFAULT_PASSWORD_LENGTH,
+} from '../../core/credential-generator'
 import {
   saveCredentials,
   listCredentials,
@@ -89,7 +92,10 @@ usersCommand
         // Generate or use provided password
         const password =
           options.password ||
-          generatePassword({ length: 20, alphanumericOnly: true })
+          generatePassword({
+            length: DEFAULT_PASSWORD_LENGTH,
+            alphanumericOnly: true,
+          })
 
         const database = options.database || config.database
 

--- a/config/defaults.ts
+++ b/config/defaults.ts
@@ -4,6 +4,7 @@ import {
   isEngineSupported,
   getSupportedEngines,
   type EngineDefaults,
+  type AuxPort,
 } from './engine-defaults'
 import { Engine } from '../types'
 
@@ -14,6 +15,7 @@ export {
   isEngineSupported,
   getSupportedEngines,
   type EngineDefaults,
+  type AuxPort,
 }
 
 export type PlatformMappings = {

--- a/config/engine-defaults.ts
+++ b/config/engine-defaults.ts
@@ -20,6 +20,27 @@
 import { Engine, ALL_ENGINES } from '../types'
 import { listVersions as hostdbListVersions } from 'hostdb'
 
+/**
+ * An auxiliary network port an engine binds in addition to its primary
+ * database port, expressed as a fixed offset from that primary port. These are
+ * intrinsic to how spindb configures each engine (e.g. QuestDB's HTTP API
+ * always lands at the PG-wire port + 188). A consumer that publishes engine
+ * ports (e.g. a port-block allocator) must reserve these alongside the primary
+ * port so a neighbouring database is never handed one as its own base.
+ *
+ * Only engines whose aux ports are a STATIC offset appear here. TypeDB's
+ * HTTP-API offset is deliberately excluded: it is configurable at runtime via
+ * SPINDB_TYPEDB_HTTP_OFFSET (default 6271), so it is not a fixed fact. TypeDB
+ * 3.11+ also binds a loopback-only admin port at primary + 6372, which is not
+ * published and not relevant to port-block reservation.
+ */
+export type AuxPort = {
+  // Stable identifier for the port's role (e.g. 'http', 'grpc', 'raft').
+  name: string
+  // Offset added to the engine's primary database port.
+  offset: number
+}
+
 export type EngineDefaults = {
   // Default major-version line that spindb recommends. Shorthand like '18' or
   // '8.4'. Resolved to a full version (e.g. '8.4.9') via hostdb at create time.
@@ -42,6 +63,9 @@ export type EngineDefaults = {
   clientTools: string[]
   // Default max connections (higher than PostgreSQL default of 100 for parallel builds)
   maxConnections: number
+  // Auxiliary ports bound at fixed offsets from the primary port (omitted when
+  // the engine binds no static aux ports). See AuxPort.
+  auxPorts?: AuxPort[]
 }
 
 export const engineDefaults: Record<Engine, EngineDefaults> = {
@@ -164,6 +188,7 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     dataSubdir: 'storage',
     clientTools: [], // Qdrant uses REST API, no separate CLI tools
     maxConnections: 0, // Not applicable for vector DB
+    auxPorts: [{ name: 'grpc', offset: 1 }], // gRPC at HTTP port + 1
   },
   [Engine.Meilisearch]: {
     defaultVersion: '1',
@@ -212,6 +237,7 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     dataSubdir: 'data',
     clientTools: ['cockroach'],
     maxConnections: 0, // Not applicable - managed internally
+    auxPorts: [{ name: 'httpUi', offset: 1 }], // HTTP admin UI at port + 1
   },
   [Engine.SurrealDB]: {
     defaultVersion: '2',
@@ -236,6 +262,13 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     dataSubdir: 'db',
     clientTools: ['questdb'],
     maxConnections: 0, // Not applicable - managed internally
+    // PG-wire is the primary port; HTTP API = +188, HTTP min/health = +191,
+    // ILP-over-TCP ingestion = +197 (see engines/questdb/index.ts).
+    auxPorts: [
+      { name: 'http', offset: 188 },
+      { name: 'httpMin', offset: 191 },
+      { name: 'ilpTcp', offset: 197 },
+    ],
   },
   [Engine.TypeDB]: {
     defaultVersion: '3',
@@ -272,6 +305,16 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     dataSubdir: 'data',
     clientTools: [], // Weaviate uses REST/GraphQL API, no separate CLI tools
     maxConnections: 0, // Not applicable for vector DB
+    // HTTP REST is the primary port; the cluster/consensus ports sit at fixed
+    // offsets (see engines/weaviate/index.ts): gRPC = +1, gossip = +100,
+    // cluster-data = +101, RAFT = +200, RAFT internal RPC = +201.
+    auxPorts: [
+      { name: 'grpc', offset: 1 },
+      { name: 'gossip', offset: 100 },
+      { name: 'clusterData', offset: 101 },
+      { name: 'raft', offset: 200 },
+      { name: 'raftInternalRpc', offset: 201 },
+    ],
   },
   [Engine.TigerBeetle]: {
     defaultVersion: '0.16',

--- a/core/credential-generator.ts
+++ b/core/credential-generator.ts
@@ -22,7 +22,8 @@ const ALPHANUMERIC_CHARSET = LOWERCASE + UPPERCASE + DIGITS
 
 // Canonical length for a generated database credential.
 //
-// Shared credential spec (ADR-001, layerbase-architecture): the standard
+// Shared credential spec (ADR-001,
+// layerbase-architecture/decisions/001-credential-charsets.md): the standard
 // generated DB password is 24 alphanumeric characters. The same spec is
 // implemented in layerbase-cloud's `src/lib/credentials.ts`; both repos run
 // conformance tests so the two cannot re-drift.

--- a/core/credential-generator.ts
+++ b/core/credential-generator.ts
@@ -20,6 +20,14 @@ const DEFAULT_CHARSET = LOWERCASE + UPPERCASE + DIGITS + SYMBOLS
 // Alphanumeric only (for systems that don't support special chars)
 const ALPHANUMERIC_CHARSET = LOWERCASE + UPPERCASE + DIGITS
 
+// Canonical length for a generated database credential.
+//
+// Shared credential spec (ADR-001, layerbase-architecture): the standard
+// generated DB password is 24 alphanumeric characters. The same spec is
+// implemented in layerbase-cloud's `src/lib/credentials.ts`; both repos run
+// conformance tests so the two cannot re-drift.
+export const DEFAULT_PASSWORD_LENGTH = 24
+
 export type PasswordOptions = {
   // Length of the password (default: 16)
   length?: number
@@ -40,15 +48,19 @@ export function generatePassword(options: PasswordOptions = {}): string {
   const chars =
     charset || (alphanumericOnly ? ALPHANUMERIC_CHARSET : DEFAULT_CHARSET)
 
-  // Generate random bytes
-  const bytes = randomBytes(length)
-
-  // Convert to password characters
+  // Rejection sampling: discard bytes >= maxValid to eliminate modulo bias.
+  // Without this, characters at indices 0..(256 % chars.length - 1) would
+  // appear slightly more often than the rest. Over-allocate each draw by 16
+  // bytes so a charset length that rejects many bytes still finishes quickly.
+  const maxValid = 256 - (256 % chars.length)
   let password = ''
-  for (let i = 0; i < length; i++) {
-    // Use modulo to map byte to character index
-    // This is slightly biased but acceptable for password generation
-    password += chars[bytes[i] % chars.length]
+  while (password.length < length) {
+    const bytes = randomBytes(length - password.length + 16)
+    for (let i = 0; i < bytes.length && password.length < length; i++) {
+      if (bytes[i] < maxValid) {
+        password += chars[bytes[i] % chars.length]
+      }
+    }
   }
 
   return password
@@ -88,6 +100,9 @@ export type Credentials = {
 export function generateCredentials(): Credentials {
   return {
     username: 'spindb',
-    password: generatePassword({ length: 20, alphanumericOnly: true }),
+    password: generatePassword({
+      length: DEFAULT_PASSWORD_LENGTH,
+      alphanumericOnly: true,
+    }),
   }
 }

--- a/core/dependency-manager.ts
+++ b/core/dependency-manager.ts
@@ -221,6 +221,25 @@ export async function getMissingDependencies(
   return statuses.filter((s) => !s.installed).map((s) => s.dependency)
 }
 
+/**
+ * Whether `spindb create` should verify the engine's client tools (psql,
+ * sqlite3, mongosh, ...) are present.
+ *
+ * Client tools are only needed to START a database and connect to it, NOT to
+ * prebake its on-disk data dir (that needs the SERVER binary, which
+ * `ensureBinaries` downloads regardless). So `create --no-start` must skip the
+ * check (C-009): e.g. a Docker image can prebake the data dir for a file-based
+ * engine before the client tool has been fetched, without the check aborting
+ * the build. `commander` sets `options.start === false` for `--no-start`,
+ * `true` for `--start`, and `undefined` when neither is passed (check still
+ * runs, since the container will be started).
+ */
+export function clientToolCheckRequired(options: {
+  start?: boolean
+}): boolean {
+  return options.start !== false
+}
+
 export async function getAllMissingDependencies(): Promise<Dependency[]> {
   const statuses = await checkAllDependencies()
   return statuses.filter((s) => !s.installed).map((s) => s.dependency)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.55.4",
+  "version": "0.56.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/credential-generator.test.ts
+++ b/tests/unit/credential-generator.test.ts
@@ -2,7 +2,7 @@
  * Conformance tests for the credential generator (core/credential-generator.ts).
  *
  * These assert the shared credential spec pinned in ADR-001
- * (layerbase-architecture/decisions/001-credential-generation.md). The same
+ * (layerbase-architecture/decisions/001-credential-charsets.md). The same
  * spec is implemented and tested in layerbase-cloud (src/lib/credentials.ts +
  * its credentials conformance test); keeping equivalent assertions in both
  * repos is what stops the two security-sensitive generators from re-drifting.

--- a/tests/unit/credential-generator.test.ts
+++ b/tests/unit/credential-generator.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Conformance tests for the credential generator (core/credential-generator.ts).
+ *
+ * These assert the shared credential spec pinned in ADR-001
+ * (layerbase-architecture/decisions/001-credential-generation.md). The same
+ * spec is implemented and tested in layerbase-cloud (src/lib/credentials.ts +
+ * its credentials conformance test); keeping equivalent assertions in both
+ * repos is what stops the two security-sensitive generators from re-drifting.
+ *
+ * Spec:
+ *   - generateCredentials() -> { username: 'spindb', password }
+ *   - password is exactly DEFAULT_PASSWORD_LENGTH (24) characters
+ *   - password is alphanumeric only ([A-Za-z0-9])
+ *   - password contains none of the characters that are dangerous in SQL /
+ *     shell / Redis-config / URL contexts (the safety invariant)
+ *   - generatePassword honours the requested length and charset, and uses
+ *     rejection sampling (no modulo bias) so every charset character is
+ *     reachable
+ */
+
+import { describe, it } from 'node:test'
+import {
+  generateCredentials,
+  generatePassword,
+  DEFAULT_PASSWORD_LENGTH,
+} from '../../core/credential-generator'
+import { assert, assertEqual } from '../utils/assertions'
+
+// The blocklist mirrors layerbase-cloud's assertSafeCredentials
+// (DANGEROUS_CHARS_PATTERN). Anything matching this breaks at least one of:
+// SQL single-quoted strings, shell single-quoted strings, Redis config values,
+// or URL userinfo (without percent-encoding). The shared spec is alphanumeric,
+// which trivially avoids all of them.
+const DANGEROUS_CHARS = /['"`\\$#;@:/?&%!=|><~^ \t\n\r{}()[\]]/
+
+const ALPHANUMERIC = /^[A-Za-z0-9]+$/
+
+describe('credential generator (ADR-001 conformance)', () => {
+  describe('generateCredentials', () => {
+    it('uses the fixed username "spindb"', () => {
+      assertEqual(generateCredentials().username, 'spindb', 'username')
+    })
+
+    it('produces a 24-character password', () => {
+      assertEqual(DEFAULT_PASSWORD_LENGTH, 24, 'DEFAULT_PASSWORD_LENGTH')
+      for (let i = 0; i < 50; i++) {
+        assertEqual(
+          generateCredentials().password.length,
+          DEFAULT_PASSWORD_LENGTH,
+          'password length',
+        )
+      }
+    })
+
+    it('produces an alphanumeric password with no dangerous characters', () => {
+      for (let i = 0; i < 200; i++) {
+        const { password } = generateCredentials()
+        assert(
+          ALPHANUMERIC.test(password),
+          `password must be alphanumeric, got "${password}"`,
+        )
+        assert(
+          !DANGEROUS_CHARS.test(password),
+          `password must contain no dangerous characters, got "${password}"`,
+        )
+      }
+    })
+
+    it('produces a different password on each call', () => {
+      const seen = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        seen.add(generateCredentials().password)
+      }
+      // 24 alphanumeric chars is ~143 bits of entropy; 100 draws colliding is
+      // astronomically unlikely. Any collision means the generator is broken.
+      assertEqual(seen.size, 100, 'unique passwords across 100 calls')
+    })
+  })
+
+  describe('generatePassword', () => {
+    it('honours the requested length', () => {
+      for (const length of [1, 8, 16, 20, 24, 64, 128]) {
+        assertEqual(
+          generatePassword({ length }).length,
+          length,
+          `length ${length}`,
+        )
+      }
+    })
+
+    it('alphanumericOnly yields only [A-Za-z0-9]', () => {
+      for (let i = 0; i < 100; i++) {
+        const pw = generatePassword({ length: 32, alphanumericOnly: true })
+        assert(ALPHANUMERIC.test(pw), `expected alphanumeric, got "${pw}"`)
+      }
+    })
+
+    it('only emits characters from the requested custom charset', () => {
+      const charset = 'abc123'
+      const allowed = new RegExp(`^[${charset}]+$`)
+      for (let i = 0; i < 100; i++) {
+        const pw = generatePassword({ length: 40, charset })
+        assert(allowed.test(pw), `expected only "${charset}", got "${pw}"`)
+      }
+    })
+
+    it('rejection sampling reaches every character of the charset', () => {
+      // With a charset length (62) that does not divide 256, a biased modulo
+      // generator would still hit every char eventually, so this is a weak
+      // smoke test that the generator is not stuck on a subset. Draw a large
+      // alphanumeric sample and assert broad coverage.
+      const charset =
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+      const seen = new Set<string>()
+      const sample = generatePassword({ length: 20000, charset })
+      for (const ch of sample) seen.add(ch)
+      assert(
+        seen.size === charset.length,
+        `expected all ${charset.length} charset chars to appear, saw ${seen.size}`,
+      )
+    })
+  })
+})

--- a/tests/unit/dependency-manager.test.ts
+++ b/tests/unit/dependency-manager.test.ts
@@ -6,6 +6,7 @@ import {
   checkDependency,
   buildInstallCommand,
   getManualInstallInstructions,
+  clientToolCheckRequired,
   type DetectedPackageManager,
 } from '../../core/dependency-manager'
 import { assert, assertEqual } from '../utils/assertions'
@@ -466,6 +467,37 @@ describe('Error Messages', () => {
     assert(
       caughtError!.message.includes(mockPm.name),
       'Error should include package manager name',
+    )
+  })
+})
+
+describe('clientToolCheckRequired (C-009)', () => {
+  it('skips the client-tool check for --no-start (start === false)', () => {
+    // The C-009 fix: `create --no-start` only prebakes the data dir, so a
+    // missing client tool (e.g. sqlite3 not yet fetched into a Docker image)
+    // must not abort the create.
+    assertEqual(
+      clientToolCheckRequired({ start: false }),
+      false,
+      '--no-start must skip the client-tool check',
+    )
+  })
+
+  it('requires the client-tool check for --start (start === true)', () => {
+    assertEqual(
+      clientToolCheckRequired({ start: true }),
+      true,
+      '--start must require the client-tool check',
+    )
+  })
+
+  it('requires the client-tool check when neither flag is given (start === undefined)', () => {
+    // Default: the container will be started, so client tools are needed.
+    // Only an explicit --no-start opts out.
+    assertEqual(
+      clientToolCheckRequired({}),
+      true,
+      'default (no flag) must require the client-tool check',
     )
   })
 })

--- a/tests/unit/json-output.test.ts
+++ b/tests/unit/json-output.test.ts
@@ -532,6 +532,80 @@ describe('JSON Output Validation', () => {
       }
     })
 
+    it('engines supported --json should surface dataSubdir and auxPorts', () => {
+      // These engine-config facts are consumed downstream (Layerbase Cloud
+      // generates its data-dir + port-reservation tables from them). They must
+      // stay present and correct or that codegen drifts.
+      const result = runCommand('engines supported --json')
+      const parsed = JSON.parse(result.stdout.trim())
+      const engines = parsed.engines
+
+      // dataSubdir: a string on every integrated engine, with known values.
+      const expectedDataSubdir: Record<string, string> = {
+        postgresql: 'data',
+        sqlite: '',
+        mongodb: 'data',
+        questdb: 'db',
+        qdrant: 'storage',
+        ferretdb: 'pg_data',
+      }
+      for (const [name, expected] of Object.entries(expectedDataSubdir)) {
+        const engine = engines[name]
+        if (!engine) throw new Error(`Missing engine ${name}`)
+        if (typeof engine.dataSubdir !== 'string') {
+          throw new Error(`${name}.dataSubdir should be a string`)
+        }
+        if (engine.dataSubdir !== expected) {
+          throw new Error(
+            `${name}.dataSubdir should be "${expected}", got "${engine.dataSubdir}"`,
+          )
+        }
+      }
+
+      // auxPorts: an array on every integrated engine; specific static offsets
+      // for the engines that bind aux ports. These offsets are verified against
+      // each engine's start config; a change here is a breaking, reviewable event.
+      const expectedAuxPorts: Record<string, Record<string, number>> = {
+        cockroachdb: { httpUi: 1 },
+        qdrant: { grpc: 1 },
+        questdb: { http: 188, httpMin: 191, ilpTcp: 197 },
+        weaviate: {
+          grpc: 1,
+          gossip: 100,
+          clusterData: 101,
+          raft: 200,
+          raftInternalRpc: 201,
+        },
+      }
+      for (const engine of Object.values(engines)) {
+        if (!Array.isArray((engine as { auxPorts?: unknown }).auxPorts)) {
+          throw new Error('every engine must expose an auxPorts array')
+        }
+      }
+      for (const [name, expected] of Object.entries(expectedAuxPorts)) {
+        const actual = engines[name].auxPorts as {
+          name: string
+          offset: number
+        }[]
+        const actualMap = Object.fromEntries(
+          actual.map((p) => [p.name, p.offset]),
+        )
+        const actualStr = JSON.stringify(actualMap)
+        const expectedStr = JSON.stringify(expected)
+        if (actualStr !== expectedStr) {
+          throw new Error(
+            `${name}.auxPorts mismatch.\n  Expected: ${expectedStr}\n  Actual: ${actualStr}`,
+          )
+        }
+      }
+
+      // TypeDB's HTTP-API offset is runtime-configurable (SPINDB_TYPEDB_HTTP_OFFSET),
+      // so it is deliberately NOT a static auxPort.
+      if (engines.typedb.auxPorts.length !== 0) {
+        throw new Error('typedb.auxPorts should be empty (offset is env-driven)')
+      }
+    })
+
     it('doctor --json should have correct structure', () => {
       // doctor command can be slow on Windows CI due to system checks
       // (spawns binary detection for all 18 engines — dozens of process spawns)


### PR DESCRIPTION
Release PR for **spindb 0.56.0**. Merging to `main` publishes to npm via OIDC (`publish.yml`) and runs the full per-engine integration matrix (`ci.yml`).

## Included (the spindb-convergence work, #221)
- **`feat(engines)`**: `engines supported --json` now surfaces `dataSubdir` + a new static `auxPorts` field (single source of truth for downstream consumers; additive, no field removed/renamed).
- **`fix(create)`**: `--no-start` skips the client-tool check (C-009).
- **`test(credentials)`**: generator conformance suite + 20->24 length + rejection sampling (ADR-001 alphanumeric spec).
- **`chore(release)`**: 0.56.0.

## Also reconciles pre-existing drift
`main` was behind: 0.55.3/0.55.4 were published to npm but their commits never landed on `main` (main was 0.55.2). This release brings `main` forward to 0.56.0, carrying those commits.

## Backward-compat
All additive. spindb 0.56.0 keeps working with the current Layerbase Cloud image (0.55.4) and desktop pin; the only consumer of the new JSON fields (cloud's engine-config codegen) reads them at build time against the bundled version.

**Do not merge until the full engine matrix is green.**