### PR TITLE
ci: run mongo<->ferret interop test in the FerretDB job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,12 @@ jobs:
         run: pnpm test:engine ferretdb
         timeout-minutes: 20
 
+      # MongoDB <-> FerretDB backup/restore interoperability. Runs here because
+      # this job already has BOTH the ferretdb and mongodb binaries downloaded.
+      - name: Run MongoDB<->FerretDB interop tests
+        run: pnpm test:engine mongo-ferret-interop
+        timeout-minutes: 15
+
       - name: Show FerretDB logs on failure (Unix)
         if: failure() && runner.os != 'Windows'
         run: |

--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -37,6 +37,9 @@ const ENGINE_TEST_FILES: Record<string, string> = {
   weaviate: 'weaviate.test.ts',
   tigerbeetle: 'tigerbeetle.test.ts',
   libsql: 'libsql.test.ts',
+  // Cross-engine: MongoDB <-> FerretDB backup/restore interoperability. Needs
+  // BOTH engines' binaries (run from the FerretDB CI job, which downloads both).
+  'mongo-ferret-interop': 'mongo-ferret-interop.test.ts',
 }
 
 // Aliases for engine names (maps alias -> canonical name)


### PR DESCRIPTION
Wires the new `mongo-ferret-interop.test.ts` into CI: adds it to the `test:engine` map and runs it as a step in the FerretDB job (which already downloads both ferretdb + mongodb binaries). Without this it only ran locally. Verified: `pnpm test:engine mongo-ferret-interop` runs both directions (2/2). Targets dev so 0.58.0 (#228) picks it up.