### PR TITLE
test(restore): address CodeRabbit review of the --into-existing tests

### DIFF
--- a/tests/integration/mariadb.test.ts
+++ b/tests/integration/mariadb.test.ts
@@ -364,66 +364,68 @@ describe('MariaDB Integration Tests', () => {
     const beforeCount = Number(before.rows[0].n)
 
     const { tmpdir } = await import('os')
-    const backupPath = join(tmpdir(), `mariadb-into-existing-${Date.now()}.sql`)
-    await engine.backup(config!, backupPath, {
-      database: DATABASE,
-      format: 'sql',
-    })
-
-    // The self-clean mechanism that makes an in-place replay a faithful replace.
     const { readFile, rm } = await import('fs/promises')
-    const dumpText = await readFile(backupPath, 'utf-8')
-    assert(
-      dumpText.includes('DROP TABLE IF EXISTS'),
-      'mariadb-dump should emit DROP TABLE IF EXISTS (self-clean on replay)',
-    )
+    const backupPath = join(tmpdir(), `mariadb-into-existing-${Date.now()}.sql`)
+    try {
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'sql',
+      })
 
-    // Diverge the LIVE database: add a row NOT in the backup.
-    await executeQuery(
-      containerName,
-      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
-      DATABASE,
-    )
-    const diverged = await executeQuery(
-      containerName,
-      'SELECT COUNT(*) AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      Number(diverged.rows[0].n),
-      beforeCount + 1,
-      'live DB should have diverged from the backup',
-    )
+      // The self-clean mechanism that makes an in-place replay a faithful replace.
+      const dumpText = await readFile(backupPath, 'utf-8')
+      assert(
+        dumpText.includes('DROP TABLE IF EXISTS'),
+        'mariadb-dump should emit DROP TABLE IF EXISTS (self-clean on replay)',
+      )
 
-    // Restore INTO the existing database (createDatabase:false -> no DROP
-    // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
-    const result = await engine.restore(config!, backupPath, {
-      database: DATABASE,
-      createDatabase: false,
-      clean: true,
-    })
-    assert(
-      result.code === 0 || !result.stderr?.includes('FATAL'),
-      'restore should not fatally fail',
-    )
+      // Diverge the LIVE database: add a row NOT in the backup.
+      await executeQuery(
+        containerName,
+        "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+        DATABASE,
+      )
+      const diverged = await executeQuery(
+        containerName,
+        'SELECT COUNT(*) AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        Number(diverged.rows[0].n),
+        beforeCount + 1,
+        'live DB should have diverged from the backup',
+      )
 
-    // Extra row gone -> contents REPLACED, not merged.
-    const after = await executeQuery(
-      containerName,
-      'SELECT COUNT(*) AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      Number(after.rows[0].n),
-      beforeCount,
-      'in-place restore should replace contents (extra row gone), not merge',
-    )
+      // Restore INTO the existing database (createDatabase:false -> no DROP
+      // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
+      const result = await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+      assert(
+        result.code === 0 && !result.stderr?.includes('FATAL'),
+        'restore should exit 0 with no fatal error',
+      )
 
-    await rm(backupPath, { force: true })
+      // Extra row gone -> contents REPLACED, not merged.
+      const after = await executeQuery(
+        containerName,
+        'SELECT COUNT(*) AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        Number(after.rows[0].n),
+        beforeCount,
+        'in-place restore should replace contents (extra row gone), not merge',
+      )
 
-    console.log(
-      `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
-    )
+      console.log(
+        `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
+      )
+    } finally {
+      await rm(backupPath, { force: true })
+    }
   })
 
   it('should backup to compressed format (.sql.gz)', async () => {

--- a/tests/integration/mysql.test.ts
+++ b/tests/integration/mysql.test.ts
@@ -366,66 +366,68 @@ describe('MySQL Integration Tests', () => {
     const beforeCount = Number(before.rows[0].n)
 
     const { tmpdir } = await import('os')
-    const backupPath = join(tmpdir(), `mysql-into-existing-${Date.now()}.sql`)
-    await engine.backup(config!, backupPath, {
-      database: DATABASE,
-      format: 'sql',
-    })
-
-    // The self-clean mechanism that makes an in-place replay a faithful replace.
     const { readFile, rm } = await import('fs/promises')
-    const dumpText = await readFile(backupPath, 'utf-8')
-    assert(
-      dumpText.includes('DROP TABLE IF EXISTS'),
-      'mysqldump should emit DROP TABLE IF EXISTS (self-clean on replay)',
-    )
+    const backupPath = join(tmpdir(), `mysql-into-existing-${Date.now()}.sql`)
+    try {
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'sql',
+      })
 
-    // Diverge the LIVE database: add a row NOT in the backup.
-    await executeQuery(
-      containerName,
-      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
-      DATABASE,
-    )
-    const diverged = await executeQuery(
-      containerName,
-      'SELECT COUNT(*) AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      Number(diverged.rows[0].n),
-      beforeCount + 1,
-      'live DB should have diverged from the backup',
-    )
+      // The self-clean mechanism that makes an in-place replay a faithful replace.
+      const dumpText = await readFile(backupPath, 'utf-8')
+      assert(
+        dumpText.includes('DROP TABLE IF EXISTS'),
+        'mysqldump should emit DROP TABLE IF EXISTS (self-clean on replay)',
+      )
 
-    // Restore INTO the existing database (createDatabase:false -> no DROP
-    // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
-    const result = await engine.restore(config!, backupPath, {
-      database: DATABASE,
-      createDatabase: false,
-      clean: true,
-    })
-    assert(
-      result.code === 0 || !result.stderr?.includes('FATAL'),
-      'restore should not fatally fail',
-    )
+      // Diverge the LIVE database: add a row NOT in the backup.
+      await executeQuery(
+        containerName,
+        "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+        DATABASE,
+      )
+      const diverged = await executeQuery(
+        containerName,
+        'SELECT COUNT(*) AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        Number(diverged.rows[0].n),
+        beforeCount + 1,
+        'live DB should have diverged from the backup',
+      )
 
-    // Extra row gone -> contents REPLACED, not merged.
-    const after = await executeQuery(
-      containerName,
-      'SELECT COUNT(*) AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      Number(after.rows[0].n),
-      beforeCount,
-      'in-place restore should replace contents (extra row gone), not merge',
-    )
+      // Restore INTO the existing database (createDatabase:false -> no DROP
+      // DATABASE). The dump's own DROP TABLE IF EXISTS replaces the table in place.
+      const result = await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+      assert(
+        result.code === 0 && !result.stderr?.includes('FATAL'),
+        'restore should exit 0 with no fatal error',
+      )
 
-    await rm(backupPath, { force: true })
+      // Extra row gone -> contents REPLACED, not merged.
+      const after = await executeQuery(
+        containerName,
+        'SELECT COUNT(*) AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        Number(after.rows[0].n),
+        beforeCount,
+        'in-place restore should replace contents (extra row gone), not merge',
+      )
 
-    console.log(
-      `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
-    )
+      console.log(
+        `   ✓ In-place restore replaced contents (${beforeCount} rows) without dropping the database`,
+      )
+    } finally {
+      await rm(backupPath, { force: true })
+    }
   })
 
   it('should backup to compressed format (.sql.gz)', async () => {

--- a/tests/integration/postgresql.test.ts
+++ b/tests/integration/postgresql.test.ts
@@ -470,61 +470,67 @@ describe('PostgreSQL Integration Tests', () => {
     const beforeCount = before.rows[0].n as number
 
     const { tmpdir } = await import('os')
-    const backupPath = join(tmpdir(), `pg-into-existing-${Date.now()}.dump`)
-    await engine.backup(config!, backupPath, {
-      database: DATABASE,
-      format: 'custom',
-    })
-
-    // Diverge the LIVE database: add a row that is NOT in the backup.
-    await executeQuery(
-      containerName,
-      "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
-      DATABASE,
-    )
-    const diverged = await executeQuery(
-      containerName,
-      'SELECT count(*)::int AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      diverged.rows[0].n,
-      beforeCount + 1,
-      'live DB should have diverged from the backup',
-    )
-
-    // Restore INTO the existing database with object-level clean. This is the
-    // engine half of `restore --into-existing`: it must drop+recreate each
-    // object (a faithful REPLACE, not a merge) while NEVER dropping the database
-    // itself - so a live connection / pooler is undisturbed.
-    const result = await engine.restore(config!, backupPath, {
-      database: DATABASE,
-      createDatabase: false,
-      clean: true,
-    })
-    assert(
-      result.code === 0 || !result.stderr?.includes('FATAL'),
-      'restore should not fatally fail',
-    )
-
-    // The extra row is gone -> contents were REPLACED, not merged.
-    const after = await executeQuery(
-      containerName,
-      'SELECT count(*)::int AS n FROM test_user',
-      DATABASE,
-    )
-    assertEqual(
-      after.rows[0].n,
-      beforeCount,
-      'clean restore should replace contents (extra row gone), not merge or error',
-    )
-
     const { rm } = await import('fs/promises')
-    await rm(backupPath, { force: true })
+    const backupPath = join(tmpdir(), `pg-into-existing-${Date.now()}.dump`)
+    try {
+      await engine.backup(config!, backupPath, {
+        database: DATABASE,
+        format: 'custom',
+      })
 
-    console.log(
-      `   ✓ In-place clean restore replaced contents (${beforeCount} rows) without dropping the database`,
-    )
+      // Diverge the LIVE database: add a row that is NOT in the backup.
+      await executeQuery(
+        containerName,
+        "INSERT INTO test_user (name, email) VALUES ('Zed Extra', 'zed@example.com')",
+        DATABASE,
+      )
+      const diverged = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        diverged.rows[0].n,
+        beforeCount + 1,
+        'live DB should have diverged from the backup',
+      )
+
+      // Restore INTO the existing database with object-level clean. This is the
+      // engine half of `restore --into-existing`: it must drop+recreate each
+      // object (a faithful REPLACE, not a merge) while NEVER dropping the
+      // database itself - so a live connection / pooler is undisturbed.
+      const result = await engine.restore(config!, backupPath, {
+        database: DATABASE,
+        createDatabase: false,
+        clean: true,
+      })
+      // pg_restore legitimately exits non-zero on warnings (e.g. "table does not
+      // exist, skipping" during --clean --if-exists), which spindb surfaces as a
+      // non-zero code - so assert only that it did NOT fatally fail; the
+      // row-count below is the real success gate.
+      assert(
+        !result.stderr?.includes('FATAL'),
+        'restore should not fatally fail',
+      )
+
+      // The extra row is gone -> contents were REPLACED, not merged.
+      const after = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM test_user',
+        DATABASE,
+      )
+      assertEqual(
+        after.rows[0].n,
+        beforeCount,
+        'clean restore should replace contents (extra row gone), not merge or error',
+      )
+
+      console.log(
+        `   ✓ In-place clean restore replaced contents (${beforeCount} rows) without dropping the database`,
+      )
+    } finally {
+      await rm(backupPath, { force: true })
+    }
   })
 
   it('should restore from SQL format and verify data', async () => {


### PR DESCRIPTION
Addresses the CodeRabbit comments on the `--into-existing` test PRs. **Verified each against current code; fixed the valid ones, skipped the rest with reasons.**

## Fixed
- **Loose restore assertion (mariadb/mysql):** `result.code === 0 || !FATAL` → `&&`. Their restore (`mysql < dump`) exits 0 on success, so a non-zero exit IS a real failure - the `||` could mask it.
- **postgresql:** assert **no FATAL** instead of `&&`. `pg_restore` legitimately exits non-zero on warnings (e.g. "table does not exist, skipping" during `--clean --if-exists`), which spindb surfaces as a non-zero code - a blanket `&&` makes the pg test fail (I caught this by re-running). The row-count assertion after is the real success gate.
- **Temp-file cleanup leak (pg/mysql/mariadb):** wrapped the body in `try/finally` so the temp backup file is removed even when the test fails.

Validated: pg 22/22, mysql 21/21, mariadb 21/21 locally; tsc clean.

## Skipped (with reasons)
- **clickhouse `createDatabase: false`:** ClickHouse's `restore()` signature is `{ database?, clean? }` - it does NOT accept `createDatabase`, so adding it is a TypeScript excess-property error. The into-existing path is already validated by `clean: true` + the database never being dropped + the row-count.
- **Guard `dbSpinner` behind `!options.json`:** `createSpinner` is `ora({...})` with no `stream` override, so ora writes to **stderr**, never the JSON stdout. The restore CLI already has 5+ unguarded spinners and `spindb backup --json` is parsed cleanly by the cloud today - so this is a non-issue.
- **`console.log` → `logDebug` in tests:** every integration test in the suite uses `console.log` for progress output; changing only the new lines would be inconsistent with the established file convention.

Targets dev so 0.58.0 (#228) picks it up.