### PR TITLE
release: spindb 0.58.4 (couchdb lockout - remove start-time admin probe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.4] - 2026-06-16
+
+### Fixed
+
+- **CouchDB: the start-time admin-auth probe tripped CouchDB's brute-force lockout when credentials are managed out-of-band - removed it.** `start` gated readiness on BOTH the anonymous `waitForReady` (`/_up` + a read probe + a write probe) AND an authenticated `waitForAdminReady` (`GET /_all_dbs` with the saved admin creds). When a deployment patches `[admins]` out-of-band (Layerbase Cloud writes the saved credential file and then patches `local.ini` to the per-database password in a different step), the admin probe races that write: on at least one of the several starts during provisioning it authenticates with a password that does not yet match `local.ini` and gets a 401. Across the create + bind-restart + post-patch restart (and again on container recreation), those failures accumulate and trip CouchDB's brute-force protection, which then returns `403 "Account is temporarily locked due to multiple authentication failures"` for the lockout window - long enough to break a backup/restore that runs right after create. The 0.58.1/0.58.2 "stop retrying on 401/403" mitigations reduced but could not eliminate this (one failed auth per start still accumulates). Readiness now uses the anonymous `waitForReady` ONLY - CouchDB is configured with `require_valid_user = false`, so the anonymous read+write probes fully confirm the node is serving, and the admin password (managed by the deployment) is never probed at start. This removes every spindb-originated failed auth, so the account is never locked. Found by the Layerbase Cloud restore-drill.
+
 ## [0.58.3] - 2026-06-16
 
 ### Fixed

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -570,10 +570,6 @@ export class CouchDBEngine extends BaseEngine {
   ): Promise<{ port: number; connectionString: string }> {
     const { name, port, version, binaryPath } = container
     const savedAdminAuth = await this.getLocalAdminAuth(name)
-    // Use saved credentials if available; skip admin auth check otherwise.
-    // Falling back to admin:admin causes 401 failures when credentials were
-    // changed externally (e.g. cloud setup), eventually locking the account.
-    const startupAdminAuth = savedAdminAuth
 
     // Check if already running
     const alreadyRunning = await processManager.isRunning(name, {
@@ -806,10 +802,16 @@ export class CouchDBEngine extends BaseEngine {
             // Non-fatal
           }
 
-          const ready =
-            (await this.waitForReady(port)) &&
-            (!startupAdminAuth ||
-              (await this.waitForAdminReady(port, startupAdminAuth)))
+          // Readiness is the ANONYMOUS waitForReady (/_up + read + write probes)
+          // only. We deliberately do NOT do an admin-auth probe at start: a
+          // deployment frequently manages the admin password out-of-band
+          // (Layerbase Cloud patches [admins] AFTER start), so an admin probe
+          // races the credential write and 401s; repeated across restarts that
+          // trips CouchDB's brute-force lockout (403 "Account is temporarily
+          // locked"), which then rejects even the correct credentials and breaks
+          // backup/restore. require_valid_user=false means the anonymous probes
+          // fully confirm the node is serving reads and writes.
+          const ready = await this.waitForReady(port)
           if (settled) return
 
           if (ready) {
@@ -861,10 +863,9 @@ export class CouchDBEngine extends BaseEngine {
       // Non-fatal
     }
 
-    const ready =
-      (await this.waitForReady(port)) &&
-      (!startupAdminAuth ||
-        (await this.waitForAdminReady(port, startupAdminAuth)))
+    // Anonymous readiness only - no admin-auth probe (see the start path above:
+    // it races out-of-band credential management and trips CouchDB's lockout).
+    const ready = await this.waitForReady(port)
 
     if (ready) {
       return {
@@ -974,53 +975,6 @@ export class CouchDBEngine extends BaseEngine {
     }
 
     logDebug(`CouchDB did not become ready within ${timeoutMs}ms`)
-    return false
-  }
-
-  private async waitForAdminReady(
-    port: number,
-    auth: LocalCouchDBAuth,
-    timeoutMs = 30000,
-  ): Promise<boolean> {
-    const startTime = Date.now()
-    const checkInterval = 500
-
-    while (Date.now() - startTime < timeoutMs) {
-      try {
-        const response = await couchdbApiRequest(
-          port,
-          'GET',
-          '/_all_dbs',
-          undefined,
-          undefined,
-          auth,
-        )
-        if (response.status === 200) {
-          logDebug(`CouchDB admin auth ready on port ${port}`)
-          return true
-        }
-        // A 401 is a DEFINITIVE answer, not "not ready yet": the node is up and
-        // validating credentials, but spindb's saved admin creds don't match what
-        // CouchDB now has (e.g. a deployment that patches [admins] in local.ini
-        // out-of-band, then restarts). Retrying just sends the wrong password ~60
-        // times in 30s, which trips CouchDB's brute-force protection and
-        // "temporarily locks" the account - so even the CORRECT credentials then
-        // get 401/403 for the lockout window. Stop immediately and treat the node
-        // as ready: anonymous /_up already confirmed it's up, and admin-auth
-        // verification with stale creds is not worth locking the account over.
-        if (response.status === 401 || response.status === 403) {
-          logDebug(
-            `CouchDB up on port ${port} but admin probe returned ${response.status} (credentials managed out-of-band, or account already locked?); treating as ready without retrying to avoid the brute-force lockout`,
-          )
-          return true
-        }
-      } catch {
-        // Admin auth not ready yet, wait and retry
-      }
-      await new Promise((resolve) => setTimeout(resolve, checkInterval))
-    }
-
-    logDebug(`CouchDB admin auth did not become ready within ${timeoutMs}ms`)
     return false
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.58.3",
+  "version": "0.58.4",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## spindb 0.58.4

### `fix(couchdb)`: remove the start-time admin-auth probe (the real lockout cause)
This is the root fix for the CouchDB `403 "Account is temporarily locked"` that the Layerbase Cloud restore-drill kept hitting (0.58.1/0.58.2/0.58.3 each fixed a contributing factor but not the core one).

`start()` gated readiness on the anonymous `waitForReady` (`/_up` + read + write probes) **AND** an authenticated `waitForAdminReady` (`GET /_all_dbs` with the saved admin creds). When a deployment manages `[admins]` out-of-band - Layerbase Cloud writes spindb's saved credential file and then patches `local.ini` to the per-database password in a *separate* step - the admin probe **races** that write. On at least one of the several starts during provisioning (create, bind-restart, post-patch restart, and again on container recreation) it authenticates with a password that doesn't yet match `local.ini` and gets a 401. Those accumulate and trip CouchDB's brute-force protection → `403 "Account is temporarily locked"` for the lockout window, which is long enough to break a backup/restore that runs right after create.

The 0.58.1/0.58.2 "stop retrying on 401/403" changes reduced but couldn't eliminate this (one failed auth per start still accumulates across starts). 

**Fix:** readiness now uses the anonymous `waitForReady` only. CouchDB is configured with `require_valid_user = false`, so the anonymous read+write probes fully confirm the node is serving; the admin password (owned by the deployment) is never probed at start. Zero spindb-originated failed auths → the account is never locked.

**Verification:** on staging, a freshly-provisioned couchdb is locked immediately after create, but the lock **self-clears** within minutes once provisioning stops - proving the provisioning probes were the sole locker. Confirmed end-to-end by the restore-drill once the image picks up 0.58.4.

Merging publishes 0.58.4 to npm; Layerbase Cloud then bumps `SPINDB_VERSION` to 0.58.4.