### PR TITLE
feat(memory): engine-agnostic memory budget (--memory-budget-mb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.60.0] - 2026-06-29
+
+### Added
+
+- **`spindb create --memory-budget-mb <n>`**: a soft memory budget (MB)
+  persisted on the container and re-applied on every start. Engine-agnostic seam
+  (`core/memory-budget.ts`): MySQL turns off `performance_schema` and shrinks the
+  InnoDB buffer pool; MariaDB trims its InnoDB buffer pool and Aria pagecache;
+  other engines run at their defaults (no-op). Lets a caller run MySQL-family
+  databases lean - a default MySQL measured ~547 MB RSS vs ~169 MB for MariaDB,
+  the difference being `performance_schema` (MySQL ships it on, MariaDB off).
+
 ## [0.59.1] - 2026-06-23
 
 ### Fixed

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -7,6 +7,7 @@ Quick reference for all SpinDB commands.
 ```bash
 spindb create mydb                      # Create PostgreSQL (default)
 spindb create mydb -e mysql             # Create MySQL
+spindb create mydb -e mysql --memory-budget-mb 256  # Lean MySQL (perf_schema off + small buffer pool)
 spindb create mydb -e mariadb           # Create MariaDB
 spindb create mydb -e sqlite            # Create SQLite
 spindb create mydb -e duckdb            # Create DuckDB

--- a/cli/commands/create.ts
+++ b/cli/commands/create.ts
@@ -464,6 +464,10 @@ export const createCommand = new Command('create')
     'Maximum number of database connections (default: 200)',
   )
   .option(
+    '--memory-budget-mb <number>',
+    'Soft memory budget in MB; engines run lean within it (MySQL/MariaDB so far, others ignore it)',
+  )
+  .option(
     '-f, --force',
     'Overwrite existing container without prompting (deletes existing data)',
   )
@@ -489,6 +493,7 @@ export const createCommand = new Command('create')
         port?: string
         path?: string
         maxConnections?: string
+        memoryBudgetMb?: string
         force?: boolean
         start?: boolean
         connect?: boolean
@@ -581,7 +586,6 @@ export const createCommand = new Command('create')
             )
           }
         }
-
 
         // Redis/Valkey use numbered databases (0-15), default to "0"
         // Other engines default to container name (with hyphens replaced by underscores for SQL compatibility)
@@ -704,6 +708,18 @@ export const createCommand = new Command('create')
             return exitWithError({
               message:
                 'Invalid --max-connections value: must be a positive integer',
+              json: options.json,
+            })
+          }
+        }
+
+        // Validate --memory-budget-mb if provided
+        if (options.memoryBudgetMb) {
+          const parsed = parseInt(options.memoryBudgetMb, 10)
+          if (!Number.isFinite(parsed) || parsed <= 0) {
+            return exitWithError({
+              message:
+                'Invalid --memory-budget-mb value: must be a positive integer',
               json: options.json,
             })
           }
@@ -891,6 +907,9 @@ export const createCommand = new Command('create')
             port,
             database,
             binaryPath,
+            memoryBudgetMb: options.memoryBudgetMb
+              ? parseInt(options.memoryBudgetMb, 10)
+              : undefined,
           })
 
           tx.addRollback({

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -46,6 +46,8 @@ export type CreateOptions = {
   database: string
   /** Path to the engine binary (for system-installed engines like MySQL, MongoDB, Redis) */
   binaryPath?: string
+  /** Soft memory budget (MB) for the engine's fixed structures. Persisted; applied per-engine at start. */
+  memoryBudgetMb?: number
 }
 
 export type DeleteOptions = {
@@ -54,7 +56,8 @@ export type DeleteOptions = {
 
 export class ContainerManager {
   async create(name: string, options: CreateOptions): Promise<ContainerConfig> {
-    const { engine, version, port, database, binaryPath } = options
+    const { engine, version, port, database, binaryPath, memoryBudgetMb } =
+      options
 
     // Validate container name
     if (!this.isValidName(name)) {
@@ -88,6 +91,8 @@ export class ContainerManager {
       // Store binary path for system-installed engines (MySQL, MongoDB, Redis)
       // This ensures version consistency when starting the container
       ...(binaryPath && { binaryPath }),
+      // Persist the memory budget so every start/wake re-applies it.
+      ...(memoryBudgetMb ? { memoryBudgetMb } : {}),
     }
 
     await this.saveConfig(name, { engine }, config)

--- a/core/memory-budget.ts
+++ b/core/memory-budget.ts
@@ -1,0 +1,54 @@
+import { Engine } from '../types'
+
+/**
+ * Translate a memory budget (MB) into engine-specific server args that shrink
+ * the engine's fixed RAM footprint. This is the engine-agnostic seam: every
+ * engine maps the same budget its own way, and an engine with no mapping (or no
+ * budget) returns [] so it just runs at its defaults.
+ *
+ * Set via `spindb create --memory-budget-mb <n>` and persisted on the container
+ * (ContainerConfig.memoryBudgetMb), so it is re-applied on every start/wake.
+ *
+ * Measured 2026-06-29: a default MySQL is ~547 MB RSS vs MariaDB ~169 MB for the
+ * same role, both on InnoDB - the difference is almost entirely
+ * performance_schema (MySQL ships it ON, MariaDB OFF). So performance_schema is
+ * the dominant lever for MySQL; the InnoDB buffer pool (128 MB default on both)
+ * is secondary.
+ *
+ * @param engine    the container's engine
+ * @param budgetMb  soft target for the engine's fixed structures, in MB.
+ *                  Undefined or <= 0 means "no budget" (engine defaults).
+ */
+export function memoryBudgetArgs(
+  engine: Engine,
+  budgetMb: number | undefined,
+): string[] {
+  if (!budgetMb || budgetMb <= 0) return []
+
+  // Buffer-pool / cache sizing scaled from the budget, floored so the engine
+  // stays healthy (InnoDB dislikes a sub-64 MB pool).
+  const cacheMb = Math.max(64, Math.floor(budgetMb / 4))
+
+  switch (engine) {
+    case Engine.MySQL:
+      // performance_schema is the big consumer (~200-400 MB, auto-sized for
+      // max_connections); turning it off is most of the win. The buffer pool is
+      // scaled down from its 128 MB default. max_connections is left alone (a
+      // pooler caps real clients; mysqld needs backend headroom).
+      return [
+        '--performance-schema=OFF',
+        `--innodb-buffer-pool-size=${cacheMb}M`,
+      ]
+    case Engine.MariaDB:
+      // MariaDB already ships performance_schema OFF, so it is lean by default.
+      // Trim the InnoDB buffer pool and the Aria pagecache (both 128 MB by
+      // default) for a marginal additional reduction.
+      return [
+        `--innodb-buffer-pool-size=${cacheMb}M`,
+        `--aria-pagecache-buffer-size=${cacheMb}M`,
+      ]
+    default:
+      // No translation for this engine yet -> run at engine defaults.
+      return []
+  }
+}

--- a/engines/mariadb/index.ts
+++ b/engines/mariadb/index.ts
@@ -10,6 +10,7 @@ import { join } from 'path'
 import { BaseEngine } from '../base-engine'
 import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
+import { memoryBudgetArgs } from '../../core/memory-budget'
 import {
   platformService,
   isWindows,
@@ -436,6 +437,10 @@ export class MariaDBEngine extends BaseEngine {
       `--max-connections=${engineDef.maxConnections}`,
       '--host-cache-size=0',
     ]
+
+    // Engine-agnostic memory budget (persisted on the container, set via
+    // `spindb create --memory-budget-mb`). No-op when unset.
+    args.push(...memoryBudgetArgs(container.engine, container.memoryBudgetMb))
 
     if (platform !== Platform.Win32) {
       const socketFile = join(

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -11,6 +11,7 @@ import { join } from 'path'
 import { BaseEngine } from '../base-engine'
 import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
+import { memoryBudgetArgs } from '../../core/memory-budget'
 import {
   platformService,
   isWindows,
@@ -526,6 +527,10 @@ export class MySQLEngine extends BaseEngine {
       `--max-connections=${engineDef.maxConnections}`,
       '--host-cache-size=0',
     ]
+
+    // Engine-agnostic memory budget (persisted on the container, set via
+    // `spindb create --memory-budget-mb`). No-op when unset.
+    args.push(...memoryBudgetArgs(container.engine, container.memoryBudgetMb))
 
     if (platform !== Platform.Win32) {
       const socketFile = join(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.59.1",
+  "version": "0.60.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/memory-budget.test.ts
+++ b/tests/unit/memory-budget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for memoryBudgetArgs - the engine-agnostic memory-budget translation
+ * that turns a budget (MB) into per-engine server args.
+ */
+
+import { describe, it } from 'node:test'
+import { Engine } from '../../types'
+import { memoryBudgetArgs } from '../../core/memory-budget'
+import { assert, assertEqual } from '../utils/assertions'
+
+describe('memoryBudgetArgs', () => {
+  it('returns no args when there is no budget', () => {
+    assertEqual(
+      memoryBudgetArgs(Engine.MySQL, undefined).length,
+      0,
+      'undefined budget',
+    )
+    assertEqual(memoryBudgetArgs(Engine.MySQL, 0).length, 0, 'zero budget')
+  })
+
+  it('MySQL turns performance_schema off and scales the buffer pool', () => {
+    const args = memoryBudgetArgs(Engine.MySQL, 256)
+    assert(args.includes('--performance-schema=OFF'), 'perf_schema off')
+    assert(
+      args.includes('--innodb-buffer-pool-size=64M'),
+      'buffer pool 256/4 = 64M',
+    )
+  })
+
+  it('MySQL floors the buffer pool at 64M for tiny budgets', () => {
+    const args = memoryBudgetArgs(Engine.MySQL, 100)
+    assert(args.includes('--innodb-buffer-pool-size=64M'), 'floored at 64M')
+  })
+
+  it('MariaDB trims buffer pool + aria pagecache, no perf_schema flag', () => {
+    const args = memoryBudgetArgs(Engine.MariaDB, 256)
+    assert(args.includes('--innodb-buffer-pool-size=64M'), 'buffer pool')
+    assert(args.includes('--aria-pagecache-buffer-size=64M'), 'aria pagecache')
+    assert(
+      !args.some((a) => a.includes('performance-schema')),
+      'no perf_schema flag (MariaDB defaults it off)',
+    )
+  })
+
+  it('untranslated engines run at defaults (no args)', () => {
+    assertEqual(
+      memoryBudgetArgs(Engine.PostgreSQL, 256).length,
+      0,
+      'postgres no-op',
+    )
+    assertEqual(memoryBudgetArgs(Engine.SQLite, 256).length, 0, 'sqlite no-op')
+    assertEqual(memoryBudgetArgs(Engine.Redis, 256).length, 0, 'redis no-op')
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,6 +44,12 @@ export type ContainerConfig = {
   //              when false/undefined, passes --no-auth (disables SCRAM)
   // Set via `spindb start --auth` or `spindb start --no-auth`. Persisted across restarts.
   authEnabled?: boolean
+  // Soft memory budget (MB) for the engine's fixed structures. Each engine
+  // translates it into its own server args (see core/memory-budget.ts): MySQL
+  // turns off performance_schema + shrinks the buffer pool; MariaDB trims its
+  // caches; others run at defaults. Set via `spindb create --memory-budget-mb`,
+  // persisted so it re-applies on every start. Unset = engine defaults.
+  memoryBudgetMb?: number
   // Remote database linking (external databases not managed by SpinDB)
   remote?: RemoteConnectionConfig
 }


### PR DESCRIPTION
## What

An engine-agnostic **memory budget** for containers: `spindb create --memory-budget-mb <n>` sets `ContainerConfig.memoryBudgetMb`, persisted so it re-applies on every start. `core/memory-budget.ts` translates the budget into per-engine server args:

- **MySQL** -> `--performance-schema=OFF` + InnoDB buffer pool scaled from the budget (floored at 64M)
- **MariaDB** -> InnoDB buffer pool + Aria pagecache scaled (perf_schema is already off by default)
- **every other engine** -> no-op (runs at engine defaults)

Unset budget = no args = today's behavior. New engines opt in by adding a case to `memoryBudgetArgs`; they're never forced to.

## Why

A default MySQL measured **~547 MB RSS** vs **~169 MB for MariaDB** in the same role, both on InnoDB. The gap is almost entirely `performance_schema` (MySQL ships it on, MariaDB off). This lets a caller (e.g. a hosting control plane's free tier) run MySQL-family databases lean **without giving up InnoDB/transactions** - turning perf_schema off has no effect on queries or transactions, only on observability.

The knob is intentionally engine-agnostic (a budget every engine maps its own way) rather than a one-engine flag.

## Validation

- `core/memory-budget.ts` is pure and **unit-tested** (`tests/unit/memory-budget.test.ts`, 5 cases).
- `tsc` + `eslint` clean (pre-commit hook passed).
- End-to-end (real mysqld boots with the args + perf_schema actually off + RSS drop) is best validated with real binaries - either an integration-test assertion (`tests/integration/{mysql,mariadb}.test.ts`) or on staging after the version bump + image rebuild. Can add the integration assertions here if preferred.

**Heads-up (pre-existing, not from this PR):** `tests/unit/postgresql-windows.test.ts` fails on a circular-import TDZ (`Cannot access 'postgresqlEngine' before initialization`) - confirmed identical on a clean tree.

## Follow-ups after merge
- Bump the spindb dep in layerbase-cloud and layerbase-desktop.
- Cloud wiring (separate PR): free tier sets `memoryBudgetMb` (~256 MB), paid leaves it unset.

Version: 0.59.1 -> 0.60.0.
