### PR TITLE
feat(restore): --into-existing for mysql + mariadb (wire-engine batch)

### DIFF
--- a/cli/commands/restore.ts
+++ b/cli/commands/restore.ts
@@ -126,7 +126,11 @@ export const restoreCommand = new Command('restore')
         // replaced, not merged into). This allowlist grows one engine at a time
         // as each gets clean-restore support plus an integration round-trip test
         // - never silently merge on an engine that can't replace.
-        const INTO_EXISTING_ENGINES = new Set(['postgresql'])
+        const INTO_EXISTING_ENGINES = new Set([
+          'postgresql',
+          'mysql',
+          'mariadb',
+        ])
         if (options.intoExisting && !INTO_EXISTING_ENGINES.has(engineName)) {
           const msg = `--into-existing is not yet supported for ${engineName}. Restore without it (drop + recreate the database) instead.`
           if (options.json) {

--- a/tests/integration/mariadb.test.ts
+++ b/tests/integration/mariadb.test.ts
@@ -346,6 +346,86 @@ describe('MariaDB Integration Tests', () => {
     console.log(`   ✓ SQL backup created with ${result.size} bytes`)
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(`\n♻️  Testing in-place restore (replace, not merge)...`)
+
+    const engine = getEngine(ENGINE)
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    // Capture current state and back it up (SQL - the format the cloud pins for
+    // MariaDB). The dump carries DROP TABLE IF EXISTS (mariadb-dump default), so
+    // replaying it REPLACES each table in place - no engine `clean` flag needed.
+    const before = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    const beforeCount = Number(before.rows[0].n)
+
+    const { tmpdir } = await import('os')
+    const backupPath = join(tmpdir(), `mariadb-into-existing-${Date.now()}.sql`)
+    await engine.backup(config!, backupPath, {
+      database: DATABASE,
+      format: 'sql',
+    })
+
+    // The self-clean mechanism that makes an in-place replay a faithful replace.
+    const { readFile, rm } = await import('fs/promises')
+    const dumpText = await readFile(backupPath, 'utf-8')
+    assert(
+      dumpText.includes('DROP TABLE IF EXISTS'),
+      'mariadb-dump should emit DROP TABLE IF EXISTS (self-clean on replay)',
+    )
+
+    // Diverge the LIVE database: add a row NOT in the backup.
+    await executeQuery(
+      containerName,
+      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+      DATABASE,
+    )
+    const diverged = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      Number(diverged.rows[0].n),
+      beforeCount + 1,
+      'live DB should have diverged from the backup',
+    )
+
+    // Restore INTO the existing database (createDatabase:false -> no DROP
+    // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
+    const result = await engine.restore(config!, backupPath, {
+      database: DATABASE,
+      createDatabase: false,
+      clean: true,
+    })
+    assert(
+      result.code === 0 || !result.stderr?.includes('FATAL'),
+      'restore should not fatally fail',
+    )
+
+    // Extra row gone -> contents REPLACED, not merged.
+    const after = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      Number(after.rows[0].n),
+      beforeCount,
+      'in-place restore should replace contents (extra row gone), not merge',
+    )
+
+    await rm(backupPath, { force: true })
+
+    console.log(
+      `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
+    )
+  })
+
   it('should backup to compressed format (.sql.gz)', async () => {
     console.log(`\n📦 Testing compressed format backup (.sql.gz)...`)
 

--- a/tests/integration/mysql.test.ts
+++ b/tests/integration/mysql.test.ts
@@ -348,6 +348,86 @@ describe('MySQL Integration Tests', () => {
     console.log(`   ✓ SQL backup created with ${result.size} bytes`)
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(`\n♻️  Testing in-place restore (replace, not merge)...`)
+
+    const engine = getEngine(ENGINE)
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    // Capture current state and back it up (SQL - the format the cloud pins for
+    // MySQL). The dump carries DROP TABLE IF EXISTS (mysqldump default), so
+    // replaying it REPLACES each table in place - no engine `clean` flag needed.
+    const before = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    const beforeCount = Number(before.rows[0].n)
+
+    const { tmpdir } = await import('os')
+    const backupPath = join(tmpdir(), `mysql-into-existing-${Date.now()}.sql`)
+    await engine.backup(config!, backupPath, {
+      database: DATABASE,
+      format: 'sql',
+    })
+
+    // The self-clean mechanism that makes an in-place replay a faithful replace.
+    const { readFile, rm } = await import('fs/promises')
+    const dumpText = await readFile(backupPath, 'utf-8')
+    assert(
+      dumpText.includes('DROP TABLE IF EXISTS'),
+      'mysqldump should emit DROP TABLE IF EXISTS (self-clean on replay)',
+    )
+
+    // Diverge the LIVE database: add a row NOT in the backup.
+    await executeQuery(
+      containerName,
+      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+      DATABASE,
+    )
+    const diverged = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      Number(diverged.rows[0].n),
+      beforeCount + 1,
+      'live DB should have diverged from the backup',
+    )
+
+    // Restore INTO the existing database (createDatabase:false -> no DROP
+    // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
+    const result = await engine.restore(config!, backupPath, {
+      database: DATABASE,
+      createDatabase: false,
+      clean: true,
+    })
+    assert(
+      result.code === 0 || !result.stderr?.includes('FATAL'),
+      'restore should not fatally fail',
+    )
+
+    // Extra row gone -> contents REPLACED, not merged.
+    const after = await executeQuery(
+      containerName,
+      'SELECT COUNT(*) AS n FROM test_user',
+      DATABASE,
+    )
+    assertEqual(
+      Number(after.rows[0].n),
+      beforeCount,
+      'in-place restore should replace contents (extra row gone), not merge',
+    )
+
+    await rm(backupPath, { force: true })
+
+    console.log(
+      `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
+    )
+  })
+
   it('should backup to compressed format (.sql.gz)', async () => {
     console.log(`\n📦 Testing compressed format backup (.sql.gz)...`)
 


### PR DESCRIPTION
Second engine increment of non-destructive restore (after PostgreSQL #225). Batching the wire engines on `dev` before one spindb release.

## What
Adds **mysql** and **mariadb** to the `--into-existing` allowlist. **No engine code change** - their dumps carry `DROP TABLE IF EXISTS` (mysqldump/mariadb-dump default, confirmed: no `--skip-add-drop-table`), so replaying into the existing database REPLACES each table in place. This is exactly what the cloud's legacy `mysql < dump` / `mariadb < dump` restore already does, so delegation will be behavior-preserving.

## Tests (real engines, locally verified)
For each: back up (SQL format, the cloud's pin) → assert the dump contains `DROP TABLE IF EXISTS` → insert a row NOT in the backup → `restore` into the existing DB → the extra row is gone (replaced, not merged) and the database is never dropped. **mysql 21/21, mariadb 21/21**; lint/tsc clean.

## Allowlist now
`postgresql, mysql, mariadb`. Next: mongo/ferret (already `--drop` by default), then cockroach/clickhouse/questdb (already honor `clean`), then the additive engines that need `clean` added (surrealdb/typedb/influxdb/couchdb). Then one spindb release → cloud delegates restore per engine (drill-gated).