### PR TITLE
fix(mongodb): authenticate backup/restore against the correct authSource (cloud admin vs local db) - v0.58.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.6] - 2026-06-17
+
+### Fixed
+
+- **MongoDB backup/restore now authenticate correctly regardless of where the auth user lives (`<database>` vs `admin`).** `mongodump`/`mongorestore` always built their connection with `authSource = savedCreds.database || 'admin'`, i.e. they authenticated against the TARGET database. That is correct for a spindb-created mongo (spindb's `createUser` puts the user in `<database>`), but WRONG when an external provisioner creates the root user in `admin` - e.g. Layerbase Cloud runs `MONGO_INITDB_ROOT` (`root@admin`; its connection strings use `?authSource=admin`). Against such a deployment every delegated `mongodump`/`mongorestore` failed `AuthenticationFailed`. Two-part fix so spindb is correct in BOTH environments, with the caller able to say which:
+  - **Explicit contract:** `UserCredentials` gains an optional `authSource`, persisted as `DB_AUTH_SOURCE` in the credential file. A caller that provisions the user outside `<database>` (the cloud) sets it to `admin`, and backup/restore authenticate against it with no guessing. When unset (a normal local `spindb create`), behavior is unchanged.
+  - **Fallback:** when `authSource` is not set, backup/restore try `<database>` then `admin`, retrying ONLY on an authentication failure (`resolveMongoAuthSources` / `isMongoAuthError`). This keeps local spindb mongos correct by default AND makes an already-provisioned cloud mongo (whose credential file predates the field) work with no backfill. MongoDB has no failed-auth lockout, so the extra attempt is safe.
+  - `getLocalAuth` (the mongosh/console path) also honors the explicit `authSource`.
+  Found by the Layerbase Cloud e2e canary running REAL mongodb (the restore-drill SKIPs mongo under SSPL and had only proxied it via FerretDB, which authenticates differently).
+
 ## [0.58.5] - 2026-06-17
 
 ### Fixed

--- a/core/credential-manager.ts
+++ b/core/credential-manager.ts
@@ -129,6 +129,12 @@ function formatCredentials(credentials: UserCredentials): string {
     if (credentials.database) {
       lines.push(`DB_NAME=${encodeEnvValue(credentials.database)}`)
     }
+    // Explicit auth database (MongoDB): when the auth user is not in <database>
+    // (e.g. a cloud root user in `admin`), the caller persists it so backup/
+    // restore authenticate against the right database without guessing.
+    if (credentials.authSource) {
+      lines.push(`DB_AUTH_SOURCE=${encodeEnvValue(credentials.authSource)}`)
+    }
     lines.push(`DB_URL=${encodeEnvValue(credentials.connectionString)}`)
   }
 
@@ -185,6 +191,7 @@ function parseCredentialFile(
     engine,
     container: containerName,
     database: vars.DB_NAME,
+    authSource: vars.DB_AUTH_SOURCE,
   }
 }
 

--- a/engines/mongo-uri.ts
+++ b/engines/mongo-uri.ts
@@ -5,7 +5,39 @@ export type MongoWireAuth = {
 }
 
 export function normalizeMongoHost(bindAddress?: string): string {
-  return bindAddress === '0.0.0.0' ? '127.0.0.1' : bindAddress ?? '127.0.0.1'
+  return bindAddress === '0.0.0.0' ? '127.0.0.1' : (bindAddress ?? '127.0.0.1')
+}
+
+/**
+ * Resolve the candidate auth databases (mongo `authSource`) to try, in order.
+ *
+ * - An explicit `authSource` (persisted by a caller that provisioned the user
+ *   elsewhere - e.g. a cloud that creates the root user in `admin` via
+ *   MONGO_INITDB_ROOT) is authoritative: return it alone, no guessing.
+ * - Otherwise fall back to `<database>` (spindb's own `createUser` puts the user
+ *   in the target database) then `admin` (the MongoDB root-user convention), so
+ *   backup/restore authenticate whether the user was created by spindb locally
+ *   or by an external provisioner. Deduped, since `database` may be `admin`.
+ */
+export function resolveMongoAuthSources(options: {
+  authSource?: string
+  database?: string
+}): string[] {
+  if (options.authSource) {
+    return [options.authSource]
+  }
+  const candidates = [options.database, 'admin'].filter((d): d is string => !!d)
+  return candidates.length > 0 ? [...new Set(candidates)] : ['admin']
+}
+
+/**
+ * Whether a mongodump/mongorestore failure looks like an authentication failure,
+ * so the caller can retry against the next candidate authSource.
+ */
+export function isMongoAuthError(stderr: string): boolean {
+  return /AuthenticationFailed|auth error|Authentication failed|not authorized|requires authentication|UserNotFound/i.test(
+    stderr,
+  )
 }
 
 export function buildMongoUri(

--- a/engines/mongodb/backup.ts
+++ b/engines/mongodb/backup.ts
@@ -133,7 +133,7 @@ export async function createBackup(
           '--db',
           db,
         ]
-      : ['--host', '127.0.0.1', '--port', String(port), '--db', db]
+      : ['--host', host, '--port', String(port), '--db', db]
     return [...connection, ...formatArgs]
   }
 

