### PR TITLE
release: spindb 0.58.3 (couchdb [admins] duplicate -> lockout fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.3] - 2026-06-16
+
+### Fixed
+
+- **CouchDB: `spindb start` appended a duplicate `[admins]` entry, tripping CouchDB's brute-force lockout.** `patchCouchDBConfig` re-asserts the admin on every start by regenerating local.ini. Its section-matching regex (`/\[admins\][\s\S]*?(?=\n\[|$)/m`) used the `m` flag, so `$` matched end-of-LINE and the pattern captured only the `[admins]` HEADER, not the section body. It then appended a fresh `admin =` line instead of replacing the existing one - leaving TWO conflicting admin passwords. A deployment that manages the admin password out-of-band (Layerbase Cloud rotates it to a per-database password) ends up with spindb's password AND the cloud's; CouchDB authenticates against the wrong one, and after a few failed logins returns `403 "Account is temporarily locked due to multiple authentication failures"`, breaking backup/restore. `patchCouchDBConfig` now PRESERVES an existing admin entry (it is the source of truth) and only writes the managed admin when none exists - the admin is set once at create (`generateCouchDBConfig`) and never re-asserted on later starts. Found by the Layerbase Cloud restore-drill; covered by a new `couchdb-config-patch` unit test.
+
 ## [0.58.2] - 2026-06-16
 
 ### Fixed

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -7,7 +7,10 @@ import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
 import { platformService, isWindows } from '../../core/platform-service'
 import { configManager } from '../../core/config-manager'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import {
   logDebug,
   logWarning,
@@ -109,7 +112,7 @@ ${adminUsername} = ${adminPassword}
 `
 }
 
-function patchCouchDBConfig(
+export function patchCouchDBConfig(
   existingConfig: string,
   options: {
     port: number
@@ -128,23 +131,33 @@ function patchCouchDBConfig(
   }
   if (options.adminUsername && options.adminPassword) {
     const managedAdminLine = `${options.adminUsername} = ${options.adminPassword}`
-    const adminsSection = `[admins]\n${managedAdminLine}`
-    const adminsSectionPattern = /\[admins\][\s\S]*?(?=\n\[|$)/m
     const escapedUsername = options.adminUsername.replace(
       /[.*+?^${}()|[\]\\]/g,
       '\\$&',
     )
-    const managedAdminPattern = new RegExp(`^${escapedUsername}\\s*=.*$`, 'm')
+    const managedAdminPattern = new RegExp(`^${escapedUsername}\\s*=`, 'm')
 
-    if (adminsSectionPattern.test(config)) {
-      config = config.replace(adminsSectionPattern, (section) => {
-        if (managedAdminPattern.test(section)) {
-          return section.replace(managedAdminPattern, managedAdminLine)
-        }
-        return `${section.trimEnd()}\n${managedAdminLine}`
-      })
-    } else {
-      config = `${config.trimEnd()}\n\n${adminsSection}\n`
+    // An EXISTING admin entry is the source of truth and is PRESERVED. A
+    // deployment (e.g. Layerbase Cloud) rotates the [admins] password
+    // out-of-band, then restarts; re-asserting spindb's saved/default password
+    // on every start would fight that. Worse, the previous section-matching
+    // regex (`/\[admins\][\s\S]*?(?=\n\[|$)/m`) mis-parsed a trailing [admins]
+    // section: with the `m` flag `$` matches end-of-LINE, so it captured only
+    // the `[admins]` header and then APPENDED a second `admin =` line. CouchDB
+    // then holds two conflicting admin passwords and, after a few failed logins
+    // with the "wrong" one, returns 403 "Account is temporarily locked due to
+    // multiple authentication failures". The admin is written once when the
+    // config is first generated (generateCouchDBConfig); later starts must not
+    // touch an entry that already exists - only add one if it is missing.
+    if (!managedAdminPattern.test(config)) {
+      if (/^\[admins\]/m.test(config)) {
+        config = config.replace(
+          /^\[admins\][^\n]*\n?/m,
+          (header) => `${header}${managedAdminLine}\n`,
+        )
+      } else {
+        config = `${config.trimEnd()}\n\n[admins]\n${managedAdminLine}\n`
+      }
     }
   }
   return config
@@ -544,7 +557,7 @@ export class CouchDBEngine extends BaseEngine {
       timeoutMs,
       auth === null
         ? null
-        : auth ?? (await this.getRuntimeAdminAuth(container.name)),
+        : (auth ?? (await this.getRuntimeAdminAuth(container.name))),
     )
   }
 
@@ -920,10 +933,7 @@ export class CouchDBEngine extends BaseEngine {
             undefined,
             null,
           )
-          if (
-            readProbe.status !== 404 &&
-            readProbe.status !== 401
-          ) {
+          if (readProbe.status !== 404 && readProbe.status !== 401) {
             logDebug(
               `CouchDB _up ok but read probe returned ${readProbe.status} ` +
                 `on port ${port}, waiting...`,
@@ -936,11 +946,7 @@ export class CouchDBEngine extends BaseEngine {
           // Underscore-prefixed names are reserved for system DBs and will
           // be rejected on PUT, so use a plain name.
           const probeDbPath = '/spindb_writeprobe'
-          const putResponse = await couchdbApiRequest(
-            port,
-            'PUT',
-            probeDbPath,
-          )
+          const putResponse = await couchdbApiRequest(port, 'PUT', probeDbPath)
           if (
             putResponse.status === 201 ||
             putResponse.status === 412 ||

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.58.2",
+  "version": "0.58.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/couchdb-config-patch.test.ts
+++ b/tests/unit/couchdb-config-patch.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for patchCouchDBConfig's [admins] handling.
+ *
+ * CouchDB's local.ini is regenerated on every `spindb start`. The cloud
+ * (Layerbase Cloud) rotates the admin password in [admins] out-of-band, so the
+ * patch MUST preserve an existing admin entry rather than re-assert spindb's
+ * own. The old regex captured only the `[admins]` header and appended a second
+ * `admin =` line, leaving two conflicting admin passwords - CouchDB then locks
+ * the account ("temporarily locked due to multiple authentication failures").
+ * These tests pin the preserve-not-duplicate behavior.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { patchCouchDBConfig } from '../../engines/couchdb/index'
+
+const adminLines = (config: string): string[] =>
+  config.split('\n').filter((l) => /^admin\s*=/.test(l))
+
+describe('patchCouchDBConfig [admins] handling', () => {
+  it('preserves an existing admin entry and never duplicates it', () => {
+    const existing = [
+      '[chttpd]',
+      'port = 5984',
+      '',
+      '[admins]',
+      '; CouchDB 3.x requires admin account for privileged API operations',
+      'admin = -pbkdf2:sha256-deadbeef,salt,10',
+    ].join('\n')
+
+    const patched = patchCouchDBConfig(existing, {
+      port: 11500,
+      adminUsername: 'admin',
+      adminPassword: 'a-different-password',
+    })
+
+    const lines = adminLines(patched)
+    assert.equal(lines.length, 1, 'must keep exactly one admin line')
+    assert.match(
+      lines[0],
+      /-pbkdf2:sha256-deadbeef/,
+      'existing value preserved',
+    )
+    assert.doesNotMatch(
+      patched,
+      /a-different-password/,
+      'spindb must not re-assert its own password over the cloud-managed one',
+    )
+  })
+
+  it('preserves an existing admin even when [admins] is the trailing section', () => {
+    // Reproduces the original bug: a trailing [admins] section made the old
+    // regex (with the `m` flag) match only the header and append a duplicate.
+    const existing = [
+      '[log]',
+      'level = info',
+      '',
+      '[admins]',
+      'admin = cloudpw',
+    ].join('\n')
+    const patched = patchCouchDBConfig(existing, {
+      port: 11500,
+      adminUsername: 'admin',
+      adminPassword: 'spindbpw',
+    })
+    assert.equal(adminLines(patched).length, 1)
+    assert.match(adminLines(patched)[0], /cloudpw/)
+  })
+
+  it('adds the admin under an existing [admins] header that has no entry', () => {
+    const existing = ['[admins]', '; placeholder, no admin yet'].join('\n')
+    const patched = patchCouchDBConfig(existing, {
+      port: 11500,
+      adminUsername: 'admin',
+      adminPassword: 'freshpw',
+    })
+    const lines = adminLines(patched)
+    assert.equal(lines.length, 1)
+    assert.match(lines[0], /^admin = freshpw$/)
+  })
+
+  it('creates an [admins] section when none exists', () => {
+    const existing = ['[chttpd]', 'port = 5984'].join('\n')
+    const patched = patchCouchDBConfig(existing, {
+      port: 11500,
+      adminUsername: 'admin',
+      adminPassword: 'freshpw',
+    })
+    assert.match(patched, /\[admins\]\nadmin = freshpw/)
+    assert.equal(adminLines(patched).length, 1)
+  })
+
+  it('still patches the port', () => {
+    const existing = ['[chttpd]', 'port = 5984', '[admins]', 'admin = x'].join(
+      '\n',
+    )
+    const patched = patchCouchDBConfig(existing, { port: 11500 })
+    assert.match(patched, /^port = 11500$/m)
+  })
+})


### PR DESCRIPTION
## spindb 0.58.3

### `fix(couchdb)`: `spindb start` no longer duplicates the `[admins]` entry
`patchCouchDBConfig` regenerates `local.ini` on every start and re-asserts the admin. Its section-matching regex `/\[admins\][\s\S]*?(?=\n\[|$)/m` used the `m` flag, so `$` matched **end-of-line** and the pattern captured only the `[admins]` **header**, not the section body. It then **appended** a fresh `admin =` line instead of replacing the existing one.

A deployment that manages the admin password out-of-band - Layerbase Cloud rotates couchdb's admin to a per-database password during setup - therefore ended up with TWO `admin =` lines (spindb's default + the cloud's). CouchDB authenticates against the wrong one and, after a few failed logins, returns `403 "Account is temporarily locked due to multiple authentication failures"`, which broke backup/restore.

Fix: `patchCouchDBConfig` now **preserves** an existing admin entry (it is the source of truth - the admin is written once at create via `generateCouchDBConfig`) and only writes the managed admin when none exists. New `couchdb-config-patch` unit test pins preserve-not-duplicate across the trailing-section, missing-entry, and no-section cases.

Found by the Layerbase Cloud restore-drill (couchdb leg). Verified end-to-end on staging after this lands and the image picks it up.

Merging publishes 0.58.3 to npm; Layerbase Cloud then bumps `SPINDB_VERSION` to 0.58.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.58.3

* **Bug Fixes**
  * Resolved a CouchDB configuration issue where `spindb start` was appending duplicate admin entries, which could result in conflicting credentials when admin settings already existed in the configuration.

* **Tests**
  * Added comprehensive unit test coverage for CouchDB configuration patching, ensuring proper preservation and management of existing admin credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->