### PR TITLE
fix(cli): pluralize the version-picker count label correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.2] - 2026-07-04
+
+### Fixed
+
+- **Interactive version picker no longer says "(1 versions)".** In the create
+  wizard's major-version list, the count label is now pluralized correctly, so
+  a major with a single available build reads "(1 version)" instead of
+  "(1 versions)". Most visible on pre-v1 engines, which commonly have just one
+  build available.
+
 ## [0.61.1] - 2026-07-04
 
 ### Changed

--- a/cli/ui/prompts.ts
+++ b/cli/ui/prompts.ts
@@ -613,7 +613,11 @@ export async function promptVersion(
     }
 
     const countLabel =
-      versionCount > 0 ? chalk.gray(`(${versionCount} versions)`) : ''
+      versionCount > 0
+        ? chalk.gray(
+            `(${versionCount} version${versionCount === 1 ? '' : 's'})`,
+          )
+        : ''
     const deprecatedLabel = allDeprecated ? chalk.yellow(' [deprecated]') : ''
     const label = isLatestMajor
       ? `${engine.displayName} ${major} ${countLabel} ${chalk.green('← latest')}`
@@ -817,9 +821,7 @@ export async function promptPort(
     const portAvailable = await portManager.isPortAvailable(port)
     if (!portAvailable) {
       console.log()
-      console.log(
-        chalk.yellow(`  ⚠ Warning: Port ${port} is currently in use`),
-      )
+      console.log(chalk.yellow(`  ⚠ Warning: Port ${port} is currently in use`))
       console.log(
         chalk.gray(
           '    The container will be created but may fail to start until the port is freed.',

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.1'
+export const VERSION = '0.61.2'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.1",
+  "version": "0.61.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## What

The interactive create wizard's major-version list always rendered `(N versions)`, so a major with a single available build showed the ungrammatical **`(1 versions)`**. Now pluralized based on the count, so it reads `(1 version)`.

Most visible on pre-v1 engines, which commonly have just one build available.

## Fixes

Closes #136.

## Scope

Display-only, in the interactive picker (`cli/ui/prompts.ts`). No command, flag, or API change; does not affect the cloud or desktop consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the version count label in the version picker so singular and plural text displays properly.
  * Updated the port-in-use warning display for cleaner formatting.
* **Chores**
  * Bumped the app release version to **v0.61.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->