### PR TITLE
chore(release): 0.61.1 - standardize commercial licensing language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.1] - 2026-07-04
+
+### Changed
+
+- **Licensing:** standardized the commercial-licensing language in `LICENSE`.
+  The PolyForm Noncommercial 1.0.0 grant is unchanged; the commercial-use
+  notice now explicitly enumerates commercial use (commercial
+  products/services/SaaS, internal for-profit operations, and using the
+  software, its source, or its output to train, fine-tune, evaluate, or
+  retrieval-augment AI/ML models, systems, or agents for any for-profit
+  purpose), states that a one-time commercial license fee applies, and lists
+  the licensing contact as bob@layerbase.com.
+
 ## [0.61.0] - 2026-06-29
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -5,10 +5,26 @@
 ## Commercial Licensing
 
 This software is free for noncommercial use under the terms below.
-Commercial use — including use in or for a commercial product,
-service, or internal business operation — requires a separate
-commercial license. To inquire about commercial licensing, contact
-the licensor at **bob@bbass.co**.
+**Any commercial use requires a separate, paid commercial license.**
+
+Commercial use includes, without limitation:
+
+- use in or for any commercial product, service, or SaaS offering;
+- use in the internal business operations of any for-profit entity;
+- using the software, its source code, or its output to train,
+  fine-tune, evaluate, retrieval-augment, or otherwise develop any
+  AI or machine-learning model, system, or agent in connection with a
+  commercial, for-profit, or revenue-generating purpose; and
+- any other for-profit endeavor.
+
+A one-time commercial license fee applies. To obtain a commercial
+license, or to confirm whether your use requires one, contact the
+licensor at **bob@layerbase.com**.
+
+This section does not grant any rights beyond the PolyForm
+Noncommercial License 1.0.0 set out below. It describes the separate
+commercial license the licensor offers for uses that the license
+below does not permit.
 
 ## Acceptance
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.59.1'
+export const VERSION = '0.61.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary

Standardizes the commercial-licensing language in `LICENSE` and bumps the release to `0.61.1`.

## Changes

- **LICENSE:** PolyForm Noncommercial 1.0.0 grant is unchanged. The commercial-use notice now explicitly enumerates commercial use - commercial products/services/SaaS, internal for-profit operations, and using the software/its source/its output to train, fine-tune, evaluate, or retrieval-augment AI/ML models, systems, or agents for any for-profit purpose. States that a one-time commercial license fee applies. Licensing contact is `bob@layerbase.com`.
- **Version:** `0.61.0 -> 0.61.1` (patch; docs/license change, no API change). Regenerated `config/version.ts`.
- **CHANGELOG:** `[0.61.1] - 2026-07-04` under Changed.

Merging to `main` triggers the OIDC publish job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated the app/package version to **0.61.1**.
  * Added a new changelog entry for the release.
  * Clarified and standardized the commercial licensing terms, including more explicit usage definitions and updated contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->