### PR TITLE
feat(restore): --into-existing non-destructive in-place restore (P1 increment 1: foundation + PostgreSQL)

### DIFF
--- a/cli/commands/restore.ts
+++ b/cli/commands/restore.ts
@@ -35,6 +35,10 @@ export const restoreCommand = new Command('restore')
     'Pull data from a remote database connection string',
   )
   .option('-f, --force', 'Overwrite existing database without confirmation')
+  .option(
+    '--into-existing',
+    'Restore INTO an existing database without dropping/recreating it (non-destructive to the database object; replaces its contents). The database must already exist. Safe to run against a live database with open connections (e.g. behind a connection pooler).',
+  )
   .option('-j, --json', 'Output result as JSON')
   .action(
     async (
@@ -44,6 +48,7 @@ export const restoreCommand = new Command('restore')
         database?: string
         fromUrl?: string
         force?: boolean
+        intoExisting?: boolean
         json?: boolean
       },
     ) => {
@@ -115,6 +120,22 @@ export const restoreCommand = new Command('restore')
 
         const { engine: engineName } = config
         const engine = getEngine(engineName)
+
+        // --into-existing does a faithful in-place REPLACE only for engines
+        // whose restore drops + recreates each object (so the contents are
+        // replaced, not merged into). This allowlist grows one engine at a time
+        // as each gets clean-restore support plus an integration round-trip test
+        // - never silently merge on an engine that can't replace.
+        const INTO_EXISTING_ENGINES = new Set(['postgresql'])
+        if (options.intoExisting && !INTO_EXISTING_ENGINES.has(engineName)) {
+          const msg = `--into-existing is not yet supported for ${engineName}. Restore without it (drop + recreate the database) instead.`
+          if (options.json) {
+            console.log(JSON.stringify({ error: msg }))
+          } else {
+            console.log(chalk.red(`\n  ${msg}\n`))
+          }
+          process.exit(1)
+        }
 
         // Check if container needs to be running for restore
         // - File-based engines (SQLite, DuckDB) don't need to be running
@@ -355,7 +376,22 @@ export const restoreCommand = new Command('restore')
         const databaseExists =
           config.databases && config.databases.includes(databaseName)
 
-        if (databaseExists) {
+        // --into-existing requires the database to already exist - it never
+        // creates one (that is the destructive path's job) and it never drops
+        // it. Fail clearly rather than silently doing nothing.
+        if (options.intoExisting && !databaseExists) {
+          const msg = `Database "${databaseName}" does not exist. Restore without --into-existing to create it.`
+          if (options.json) {
+            console.log(JSON.stringify({ error: msg }))
+          } else {
+            console.log(chalk.red(`\n  ${msg}\n`))
+          }
+          process.exit(1)
+        }
+
+        // The drop+recreate path is destructive; --into-existing skips it
+        // entirely and restores into the live database in place.
+        if (databaseExists && !options.intoExisting) {
           if (!options.force) {
             // In JSON mode, just error out - no interactive prompts
             if (options.json) {
@@ -414,54 +450,68 @@ export const restoreCommand = new Command('restore')
         let databaseCreated = false
 
         const dbSpinner = createSpinner(
-          `Creating database "${databaseName}"...`,
+          options.intoExisting
+            ? `Preparing existing database "${databaseName}"...`
+            : `Creating database "${databaseName}"...`,
         )
         dbSpinner.start()
 
         try {
-          await engine.createDatabase(config, databaseName)
-          databaseCreated = true
-          dbSpinner.succeed(`Database "${databaseName}" ready`)
+          if (!options.intoExisting) {
+            await engine.createDatabase(config, databaseName)
+            databaseCreated = true
+            dbSpinner.succeed(`Database "${databaseName}" ready`)
 
-          // File-based engines (SQLite, DuckDB) don't need database tracking
-          // They use a registry and the file IS the database
-          if (!isFileBasedEngine(engineName)) {
-            // Register rollback to drop database if restore fails
-            tx.addRollback({
-              description: `Drop database "${databaseName}"`,
-              execute: async () => {
-                try {
-                  await engine.dropDatabase(config, databaseName)
-                  logDebug(`Rolled back: dropped database "${databaseName}"`)
-                } catch (dropErr) {
-                  logDebug(
-                    `Failed to drop database during rollback: ${dropErr instanceof Error ? dropErr.message : String(dropErr)}`,
-                  )
-                }
-              },
-            })
+            // File-based engines (SQLite, DuckDB) don't need database tracking
+            // They use a registry and the file IS the database
+            if (!isFileBasedEngine(engineName)) {
+              // Register rollback to drop database if restore fails
+              tx.addRollback({
+                description: `Drop database "${databaseName}"`,
+                execute: async () => {
+                  try {
+                    await engine.dropDatabase(config, databaseName)
+                    logDebug(`Rolled back: dropped database "${databaseName}"`)
+                  } catch (dropErr) {
+                    logDebug(
+                      `Failed to drop database during rollback: ${dropErr instanceof Error ? dropErr.message : String(dropErr)}`,
+                    )
+                  }
+                },
+              })
 
-            await containerManager.addDatabase(containerName, databaseName)
+              await containerManager.addDatabase(containerName, databaseName)
 
-            // Register rollback to remove database from container tracking
-            tx.addRollback({
-              description: `Remove "${databaseName}" from container tracking`,
-              execute: async () => {
-                try {
-                  await containerManager.removeDatabase(
-                    containerName,
-                    databaseName,
-                  )
-                  logDebug(
-                    `Rolled back: removed "${databaseName}" from container tracking`,
-                  )
-                } catch (removeErr) {
-                  logDebug(
-                    `Failed to remove database from tracking during rollback: ${removeErr instanceof Error ? removeErr.message : String(removeErr)}`,
-                  )
-                }
-              },
-            })
+              // Register rollback to remove database from container tracking
+              tx.addRollback({
+                description: `Remove "${databaseName}" from container tracking`,
+                execute: async () => {
+                  try {
+                    await containerManager.removeDatabase(
+                      containerName,
+                      databaseName,
+                    )
+                    logDebug(
+                      `Rolled back: removed "${databaseName}" from container tracking`,
+                    )
+                  } catch (removeErr) {
+                    logDebug(
+                      `Failed to remove database from tracking during rollback: ${removeErr instanceof Error ? removeErr.message : String(removeErr)}`,
+                    )
+                  }
+                },
+              })
+            }
+          } else {
+            // --into-existing: the database already exists and is deliberately
+            // NEITHER dropped NOR recreated, and NO drop-on-failure rollback is
+            // registered - we must never drop the caller's existing data. The
+            // engine restore replaces the contents in place (e.g. pg_restore
+            // --clean --if-exists drops + recreates each object), which is safe
+            // while live connections (a pooler, a health monitor) stay open.
+            dbSpinner.succeed(
+              `Restoring into existing database "${databaseName}"`,
+            )
           }
 
           const restoreSpinner = createSpinner('Restoring backup...')
@@ -470,6 +520,9 @@ export const restoreCommand = new Command('restore')
           const result = await engine.restore(config, backupPath, {
             database: databaseName,
             createDatabase: false,
+            // Object-level clean so an in-place restore is a faithful REPLACE
+            // (not a merge into the existing contents).
+            ...(options.intoExisting ? { clean: true } : {}),
           })
 
           // Check if restore completely failed (non-zero code with no data restored)

--- a/engines/postgresql/restore.ts
+++ b/engines/postgresql/restore.ts
@@ -130,6 +130,35 @@ export type RestoreOptions = {
   format?: string
   pgRestorePath?: string
   containerVersion?: string
+  /**
+   * Restore INTO an existing database without dropping it first (the caller
+   * already guarantees the database exists). When set, `pg_restore` is given
+   * `--clean --if-exists` so each object is dropped and recreated, replacing the
+   * database's contents while leaving the database itself (and any live
+   * connections to it) untouched. Used by the non-destructive `restore
+   * --into-existing` path. Only affects the custom/tar (`pg_restore`) format;
+   * plain-SQL dumps carry their own DROP statements (or not) and are replayed
+   * as-is.
+   */
+  clean?: boolean
+}
+
+/**
+ * Build the `pg_restore` command for a custom/tar dump. Pure (no I/O) so the
+ * argument construction - especially the `--clean --if-exists` that makes
+ * `--into-existing` a faithful replace - is unit-testable.
+ */
+export function buildPgRestoreCommand(args: {
+  restorePath: string
+  port: number
+  user: string
+  database: string
+  formatFlag: string
+  backupPath: string
+  clean?: boolean
+}): string {
+  const cleanFlags = args.clean ? ' --clean --if-exists' : ''
+  return `"${args.restorePath}" -h 127.0.0.1 -p ${args.port} -U ${args.user} -d ${args.database} --no-owner --no-privileges${cleanFlags} ${args.formatFlag} "${args.backupPath}"`
 }
 
 /**
@@ -274,6 +303,7 @@ export async function restoreBackup(
     format,
     pgRestorePath,
     containerVersion,
+    clean,
   } = options
   const execOptions = {
     maxBuffer: 50 * 1024 * 1024,
@@ -324,7 +354,15 @@ export async function restoreBackup(
             ? '-Ft'
             : ''
       const result = await execAsync(
-        `"${restorePath}" -h 127.0.0.1 -p ${port} -U ${user} -d ${database} --no-owner --no-privileges ${formatFlag} "${backupPath}"`,
+        buildPgRestoreCommand({
+          restorePath,
+          port,
+          user,
+          database,
+          formatFlag,
+          backupPath,
+          clean,
+        }),
         execOptions,
       )
 

--- a/tests/integration/postgresql.test.ts
+++ b/tests/integration/postgresql.test.ts
@@ -454,6 +454,79 @@ describe('PostgreSQL Integration Tests', () => {
     console.log(`   ✓ Custom format backup created with ${result.size} bytes`)
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(`\n♻️  Testing in-place clean restore (replace, not merge)...`)
+
+    const engine = getEngine(ENGINE)
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    // Capture current state and back it up (custom format -> pg_restore path).
+    const before = await executeQuery(
+      containerName,
+      'SELECT count(*)::int AS n FROM test_user',
+      DATABASE,
+    )
+    const beforeCount = before.rows[0].n as number
+
+    const { tmpdir } = await import('os')
+    const backupPath = join(tmpdir(), `pg-into-existing-${Date.now()}.dump`)
+    await engine.backup(config!, backupPath, {
+      database: DATABASE,
+      format: 'custom',
+    })
+
+    // Diverge the LIVE database: add a row that is NOT in the backup.
+    await executeQuery(
+      containerName,
+      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+      DATABASE,
+    )
+    const diverged = await executeQuery(
+      containerName,
+      'SELECT count(*)::int AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      diverged.rows[0].n,
+      beforeCount + 1,
+      'live DB should have diverged from the backup',
+    )
+
+    // Restore INTO the existing database with object-level clean. This is the
+    // engine half of `restore --into-existing`: it must drop+recreate each
+    // object (a faithful REPLACE, not a merge) while NEVER dropping the database
+    // itself - so a live connection / pooler is undisturbed.
+    const result = await engine.restore(config!, backupPath, {
+      database: DATABASE,
+      createDatabase: false,
+      clean: true,
+    })
+    assert(
+      result.code === 0 || !result.stderr?.includes('FATAL'),
+      'restore should not fatally fail',
+    )
+
+    // The extra row is gone -> contents were REPLACED, not merged.
+    const after = await executeQuery(
+      containerName,
+      'SELECT count(*)::int AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      after.rows[0].n,
+      beforeCount,
+      'clean restore should replace contents (extra row gone), not merge or error',
+    )
+
+    const { rm } = await import('fs/promises')
+    await rm(backupPath, { force: true })
+
+    console.log(
+      `   ✓ In-place clean restore replaced contents (${beforeCount} rows) without dropping the database`,
+    )
+  })
+
   it('should restore from SQL format and verify data', async () => {
     console.log(`\n📥 Testing SQL format restore...`)
 

--- a/tests/unit/postgresql-restore.test.ts
+++ b/tests/unit/postgresql-restore.test.ts
@@ -1,0 +1,50 @@
+/**
+ * PostgreSQL restore module unit tests
+ */
+
+import { describe, it } from 'node:test'
+import { assert } from '../utils/assertions'
+import { buildPgRestoreCommand } from '../../engines/postgresql/restore'
+
+describe('PostgreSQL Restore Module', () => {
+  describe('buildPgRestoreCommand', () => {
+    const base = {
+      restorePath: '/bin/pg_restore',
+      port: 10000,
+      user: 'postgres',
+      database: 'mydb',
+      formatFlag: '-Fc',
+      backupPath: '/tmp/backup.dump',
+    }
+
+    it('targets the local engine with owner/privilege stripping and the format flag', () => {
+      const cmd = buildPgRestoreCommand(base)
+      assert(cmd.includes('-h 127.0.0.1'), 'connects to localhost')
+      assert(cmd.includes('-p 10000'), 'uses the port')
+      assert(cmd.includes('-U postgres'), 'uses the user')
+      assert(cmd.includes('-d mydb'), 'targets the database')
+      assert(cmd.includes('--no-owner --no-privileges'), 'strips owner/privs')
+      assert(cmd.includes('-Fc'), 'passes the format flag')
+      assert(cmd.includes('"/tmp/backup.dump"'), 'quotes the backup path')
+    })
+
+    it('omits --clean by default (additive into an empty, just-created DB)', () => {
+      const cmd = buildPgRestoreCommand(base)
+      assert(!cmd.includes('--clean'), 'no --clean without the flag')
+      assert(!cmd.includes('--if-exists'), 'no --if-exists without the flag')
+    })
+
+    it('adds --clean --if-exists when clean is set (the --into-existing REPLACE)', () => {
+      // For an in-place restore into a live database we must drop + recreate each
+      // object so the result REPLACES the contents (not merges into them), while
+      // leaving the database itself (and its open connections) untouched.
+      const cmd = buildPgRestoreCommand({ ...base, clean: true })
+      assert(cmd.includes('--clean --if-exists'), 'includes --clean --if-exists')
+      // ordering: clean flags before the format flag and the file
+      assert(
+        cmd.indexOf('--clean --if-exists') < cmd.indexOf('-Fc'),
+        'clean flags precede the format flag',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds a `spindb restore … --into-existing` mode: restore **into an existing database without dropping/recreating it**, so it's safe to run against a live database with open connections (a connection pooler, a health monitor). This is the foundation for letting Layerbase Cloud delegate **restore** to spindb - the half of the backup/restore convergence (WS-A) we deferred because spindb's restore was destructive.

## The key finding

spindb's restore wasn't destructive because of the engines - the `DROP DATABASE` + recreate lives in the **CLI orchestration** (`cli/commands/restore.ts`), and the per-engine restore functions mostly restore additively into the existing DB. So `--into-existing` is a CLI-level branch, not an engine rewrite.

## What this increment does

- **`--into-existing` flag.** When set it: requires the DB to already exist; **skips the drop, the recreate, AND the drop-on-failure rollback** (a failed in-place restore must never drop the caller's data - double-guarded: `databaseCreated` stays false *and* no rollbacks are registered); and passes object-level `clean` so the result is a faithful **REPLACE**, not a merge.
- **Engine allowlist.** `--into-existing` is gated to engines that can actually replace-in-place (drop+recreate each object). **postgresql only** in this increment; the set grows one engine at a time as each gets clean-restore support + an integration round-trip test. Unsupported engines get a clear error - never a silent merge.
- **PostgreSQL `clean`** → `pg_restore --clean --if-exists`, extracted into a pure `buildPgRestoreCommand()` so the argument construction is unit-testable.

## Tests

- **Unit** (`tests/unit/postgresql-restore.test.ts`): `buildPgRestoreCommand` adds `--clean --if-exists` iff `clean`, omits it otherwise, correct ordering. 
- **Integration** (`tests/integration/postgresql.test.ts`, runs against real postgres): back up → insert a row NOT in the backup → `engine.restore(clean:true)` → the extra row is gone (replaced, not merged) and the database is still live/queryable (never dropped). **Passed locally (22/22 pg integration tests).**
- Full unit suite **1631 pass / 0 fail**; `pnpm lint` (eslint + tsc) clean.

## Safety / scope

- **Purely additive.** Existing restore (without `--into-existing`) is byte-identical - the new behavior is fully gated on the flag, and the flag is gated to postgresql.
- No cloud change here. The cloud delegating restore is a later step (per engine, drill-gated) after this releases.

## Not in this increment (the roadmap)

- Clean-restore support + integration tests for the rest of the wire/HTTP engines (mysql/mariadb self-clean via the dump; mongo/ferret via `--drop`; cockroach/clickhouse/questdb already honor `clean`; surrealdb/typedb/influxdb/couchdb need it added) - each added to the allowlist as it's verified.
- File-swap engines (redis/sqlite/duckdb/qdrant/meili/weaviate/tigerbeetle/libsql) are full-replacement + need a process/proxy restart → that's **P2**, coupled to the cloud's proxy/pooler supervisor work (WS-E).