--- a/engines/mongodb/backup.ts
+++ b/engines/mongodb/backup.ts
@@ -9,10 +9,22 @@ import { existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { mkdir } from 'fs/promises'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { getMongodumpPath, MONGODUMP_NOT_FOUND_ERROR } from './cli-utils'
-import { buildMongoUri } from '../mongo-uri'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  buildMongoUri,
+  resolveMongoAuthSources,
+  isMongoAuthError,
+} from '../mongo-uri'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 function redactMongoUri(uri: string): string {
   try {
@@ -84,94 +96,130 @@ export async function createBackup(
     getDefaultUsername(Engine.MongoDB),
   )
 
-  const args: string[] = savedCreds
-    ? [
-        '--uri',
-        buildMongoUri(port, db, {
-          username: savedCreds.username,
-          password: savedCreds.password,
-          authDatabase: savedCreds.database || 'admin',
-        }, container.bindAddress ?? '127.0.0.1'),
-        '--db',
-        db,
-      ]
-    : [
-        '--host',
-        '127.0.0.1',
-        '--port',
-        String(port),
-        '--db',
-        db,
-      ]
-
   // Determine output format (default to 'archive' as per backup-formats.ts)
   const format = options.format ?? 'archive'
   const isSingleFileArchive = format === 'archive' || format === 'archive-plain'
-  if (format === 'archive') {
-    // Archive format: single compressed file
-    args.push('--archive=' + outputPath, '--gzip')
-  } else if (format === 'archive-plain') {
-    // Uncompressed single-file archive (no --gzip), for consumers whose restore
-    // path does not pass --gzip (e.g. a plain `mongorestore --archive`). The
-    // restore side auto-detects gzip vs plain (detectBackupFormat).
-    args.push('--archive=' + outputPath)
-  } else {
-    // Directory format (bson): output to directory
-    args.push('--out', outputPath)
+  const formatArgs: string[] =
+    format === 'archive'
+      ? // Archive format: single compressed file
+        ['--archive=' + outputPath, '--gzip']
+      : format === 'archive-plain'
+        ? // Uncompressed single-file archive (no --gzip), for consumers whose
+          // restore path does not pass --gzip (e.g. a plain `mongorestore
+          // --archive`). The restore side auto-detects gzip vs plain.
+          ['--archive=' + outputPath]
+        : // Directory format (bson): output to directory
+          ['--out', outputPath]
+
+  // Build mongodump args for a given authSource. With saved credentials the auth
+  // user may live in <database> (spindb's own createUser) OR in `admin` (an
+  // external provisioner's root user, e.g. the cloud's MONGO_INITDB_ROOT) - so we
+  // try the candidate authSources in order and retry on an authentication failure.
+  const host = container.bindAddress ?? '127.0.0.1'
+  const argsForAuthSource = (authDatabase: string | null): string[] => {
+    const connection = authDatabase
+      ? [
+          '--uri',
+          buildMongoUri(
+            port,
+            db,
+            {
+              username: savedCreds!.username,
+              password: savedCreds!.password,
+              authDatabase,
+            },
+            host,
+          ),
+          '--db',
+          db,
+        ]
+      : ['--host', '127.0.0.1', '--port', String(port), '--db', db]
+    return [...connection, ...formatArgs]
   }
 
-  logDebug(`Running mongodump with args: ${sanitizeMongoArgs(args).join(' ')}`)
+  const authSources: (string | null)[] = savedCreds
+    ? resolveMongoAuthSources({
+        authSource: savedCreds.authSource,
+        database: savedCreds.database,
+      })
+    : [null]
 
-  // Note: Don't use shell mode - spawn handles paths with spaces correctly
-  // when shell: false (the default). Shell mode breaks paths like "C:\Program Files\..."
-  const spawnOptions: SpawnOptions = {
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }
+  const runMongodump = (args: string[]): Promise<BackupResult> => {
+    logDebug(
+      `Running mongodump with args: ${sanitizeMongoArgs(args).join(' ')}`,
+    )
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn(mongodump, args, spawnOptions)
+    // Note: Don't use shell mode - spawn handles paths with spaces correctly
+    // when shell: false (the default). Shell mode breaks paths like "C:\Program Files\..."
+    const spawnOptions: SpawnOptions = {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
 
-    let stderr = ''
+    return new Promise((resolve, reject) => {
+      const proc = spawn(mongodump, args, spawnOptions)
 
-    proc.stdout?.on('data', () => {
-      // mongodump outputs progress to stderr, stdout is typically empty
-    })
-    proc.stderr?.on('data', (data: Buffer) => {
-      stderr += data.toString()
-    })
+      let stderr = ''
 
-    proc.on('error', reject)
+      proc.stdout?.on('data', () => {
+        // mongodump outputs progress to stderr, stdout is typically empty
+      })
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString()
+      })
 
-    proc.on('close', async (code) => {
-      if (code === 0) {
-        // Get backup size
-        let size = 0
-        try {
-          if (isSingleFileArchive) {
-            // Archive file (compressed or plain)
-            const stats = await stat(outputPath)
-            size = stats.size
-          } else {
-            // Directory - sum up all dumped files
-            const dbDir = join(outputPath, db)
-            if (existsSync(dbDir)) {
-              size = await getDirectorySize(dbDir)
+      proc.on('error', reject)
+
+      proc.on('close', async (code) => {
+        if (code === 0) {
+          // Get backup size
+          let size = 0
+          try {
+            if (isSingleFileArchive) {
+              // Archive file (compressed or plain)
+              const stats = await stat(outputPath)
+              size = stats.size
+            } else {
+              // Directory - sum up all dumped files
+              const dbDir = join(outputPath, db)
+              if (existsSync(dbDir)) {
+                size = await getDirectorySize(dbDir)
+              }
             }
+          } catch {
+            // Size calculation failed, use 0
           }
-        } catch {
-          // Size calculation failed, use 0
-        }
 
-        resolve({
-          path: outputPath,
-          format: isSingleFileArchive ? 'archive' : 'directory',
-          size,
-        })
-      } else {
-        reject(new Error(stderr || `mongodump exited with code ${code}`))
-      }
+          resolve({
+            path: outputPath,
+            format: isSingleFileArchive ? 'archive' : 'directory',
+            size,
+          })
+        } else {
+          reject(new Error(stderr || `mongodump exited with code ${code}`))
+        }
+      })
     })
-  })
+  }
+
+  // Try each candidate authSource, retrying ONLY on authentication failures.
+  let lastError: Error | undefined
+  for (let i = 0; i < authSources.length; i++) {
+    try {
+      return await runMongodump(argsForAuthSource(authSources[i]))
+    } catch (error) {
+      lastError = error as Error
+      const isLastAttempt = i === authSources.length - 1
+      if (!isLastAttempt && isMongoAuthError(lastError.message)) {
+        logDebug(
+          `mongodump auth failed against authSource=${authSources[i]}; retrying with next candidate`,
+        )
+        continue
+      }
+      throw lastError
+    }
+  }
+  // Unreachable (the loop returns or throws); satisfies the type checker.
+  throw lastError ?? new Error('mongodump failed')
 }
 
 /**

--- a/engines/mongodb/index.ts
+++ b/engines/mongodb/index.ts
@@ -13,7 +13,10 @@ import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
 import { platformService, isWindows } from '../../core/platform-service'
 import { configManager } from '../../core/config-manager'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import {
   logDebug,
   logWarning,
@@ -31,7 +34,11 @@ import {
 } from './restore'
 import { createBackup } from './backup'
 import { getMongodumpPath, MONGODUMP_NOT_FOUND_ERROR } from './cli-utils'
-import { buildMongoUri, normalizeMongoHost, type MongoWireAuth } from '../mongo-uri'
+import {
+  buildMongoUri,
+  normalizeMongoHost,
+  type MongoWireAuth,
+} from '../mongo-uri'
 import {
   Engine,
   Platform,
@@ -463,7 +470,9 @@ export class MongoDBEngine extends BaseEngine {
     return {
       username: savedCreds.username,
       password: savedCreds.password,
-      authDatabase: savedCreds.database || 'admin',
+      // Explicit authSource (e.g. a cloud root user provisioned in `admin`) wins;
+      // otherwise spindb's own createUser puts the user in <database>.
+      authDatabase: savedCreds.authSource || savedCreds.database || 'admin',
     }
   }
 
@@ -475,14 +484,7 @@ export class MongoDBEngine extends BaseEngine {
     const savedCreds = await this.getLocalAuth(container.name)
     const host = normalizeMongoHost(container.bindAddress)
     const args = savedCreds
-      ? [
-          buildMongoUri(
-            container.port,
-            database,
-            savedCreds,
-            host,
-          ),
-        ]
+      ? [buildMongoUri(container.port, database, savedCreds, host)]
       : ['--host', host, '--port', String(container.port), database]
 
     if (options?.quiet) {
@@ -495,7 +497,12 @@ export class MongoDBEngine extends BaseEngine {
   private async runLocalMongosh(
     container: ContainerConfig,
     database: string,
-    options: { eval?: string; file?: string; quiet?: boolean; timeoutMs?: number },
+    options: {
+      eval?: string
+      file?: string
+      quiet?: boolean
+      timeoutMs?: number
+    },
   ): Promise<{ stdout: string; stderr: string }> {
     const mongosh = await this.getMongoshPath()
     const args = await this.buildLocalMongoshArgs(container, database, {
@@ -1027,22 +1034,22 @@ export class MongoDBEngine extends BaseEngine {
       args = [uri, '--quiet', '--eval', wrappedScript]
     } else if (options?.password) {
       // Local with auth: build URI with credentials
-      const uri = buildMongoUri(port, db, {
-        username: options.username || 'admin',
-        password: options.password,
-        authDatabase: 'admin',
-      }, normalizedHost)
+      const uri = buildMongoUri(
+        port,
+        db,
+        {
+          username: options.username || 'admin',
+          password: options.password,
+          authDatabase: 'admin',
+        },
+        normalizedHost,
+      )
       args = [uri, '--quiet', '--eval', wrappedScript]
     } else {
       const savedCreds = await this.getLocalAuth(container.name)
       args = savedCreds
         ? [
-            buildMongoUri(
-              port,
-              db,
-              savedCreds,
-              normalizedHost,
-            ),
+            buildMongoUri(port, db, savedCreds, normalizedHost),
             '--quiet',
             '--eval',
             wrappedScript,

--- a/engines/mongodb/restore.ts
+++ b/engines/mongodb/restore.ts
@@ -203,7 +203,7 @@ export async function restoreBackup(
             host,
           ),
         ]
-      : ['--host', '127.0.0.1', '--port', String(port)]
+      : ['--host', host, '--port', String(port)]
 
   const authSources: (string | null)[] = savedCreds
     ? resolveMongoAuthSources({

--- a/engines/mongodb/restore.ts
+++ b/engines/mongodb/restore.ts
@@ -8,10 +8,17 @@ import { existsSync, readdirSync, statSync } from 'fs'
 import { open } from 'fs/promises'
 import { join } from 'path'
 import { logDebug, logWarning } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { containerManager } from '../../core/container-manager'
 import { getMongorestorePath, MONGORESTORE_NOT_FOUND_ERROR } from './cli-utils'
-import { buildMongoUri } from '../mongo-uri'
+import {
+  buildMongoUri,
+  resolveMongoAuthSources,
+  isMongoAuthError,
+} from '../mongo-uri'
 import { Engine, type BackupFormat, type RestoreResult } from '../../types'
 
 // Detect the format of a MongoDB backup
@@ -171,22 +178,41 @@ export async function restoreBackup(
         getDefaultUsername(Engine.MongoDB),
       )
     : null
-  const container =
-    options.containerName
-      ? await containerManager.getConfig(options.containerName)
-      : null
+  const container = options.containerName
+    ? await containerManager.getConfig(options.containerName)
+    : null
   const host = container?.bindAddress ?? '127.0.0.1'
 
-  const args: string[] = savedCreds
-    ? [
-        '--uri',
-        buildMongoUri(port, database, {
-          username: savedCreds.username,
-          password: savedCreds.password,
-          authDatabase: savedCreds.database || 'admin',
-        }, host),
-      ]
-    : ['--host', '127.0.0.1', '--port', String(port)]
+  // Auth args (--uri/--host) vary by authSource; the rest of `args` (--drop,
+  // archive/path, namespace remap, built below) does not. With saved credentials
+  // the auth user may live in <database> (spindb's createUser) OR in `admin` (an
+  // external provisioner's root user, e.g. the cloud's MONGO_INITDB_ROOT), so we
+  // try the candidate authSources in order and retry on an authentication failure.
+  const authArgsForAuthSource = (authDatabase: string | null): string[] =>
+    authDatabase
+      ? [
+          '--uri',
+          buildMongoUri(
+            port,
+            database,
+            {
+              username: savedCreds!.username,
+              password: savedCreds!.password,
+              authDatabase,
+            },
+            host,
+          ),
+        ]
+      : ['--host', '127.0.0.1', '--port', String(port)]
+
+  const authSources: (string | null)[] = savedCreds
+    ? resolveMongoAuthSources({
+        authSource: savedCreds.authSource,
+        database: savedCreds.database,
+      })
+    : [null]
+
+  const args: string[] = []
 
   if (drop) {
     args.push('--drop')
@@ -261,56 +287,81 @@ export async function restoreBackup(
     addNamespaceRemapArgs(args, sourceDatabase, database)
   }
 
-  logDebug(`Running mongorestore with args: ${args.join(' ')}`)
+  const runMongorestore = (attemptArgs: string[]): Promise<RestoreResult> => {
+    logDebug(`Running mongorestore with args: ${attemptArgs.join(' ')}`)
 
-  // Note: Don't use shell mode - spawn handles paths with spaces correctly
-  // when shell: false (the default). Shell mode breaks paths like "C:\Program Files\..."
-  const spawnOptions: SpawnOptions = {
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }
+    // Note: Don't use shell mode - spawn handles paths with spaces correctly
+    // when shell: false (the default). Shell mode breaks paths like "C:\Program Files\..."
+    const spawnOptions: SpawnOptions = {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
 
-  return new Promise((resolve, reject) => {
-    const proc = spawn(mongorestore, args, spawnOptions)
+    return new Promise((resolve, reject) => {
+      const proc = spawn(mongorestore, attemptArgs, spawnOptions)
 
-    let stdout = ''
-    let stderr = ''
+      let stdout = ''
+      let stderr = ''
 
-    proc.stdout?.on('data', (data: Buffer) => {
-      stdout += data.toString()
-    })
-    proc.stderr?.on('data', (data: Buffer) => {
-      stderr += data.toString()
-    })
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString()
+      })
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString()
+      })
 
-    proc.on('error', reject)
+      proc.on('error', reject)
 
-    proc.on('close', (code) => {
-      if (code === 0) {
-        resolve({
-          format: format.format,
-          stdout,
-          stderr,
-          code,
-        })
-      } else {
-        // mongorestore may exit with non-zero but still restore some data
-        if (
-          stderr.includes('continuing') ||
-          stderr.includes('documents restored')
-        ) {
-          logWarning(`mongorestore completed with warnings: ${stderr}`)
+      proc.on('close', (code) => {
+        if (code === 0) {
           resolve({
             format: format.format,
             stdout,
             stderr,
-            code: code ?? undefined,
+            code,
           })
         } else {
-          reject(new Error(stderr || `mongorestore exited with code ${code}`))
+          // mongorestore may exit with non-zero but still restore some data
+          if (
+            stderr.includes('continuing') ||
+            stderr.includes('documents restored')
+          ) {
+            logWarning(`mongorestore completed with warnings: ${stderr}`)
+            resolve({
+              format: format.format,
+              stdout,
+              stderr,
+              code: code ?? undefined,
+            })
+          } else {
+            reject(new Error(stderr || `mongorestore exited with code ${code}`))
+          }
         }
-      }
+      })
     })
-  })
+  }
+
+  // Try each candidate authSource, retrying ONLY on authentication failures.
+  let lastError: Error | undefined
+  for (let i = 0; i < authSources.length; i++) {
+    try {
+      return await runMongorestore([
+        ...authArgsForAuthSource(authSources[i]),
+        ...args,
+      ])
+    } catch (error) {
+      lastError = error as Error
+      const isLastAttempt = i === authSources.length - 1
+      if (!isLastAttempt && isMongoAuthError(lastError.message)) {
+        logDebug(
+          `mongorestore auth failed against authSource=${authSources[i]}; retrying with next candidate`,
+        )
+        continue
+      }
+      throw lastError
+    }
+  }
+  // Unreachable (the loop returns or throws); satisfies the type checker.
+  throw lastError ?? new Error('mongorestore failed')
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.58.5",
+  "version": "0.58.6",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/credential-manager.test.ts
+++ b/tests/unit/credential-manager.test.ts
@@ -184,6 +184,57 @@ describe('Credential Manager', () => {
       assert(loaded === null, 'Should return null')
     })
 
+    it('should round-trip an explicit authSource (mongo cloud root user in admin)', async () => {
+      // A caller that provisions the auth user outside <database> (e.g. a cloud
+      // creating the root user in `admin`) persists authSource so backup/restore
+      // authenticate against the right database without guessing.
+      const original: UserCredentials = {
+        username: 'layerbase',
+        password: 'secret123',
+        connectionString: 'mongodb://layerbase:secret123@127.0.0.1:27017/mydb',
+        engine: Engine.MongoDB,
+        container: TEST_CONTAINER,
+        database: 'mydb',
+        authSource: 'admin',
+      }
+
+      await saveCredentials(TEST_CONTAINER, Engine.MongoDB, original)
+      const loaded = await loadCredentials(
+        TEST_CONTAINER,
+        Engine.MongoDB,
+        'layerbase',
+      )
+
+      assert(loaded !== null, 'Should load credentials')
+      assertEqual(loaded!.authSource, 'admin', 'authSource should round-trip')
+      assertEqual(loaded!.database, 'mydb', 'Database should still match')
+    })
+
+    it('should leave authSource undefined when not persisted (local default)', async () => {
+      const original: UserCredentials = {
+        username: 'appuser',
+        password: 'secret123',
+        connectionString: 'mongodb://appuser:secret123@127.0.0.1:27017/mydb',
+        engine: Engine.MongoDB,
+        container: TEST_CONTAINER,
+        database: 'mydb',
+      }
+
+      await saveCredentials(TEST_CONTAINER, Engine.MongoDB, original)
+      const loaded = await loadCredentials(
+        TEST_CONTAINER,
+        Engine.MongoDB,
+        'appuser',
+      )
+
+      assert(loaded !== null, 'Should load credentials')
+      assertEqual(
+        loaded!.authSource,
+        undefined,
+        'authSource stays undefined so backup/restore use the db->admin fallback',
+      )
+    })
+
     it('should load API key credentials', async () => {
       const original: UserCredentials = {
         username: 'mykey',

--- a/tests/unit/mongo-auth-source.test.ts
+++ b/tests/unit/mongo-auth-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveMongoAuthSources,
+  isMongoAuthError,
+} from '../../engines/mongo-uri'
+
+// Mongo's auth user does not always live in the target database: spindb's own
+// createUser puts it in <database>, but an external provisioner (e.g. a cloud
+// that runs MONGO_INITDB_ROOT) creates the root user in `admin`. backup/restore
+// resolve the candidate authSources from these helpers and retry on auth failure.
+
+describe('resolveMongoAuthSources', () => {
+  it('returns ONLY the explicit authSource when set (no guessing)', () => {
+    assert.deepEqual(
+      resolveMongoAuthSources({ authSource: 'admin', database: 'mydb' }),
+      ['admin'],
+    )
+    // explicit wins even if it equals the database
+    assert.deepEqual(
+      resolveMongoAuthSources({ authSource: 'mydb', database: 'mydb' }),
+      ['mydb'],
+    )
+  })
+
+  it('falls back to <database> then admin when no explicit authSource', () => {
+    // spindb-created (local): user is in <database>, so it is tried first; admin
+    // is the fallback for an externally-provisioned root user.
+    assert.deepEqual(resolveMongoAuthSources({ database: 'mydb' }), [
+      'mydb',
+      'admin',
+    ])
+  })
+
+  it('dedupes when the database IS admin', () => {
+    assert.deepEqual(resolveMongoAuthSources({ database: 'admin' }), ['admin'])
+  })
+
+  it('defaults to admin when neither is provided', () => {
+    assert.deepEqual(resolveMongoAuthSources({}), ['admin'])
+  })
+})
+
+describe('isMongoAuthError', () => {
+  it('matches the real mongodump/mongorestore auth-failure stderr', () => {
+    // The exact failure the cloud hit: spindb authed with authSource=<db> but the
+    // cloud root user is in admin.
+    assert.equal(
+      isMongoAuthError(
+        "Failed: can't create session: ... auth error: ... (AuthenticationFailed) Authentication failed.",
+      ),
+      true,
+    )
+    assert.equal(isMongoAuthError('command requires authentication'), true)
+    assert.equal(isMongoAuthError('not authorized on mydb to execute'), true)
+  })
+
+  it('does NOT match unrelated failures (so we do not retry pointlessly)', () => {
+    assert.equal(isMongoAuthError('connection refused'), false)
+    assert.equal(isMongoAuthError('gzip: invalid header'), false)
+    assert.equal(isMongoAuthError(''), false)
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -317,6 +317,12 @@ export type UserCredentials = {
   engine: Engine
   container: string
   database?: string
+  // Explicit auth database for engines where the auth user does not live in the
+  // target database (MongoDB). When a caller provisions the user elsewhere - e.g.
+  // a cloud that creates the root user in `admin` (MONGO_INITDB_ROOT) - it sets
+  // this to tell backup/restore which database to authenticate against. When
+  // unset, mongo backup/restore fall back to <database> then `admin`.
+  authSource?: string
   apiKey?: string // Meilisearch, Qdrant, LibSQL (JWT token)
 }
 


### PR DESCRIPTION
## The bug

`mongodump`/`mongorestore` always built their connection with `authSource = savedCreds.database || 'admin'` - they authenticated against the **target database**. That's correct for a spindb-created mongo (spindb's `createUser` puts the user in `<database>`), but **wrong** when an external provisioner creates the root user in `admin` - e.g. Layerbase Cloud runs `MONGO_INITDB_ROOT` (`root@admin`; its connection strings use `?authSource=admin`). Against such a deployment every delegated `mongodump`/`mongorestore` failed `AuthenticationFailed` inside the container.

Found by the cloud e2e canary running **real mongodb**. spindb's restore-drill SKIPs mongo under SSPL and had only proxied it via FerretDB (Postgres-backed, authenticates differently), so this never surfaced in spindb's own tests.

## The fix - correct in BOTH environments, caller picks which

- **Explicit contract:** `UserCredentials` gains optional `authSource`, persisted as `DB_AUTH_SOURCE` in the credential file. A caller that provisions the user outside `<database>` (the cloud) sets it to `admin`; backup/restore authenticate against it with no guessing. Unset = unchanged local behavior.
- **Fallback:** when `authSource` is unset, try `<database>` then `admin`, retrying **only** on an authentication failure (`resolveMongoAuthSources` / `isMongoAuthError`). Keeps local spindb mongos correct by default AND fixes an already-provisioned cloud mongo (cred file predates the field) with **no backfill**. MongoDB has no failed-auth lockout, so the extra attempt is safe.
- `getLocalAuth` (mongosh/console path) honors explicit `authSource` too.

## Tests / validation

- New `tests/unit/mongo-auth-source.test.ts`: `resolveMongoAuthSources` (explicit / db→admin fallback / dedupe / default) + `isMongoAuthError` (matches real stderr, ignores unrelated failures).
- `credential-manager.test.ts`: `authSource` round-trips via `DB_AUTH_SOURCE`; stays undefined when not persisted.
- `pnpm check` (tsc) clean, prettier clean, full unit suite **1651 pass / 0 fail**.

Bumps to **0.58.6**. After this publishes, the cloud writes `DB_AUTH_SOURCE=admin` in `setup-database.sh`, bumps `SPINDB_VERSION`, adds a real-mongo validation leg, and re-enables mongo backup/restore delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional authentication source parameter for MongoDB credentials to support advanced deployment scenarios.

* **Bug Fixes**
  * Fixed backup/restore authentication failures in cloud deployments where root users reside in the admin database.
  * Improved authentication handling with automatic fallback logic that tries the target database, then admin, when no explicit source is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->