### PR TITLE
feat(memory): persist/update memory budget on start (--memory-budget-mb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-06-29
+
+### Added
+
+- **`spindb start --memory-budget-mb <n>`**: set or update a container's memory
+  budget on start (0 clears it), persisted like `--bind`. Complements
+  `create --memory-budget-mb` so an existing database can be brought under (or
+  out of) a budget by restarting it, no recreate needed. The engine applies it
+  on that start and every future start.
+
 ## [0.60.0] - 2026-06-29
 
 ### Added

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -39,6 +39,7 @@ spindb start mydb -f                    # Start (auto-download missing binaries)
 spindb start mydb --bind 0.0.0.0        # Listen on all interfaces, not just localhost (persisted)
 spindb start mydb --auth                # Enable auth: MongoDB --auth, FerretDB SCRAM (persisted)
 spindb start mydb --no-auth             # Disable auth: restore default no-auth mode (persisted)
+spindb start mydb --memory-budget-mb 256  # Run lean within a 256MB budget (0 clears it, persisted)
 spindb stop mydb                        # Stop container
 spindb stop --all                       # Stop all containers
 spindb delete mydb -f                   # Force delete (stops if running, skips prompt)

--- a/cli/commands/start.ts
+++ b/cli/commands/start.ts
@@ -33,6 +33,10 @@ export const startCommand = new Command('start')
     '--no-auth',
     'Disable authentication (FerretDB v2: pass --no-auth). Persisted.',
   )
+  .option(
+    '--memory-budget-mb <number>',
+    'Soft memory budget in MB; engines run lean within it (0 clears it). Persisted.',
+  )
   .action(
     async (
       name: string | undefined,
@@ -41,6 +45,7 @@ export const startCommand = new Command('start')
         force?: boolean
         bind?: string
         auth?: boolean
+        memoryBudgetMb?: string
       },
     ) => {
       try {
@@ -186,6 +191,25 @@ export const startCommand = new Command('start')
             })
             config.authEnabled = options.auth
           }
+        }
+
+        // Persist the memory budget if provided (0 clears it). The engine
+        // applies it on this start and every future start from the persisted
+        // config - this is how a caller backfills an existing database (or
+        // updates it on a plan change) without recreating it.
+        if (options.memoryBudgetMb !== undefined) {
+          const parsed = parseInt(options.memoryBudgetMb, 10)
+          if (!Number.isFinite(parsed) || parsed < 0) {
+            return exitWithError({
+              message:
+                'Invalid --memory-budget-mb value: must be a non-negative integer (0 clears it)',
+              json: options.json,
+            })
+          }
+          await containerManager.updateConfig(containerName, {
+            memoryBudgetMb: parsed,
+          })
+          config.memoryBudgetMb = parsed
         }
 
         const engineDefaults = getEngineDefaults(engineName)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## What

Adds `--memory-budget-mb <n>` to `spindb start` (companion to the `create` flag from #240). Sets or updates the container's persisted `memoryBudgetMb` on start (0 clears it), exactly like `--bind`. The engine applies it on that start and every future start.

## Why

`create --memory-budget-mb` only covers *new* databases. This lets an **existing** database be brought under a budget (or out of one) by **restarting it** - no recreate needed. That's the path a control plane uses to backfill databases created before the feature, and to update a database when its plan changes (e.g. free -> Pro clears the budget on the next start).

## Validation
- tsc + eslint clean (pre-commit hook).
- Mirrors the existing `--bind`/`--auth` persist pattern; the apply path (`memoryBudgetArgs`) is already unit- and integration-tested from #240.

Version 0.60.0 -> 0.61.0; CHEATSHEET + CHANGELOG updated.
