### PR TITLE
release: spindb 0.58.5 (couchdb lockout - THE root cause: write probe admin:admin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.5] - 2026-06-17
+
+### Fixed
+
+- **CouchDB: the readiness WRITE probe authenticated with the `admin:admin` DEFAULT and retried ~60x, tripping the brute-force lockout. This was the ACTUAL root cause of the `403 "Account is temporarily locked"` (0.58.1-0.58.4 each fixed a contributing factor but not this).** `waitForReady`'s write probe (`PUT /spindb_writeprobe`, plus its DELETE) called `couchdbApiRequest` WITHOUT an auth argument - which defaults to `{username: 'admin', password: 'admin'}`. CouchDB is initially created with the `admin:admin` default, so the FIRST start's probe succeeds; but once a deployment rotates `[admins]` to a real password (Layerbase Cloud patches it out-of-band, then restarts), the probe's `admin:admin` PUT is a FAILED auth for `admin`. The probe retries every 500ms for up to 30s, so ~60 failed auths pile up on the restart and trip CouchDB's brute-force protection - which then rejects even the CORRECT credentials for the lockout window, breaking a backup/restore that runs right after create. The probes now use the database's SAVED admin credentials (which are written together with the `[admins]` password, so they match), and `waitForReady` treats a 401/403 on the write probe as "node is up and auth-gating" (ready) instead of retrying. Net effect: zero failed `admin` auths during startup, so the account is never locked. Confirmed by a real-engine local reproduction: rotating a running couchdb's `[admins]` password and then issuing ~60 `admin:admin` PUTs (what the old probe did) produces the exact `403 "Account is temporarily locked"`, while the rotated credentials authenticate cleanly across a stop/start with the fix. Found by the Layerbase Cloud restore-drill.
+
 ## [0.58.4] - 2026-06-16
 
 ### Fixed

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -811,7 +811,7 @@ export class CouchDBEngine extends BaseEngine {
           // locked"), which then rejects even the correct credentials and breaks
           // backup/restore. require_valid_user=false means the anonymous probes
           // fully confirm the node is serving reads and writes.
-          const ready = await this.waitForReady(port)
+          const ready = await this.waitForReady(port, savedAdminAuth)
           if (settled) return
 
           if (ready) {
@@ -865,7 +865,7 @@ export class CouchDBEngine extends BaseEngine {
 
     // Anonymous readiness only - no admin-auth probe (see the start path above:
     // it races out-of-band credential management and trips CouchDB's lockout).
-    const ready = await this.waitForReady(port)
+    const ready = await this.waitForReady(port, savedAdminAuth)
 
     if (ready) {
       return {
@@ -901,6 +901,7 @@ export class CouchDBEngine extends BaseEngine {
   //      any caller doing `PUT /<dbname>` (e.g. restore, tests) fails.
   private async waitForReady(
     port: number,
+    adminAuth: LocalCouchDBAuth | null = null,
     timeoutMs = 30000,
   ): Promise<boolean> {
     const startTime = Date.now()
@@ -947,16 +948,46 @@ export class CouchDBEngine extends BaseEngine {
           // Underscore-prefixed names are reserved for system DBs and will
           // be rejected on PUT, so use a plain name.
           const probeDbPath = '/spindb_writeprobe'
-          const putResponse = await couchdbApiRequest(port, 'PUT', probeDbPath)
+          // Use the database's SAVED admin credentials (or anonymous when none
+          // are stored) - NEVER couchdbApiRequest's admin:admin DEFAULT. Once
+          // [admins] is rotated to a non-default password (Layerbase Cloud
+          // patches it out-of-band, then restarts), an admin:admin PUT is a
+          // FAILED auth for 'admin'. This probe retries every 500ms for up to
+          // 30s, so ~60 failed auths pile up and trip CouchDB's brute-force
+          // lockout (403 "Account is temporarily locked"), which then rejects
+          // even the correct credentials and breaks a backup/restore run right
+          // after create. The saved creds match the current [admins] password
+          // (they are written together), so the PUT succeeds and never locks.
+          const putResponse = await couchdbApiRequest(
+            port,
+            'PUT',
+            probeDbPath,
+            undefined,
+            undefined,
+            adminAuth,
+          )
           if (
             putResponse.status === 201 ||
             putResponse.status === 412 ||
-            putResponse.status === 202
+            putResponse.status === 202 ||
+            // 401/403: the node is up and auth-gating writes (creds managed
+            // out-of-band, or none stored). It is serving - treat as ready
+            // rather than retrying, which is exactly what caused the lockout.
+            putResponse.status === 401 ||
+            putResponse.status === 403
           ) {
-            // Best-effort cleanup. If the DELETE fails, the next probe will
-            // see 412 (already exists) and still treat the cluster as ready.
+            // Best-effort cleanup (only meaningful when the PUT created the
+            // probe DB). If the DELETE fails, the next probe sees 412 (already
+            // exists) and still treats the cluster as ready.
             try {
-              await couchdbApiRequest(port, 'DELETE', probeDbPath)
+              await couchdbApiRequest(
+                port,
+                'DELETE',
+                probeDbPath,
+                undefined,
+                undefined,
+                adminAuth,
+              )
             } catch {
               /* probe cleanup is best-effort */
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.58.4",
+  "version": "0.58.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## spindb 0.58.5

### `fix(couchdb)`: the readiness WRITE probe authenticated as `admin:admin` - the actual lockout root cause

This is the real fix for the CouchDB `403 "Account is temporarily locked"` the Layerbase Cloud restore-drill kept hitting. 0.58.1-0.58.4 each removed a real-but-secondary factor (probe-retry, the [admins] duplicate, the start admin-readiness probe); none was the core cause.

`couchdbApiRequest` defaults its `auth` argument to `{ username: 'admin', password: 'admin' }`. `waitForReady`'s **write probe** (`PUT /spindb_writeprobe`) and its DELETE called it **without** an auth argument, so they authenticated as `admin:admin`. CouchDB is created with the `admin:admin` default, so the **first** start's probe succeeds - but once a deployment rotates `[admins]` to a real password (Layerbase Cloud patches it out-of-band, then restarts), the probe's `admin:admin` PUT is a **failed `admin` auth**. The probe retries every 500ms for up to 30s, so **~60 failed auths** pile up on the restart and trip CouchDB's brute-force protection, which then rejects even the **correct** credentials for the lockout window - breaking a backup/restore run right after create.

**Fix:** the write/delete probes now use the database's **saved** admin credentials (written together with the `[admins]` password, so they match - the PUT succeeds), and `waitForReady` treats a 401/403 on the write probe as "node up and auth-gating" (ready) rather than retrying. Net effect: **zero failed `admin` auths during startup**, so the account is never locked.

**Validation:** a real-engine local reproduction confirms both halves - rotating a running couchdb's `[admins]` password and issuing ~60 `admin:admin` PUTs (what the old probe did) produces the exact `403 "Account is temporarily locked"`, while the rotated credentials authenticate cleanly across a stop/start with the fix. The Layerbase Cloud restore-drill is the end-to-end gate once the image picks up 0.58.5.

Merging publishes 0.58.5 to npm; Layerbase Cloud then bumps `SPINDB_VERSION` to 0.58.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CouchDB startup readiness check to use saved admin credentials instead of default credentials, preventing brute-force lockouts during startup and restore scenarios. The write probe now properly treats authentication responses as "ready" instead of retrying indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->