### PR TITLE
release: spindb 0.58.1 - couchdb admin-probe lockout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.58.0] - 2026-06-16
+## [0.58.1] - 2026-06-16
+
+### Fixed
+
+- **CouchDB: stale admin-credential health probe could brute-force-lock the account, breaking restore.** On start, `waitForAdminReady` polled `GET /_all_dbs` with spindb's saved admin credentials every 500ms for up to 30s. When a deployment patches CouchDB's `[admins]` in `local.ini` out-of-band and restarts (as Layerbase Cloud does for per-database credentials), spindb's saved creds no longer match, so each poll is a 401 - ~60 failed authentications in 30s, which trips CouchDB's brute-force protection and "temporarily locks" the admin account. The CORRECT credentials then also get 401/403 for the lockout window, so a subsequent backup/restore fails. The probe now treats a 401 as a definitive "node is up, credentials managed elsewhere" answer and stops immediately (anonymous `/_up` already confirmed readiness) instead of hammering until lockout. Found by the Layerbase Cloud restore-drill.
 
 ### Added
 

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -993,6 +993,21 @@ export class CouchDBEngine extends BaseEngine {
           logDebug(`CouchDB admin auth ready on port ${port}`)
           return true
         }
+        // A 401 is a DEFINITIVE answer, not "not ready yet": the node is up and
+        // validating credentials, but spindb's saved admin creds don't match what
+        // CouchDB now has (e.g. a deployment that patches [admins] in local.ini
+        // out-of-band, then restarts). Retrying just sends the wrong password ~60
+        // times in 30s, which trips CouchDB's brute-force protection and
+        // "temporarily locks" the account - so even the CORRECT credentials then
+        // get 401/403 for the lockout window. Stop immediately and treat the node
+        // as ready: anonymous /_up already confirmed it's up, and admin-auth
+        // verification with stale creds is not worth locking the account over.
+        if (response.status === 401) {
+          logDebug(
+            `CouchDB up on port ${port} but admin probe returned 401 (credentials managed out-of-band?); treating as ready without retrying to avoid the brute-force lockout`,
+          )
+          return true
+        }
       } catch {
         // Admin auth not ready yet, wait and retry
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
Patch release. Fixes a CouchDB restore-blocking bug found by the Layerbase Cloud restore-drill.

## Fixed
**CouchDB: stale admin-credential health probe could brute-force-lock the admin account.** `waitForAdminReady` polled `GET /_all_dbs` with spindb's saved admin creds every 500ms for 30s. When a deployment patches `[admins]` in `local.ini` out-of-band and restarts (Layerbase Cloud's per-database credentials), each poll 401s; ~60 failures in 30s trip CouchDB's brute-force protection and lock the account - so the CORRECT credentials then also fail for the lockout window, breaking backup/restore. The probe now treats a 401 as "node up, credentials managed elsewhere" and stops immediately (anonymous `/_up` already confirmed readiness).

## Validation
- CouchDB integration tests pass 12/12 (incl. password-authenticated backup/restore round-trip).
- `tsc --noEmit` clean.

Merging publishes 0.58.1 to npm; Layerbase Cloud then bumps its image to pick it up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CouchDB health-probe behavior when admin credentials are managed externally, preventing unnecessary repeated authentication attempts.

* **Chores**
  * Version bumped to 0.58.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->