### PR TITLE
feat(restore): --into-existing for cockroach/clickhouse/questdb/mongo/ferret (completes the wire engines)

### DIFF
--- a/cli/commands/restore.ts
+++ b/cli/commands/restore.ts
@@ -130,6 +130,11 @@ export const restoreCommand = new Command('restore')
           'postgresql',
           'mysql',
           'mariadb',
+          'mongodb',
+          'ferretdb',
+          'cockroachdb',
+          'clickhouse',
+          'questdb',
         ])
         if (options.intoExisting && !INTO_EXISTING_ENGINES.has(engineName)) {
           const msg = `--into-existing is not yet supported for ${engineName}. Restore without it (drop + recreate the database) instead.`

--- a/tests/integration/clickhouse.test.ts
+++ b/tests/integration/clickhouse.test.ts
@@ -403,6 +403,100 @@ describe(
       console.log('   Container cloned via backup/restore')
     })
 
+    it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+      console.log(
+        `\n Verifying clean restore replaces (not merges) into the live source DB...`,
+      )
+
+      const config = await containerManager.getConfig(containerName)
+      assert(config !== null, 'Source container config should exist')
+
+      const engine = getEngine(ENGINE)
+      const { tmpdir } = await import('os')
+      const { rm } = await import('fs/promises')
+      const backupPath = join(
+        tmpdir(),
+        `clickhouse-clean-restore-${Date.now()}.sql`,
+      )
+
+      try {
+        // 1. Capture the current row count of the live source DB
+        const before = await getRowCount(
+          ENGINE,
+          testPorts[0],
+          DATABASE,
+          'test_user',
+        )
+
+        // 2. Back up the current state (this becomes the "source of truth")
+        await engine.backup(config!, backupPath, {
+          database: DATABASE,
+          format: 'sql',
+        })
+
+        // 3. Insert ONE extra row that is NOT in the backup.
+        //    Plain MergeTree INSERTs are synchronously visible (unlike async
+        //    ALTER ... DELETE mutations), so no system.mutations wait is needed.
+        await runScriptSQL(
+          containerName,
+          "INSERT INTO test_user (id, name, email) VALUES (9001, 'Ghost Row', 'ghost@example.com')",
+          DATABASE,
+        )
+
+        // 4. Assert the extra row is present: count is now before + 1
+        const afterInsert = await getRowCount(
+          ENGINE,
+          testPorts[0],
+          DATABASE,
+          'test_user',
+        )
+        assertEqual(
+          afterInsert,
+          before + 1,
+          'Extra row should be visible before restore',
+        )
+
+        // 5. Clean restore into the EXISTING database: clean:true drops + reloads
+        //    each table from the backup (DROP TABLE IF EXISTS per table), so the
+        //    extra row disappears. The database itself is never dropped.
+        await engine.restore(config!, backupPath, {
+          database: DATABASE,
+          clean: true,
+        })
+
+        // 6. Assert contents were REPLACED (not merged): count is back to `before`,
+        //    the ghost row is gone, and the table is still queryable.
+        const afterRestore = await getRowCount(
+          ENGINE,
+          testPorts[0],
+          DATABASE,
+          'test_user',
+        )
+        assertEqual(
+          afterRestore,
+          before,
+          'Clean restore should REPLACE contents (extra row removed), not merge',
+        )
+
+        const ghostCheck = await executeQuery(
+          containerName,
+          'SELECT count() AS count FROM test_user WHERE id = 9001',
+          DATABASE,
+        )
+        assertEqual(
+          Number(ghostCheck.rows[0].count),
+          0,
+          'Extra (non-backup) row should be gone after clean restore',
+        )
+
+        console.log(
+          `   Clean restore replaced contents: ${before} -> ${afterInsert} -> ${afterRestore} rows`,
+        )
+      } finally {
+        await rm(backupPath, { force: true }).catch(() => {})
+      }
+    })
+
     it('should verify restored data matches source', async () => {
       console.log(`\n Verifying restored data...`)
 

--- a/tests/integration/cockroachdb.test.ts
+++ b/tests/integration/cockroachdb.test.ts
@@ -249,6 +249,80 @@ describe('CockroachDB Integration Tests', () => {
     console.log('   Container cloned via backup/restore')
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(`\n Testing clean restore replaces (not merges) into live DB...`)
+
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Source container config should exist')
+
+    const engine = getEngine(ENGINE)
+
+    // 1. Capture current row count of the live, running source DB
+    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+
+    // 2. Back up the current state (this snapshot does NOT contain the extra row)
+    const { tmpdir } = await import('os')
+    const { rm } = await import('fs/promises')
+    const backupPath = join(
+      tmpdir(),
+      `cockroachdb-clean-restore-backup-${Date.now()}.sql`,
+    )
+
+    try {
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'sql',
+      })
+
+      // 3. Insert ONE extra row that is NOT in the backup
+      await runScriptSQL(
+        containerName,
+        "INSERT INTO test_user (id, name, email) VALUES (9999, 'Extra', 'extra@example.com');",
+        DATABASE,
+      )
+
+      // 4. Confirm the extra row is present
+      const afterInsert = await getRowCount(
+        ENGINE,
+        testPorts[0],
+        DATABASE,
+        'test_user',
+      )
+      assertEqual(
+        afterInsert,
+        before + 1,
+        'Extra row should be present before restore',
+      )
+
+      // 5. Clean restore into the EXISTING, live database (--into-existing semantics):
+      //    clean: true drops each table before reloading, so the extra row disappears.
+      await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+    } finally {
+      await rm(backupPath, { force: true })
+    }
+
+    // 6. Count is back to `before` (REPLACED, not merged) and still queryable
+    const afterRestore = await getRowCount(
+      ENGINE,
+      testPorts[0],
+      DATABASE,
+      'test_user',
+    )
+    assertEqual(
+      afterRestore,
+      before,
+      'Clean restore should REPLACE contents (extra row gone), not merge',
+    )
+
+    console.log(
+      `   Clean restore replaced contents: back to ${afterRestore} rows (net-neutral)`,
+    )
+  })
+
   it('should verify restored data matches source', async () => {
     console.log(`\n Verifying restored data...`)
 

--- a/tests/integration/ferretdb.test.ts
+++ b/tests/integration/ferretdb.test.ts
@@ -294,6 +294,89 @@ describe('FerretDB Integration Tests', () => {
     console.log('   ✓ Container cloned via backup/restore')
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(
+      `\n♻️  Testing clean restore replaces (not merges) into the existing live DB...`,
+    )
+
+    // 1. Capture current document count of the seeded collection
+    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+    assertEqual(
+      before,
+      EXPECTED_ROW_COUNT,
+      'Live DB should hold the seeded documents before backup',
+    )
+
+    const { tmpdir } = await import('os')
+    const { rm } = await import('fs/promises')
+    const backupPath = join(
+      tmpdir(),
+      `ferretdb-clean-restore-${Date.now()}.archive`,
+    )
+
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    const engine = getEngine(ENGINE)
+
+    try {
+      // 2. Back up the current (in-backup) state.
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'archive',
+      })
+
+      // 3. Insert ONE extra document NOT present in the backup, using the same
+      //    inline-JS idiom as the existing delete test (runScriptJS over db.test_user).
+      await runScriptJS(
+        containerName,
+        "db.test_user.insertOne({id: 9001, name: 'Not In Backup', email: 'extra@example.com'})",
+        DATABASE,
+      )
+
+      // 4. Assert the extra document is now live (before + 1).
+      const afterInsert = await getRowCount(
+        ENGINE,
+        testPorts[0],
+        DATABASE,
+        'test_user',
+      )
+      assertEqual(
+        afterInsert,
+        before + 1,
+        'Extra not-in-backup document should be present before restore',
+      )
+
+      // 5. Restore into the EXISTING database. FerretDB defaults to
+      //    mongorestore --drop, dropping each collection before reload, so the
+      //    extra doc disappears. createDatabase:false signals into-existing.
+      await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+    } finally {
+      await rm(backupPath, { force: true })
+    }
+
+    // 6. Count is back to `before` (REPLACED, not merged) and still queryable.
+    const afterRestore = await getRowCount(
+      ENGINE,
+      testPorts[0],
+      DATABASE,
+      'test_user',
+    )
+    assertEqual(
+      afterRestore,
+      before,
+      'Restore should REPLACE contents (extra doc dropped), not merge',
+    )
+
+    console.log(
+      `   ✓ Clean restore replaced contents: back to ${afterRestore} of ${before} rows, live DB never dropped`,
+    )
+  })
+
   it('should verify restored data matches source', async () => {
     console.log(`\n🔍 Verifying restored data...`)
     const rowCount = await getRowCount(

--- a/tests/integration/mongodb.test.ts
+++ b/tests/integration/mongodb.test.ts
@@ -385,6 +385,87 @@ describe('MongoDB Integration Tests', () => {
     console.log(`   ✓ Archive backup created with ${result.size} bytes`)
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(
+      `\n♻️  Verifying clean restore REPLACES (not merges) into the existing database...`,
+    )
+
+    const engine = getEngine(ENGINE)
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Container config should exist')
+
+    // 1. Capture the current document count of the seeded collection
+    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+
+    // 2. Back up the live database (archive format, same as the backup tests above)
+    const { tmpdir } = await import('os')
+    const backupPath = join(
+      tmpdir(),
+      `mongodb-clean-restore-${Date.now()}.archive`,
+    )
+    const backupResult = await engine.backup(config!, backupPath, {
+      database: DATABASE,
+      format: 'archive',
+    })
+    assertEqual(
+      backupResult.format,
+      'archive',
+      'Backup should use archive format',
+    )
+
+    try {
+      // 3. Insert ONE extra document that is NOT in the backup
+      await runScriptSQL(
+        containerName,
+        "db.test_user.insertOne({id: 9001, name: 'Ghost Record', email: 'ghost@example.com'})",
+        DATABASE,
+      )
+
+      // 4. Assert the live count is now before + 1
+      const afterInsert = await getRowCount(
+        ENGINE,
+        testPorts[0],
+        DATABASE,
+        'test_user',
+      )
+      assertEqual(
+        afterInsert,
+        before + 1,
+        'Extra document should be present before restore',
+      )
+
+      // 5. Restore the backup into the EXISTING database (clean: true).
+      // MongoDB restore passes `mongorestore --drop` by default, which drops
+      // each collection present in the archive before reloading it - so the
+      // extra document is REPLACED away, not merged.
+      await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+
+      // 6. Assert the count is back to `before` (replaced, not merged)
+      const afterRestore = await getRowCount(
+        ENGINE,
+        testPorts[0],
+        DATABASE,
+        'test_user',
+      )
+      assertEqual(
+        afterRestore,
+        before,
+        'Clean restore should REPLACE contents (extra document gone), not merge',
+      )
+
+      console.log(
+        `   ✓ Clean restore replaced contents: ${afterInsert} → ${afterRestore} documents (extra doc dropped)`,
+      )
+    } finally {
+      const { rm } = await import('fs/promises')
+      await rm(backupPath, { force: true }).catch(() => {})
+    }
+  })
+
   it('should restore from directory format and verify data', async () => {
     console.log(`\n📥 Testing directory format restore...`)
 

--- a/tests/integration/questdb.test.ts
+++ b/tests/integration/questdb.test.ts
@@ -245,6 +245,113 @@ describe('QuestDB Integration Tests', () => {
     console.log(`   Verified ${rowCount} rows in restored container`)
   })
 
+  it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
+    console.log(
+      `\n Testing clean restore REPLACE semantics on live container "${containerName}"...`,
+    )
+
+    const engine = getEngine(ENGINE)
+    const { tmpdir } = await import('os')
+    const { rm } = await import('fs/promises')
+    const backupPath = join(
+      tmpdir(),
+      `questdb-clean-restore-backup-${Date.now()}.sql`,
+    )
+
+    const config = await containerManager.getConfig(containerName)
+    assert(config !== null, 'Source container config should exist')
+
+    // 1. Capture the current row count of the live DB (QuestDB is
+    //    eventually-consistent on ingestion, so settle on a stable value).
+    let before = 0
+    {
+      const maxWaitMs = 15000
+      const startTime = Date.now()
+      while (Date.now() - startTime < maxWaitMs) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+        if (before >= EXPECTED_ROW_COUNT) break
+      }
+    }
+    assert(before >= EXPECTED_ROW_COUNT, 'Should have a stable baseline count')
+    console.log(`   Baseline row count: ${before}`)
+
+    try {
+      // 2. Back up the current state.
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'sql',
+      })
+
+      // 3. Insert ONE extra row that is NOT in the backup.
+      await runScriptSQL(
+        containerName,
+        "INSERT INTO test_user (id, name, email, created_at) VALUES (9001, 'Clean Restore Extra', 'clean-restore-extra@example.com', now());",
+        DATABASE,
+      )
+
+      // 4. Wait until the count reflects before+1 (WAL flush is async).
+      let afterInsert = before
+      {
+        const maxWaitMs = 15000
+        const startTime = Date.now()
+        while (Date.now() - startTime < maxWaitMs) {
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+          afterInsert = await getRowCount(
+            ENGINE,
+            testPorts[0],
+            DATABASE,
+            'test_user',
+          )
+          if (afterInsert >= before + 1) break
+        }
+      }
+      assertEqual(
+        afterInsert,
+        before + 1,
+        'Extra row should be visible before clean restore',
+      )
+      console.log(`   After extra insert: ${afterInsert} rows`)
+
+      // 5. Clean restore into the EXISTING database (--into-existing semantics):
+      //    clean:true drops each backed-up table, then psql reloads it, so the
+      //    extra row is REPLACED away (not merged).
+      await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+
+      // 6. Wait until the count is back to the baseline (replaced, not merged).
+      let afterRestore = afterInsert
+      {
+        const maxWaitMs = 15000
+        const startTime = Date.now()
+        while (Date.now() - startTime < maxWaitMs) {
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+          afterRestore = await getRowCount(
+            ENGINE,
+            testPorts[0],
+            DATABASE,
+            'test_user',
+          )
+          if (afterRestore <= before) break
+        }
+      }
+      assertEqual(
+        afterRestore,
+        before,
+        'Clean restore should REPLACE contents (extra row gone), not merge',
+      )
+
+      console.log(
+        `   Clean restore replaced contents: back to ${afterRestore} rows (extra row dropped)`,
+      )
+    } finally {
+      await rm(backupPath, { force: true }).catch(() => {})
+    }
+  })
+
   it('should prefer saved admin credentials over legacy generic credentials', async () => {
     console.log('\n Testing saved QuestDB auth-backed backup/restore...')
 


### PR DESCRIPTION
Third increment of non-destructive restore (after pg #225 and mysql/mariadb #226). Completes the **wire/HTTP engine** group on `dev` ahead of one spindb release.

## What
Adds the remaining wire engines to the `--into-existing` allowlist - **no engine code change**, each already replaces-in-place:
- **cockroachdb / clickhouse / questdb** already honor `clean: true` → `DROP TABLE IF EXISTS` per table before reload
- **mongodb / ferretdb** already default `mongorestore --drop` → per-collection drop before reload

## Tests (real engines, locally verified)
Each: back up → insert a row/doc NOT in the backup → restore into the existing DB → the extra is gone (replaced, not merged) and the database is never dropped. Engine-specific care: clickhouse uses its `{database, clean}` restore signature (no `createDatabase`); questdb polls for WAL/eventual-consistency. **cockroach 17/17, clickhouse 18/18, questdb 15/15, mongo 21/21, ferret 19/19**; full unit suite green, lint/tsc clean.

## Allowlist now
`postgresql, mysql, mariadb, mongodb, ferretdb, cockroachdb, clickhouse, questdb` - **all 8 wire engines**. 

## Remaining before the release
The 4 additive engines (surrealdb, typedb, influxdb, couchdb) need a real `clean`/drop path added to their engine restore before they're safe for `--into-existing` (currently they'd merge, so they're correctly excluded by the allowlist). After those, one spindb release → cloud delegates restore per engine (drill-gated). File-swap engines remain P2 (WS-E-coupled).