### PR TITLE
fix(questdb): skip chmod in postExtract when binaries are already executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.3] - 2026-07-07
+
+### Fixed
+
+- **QuestDB create no longer fails with EROFS on a read-only binary store.**
+  `QuestDBEngine.ensureBinaries` runs `postExtract()` even when binaries are
+  already installed (the cached path), and `postExtract` chmod-ed
+  `questdb.sh` unconditionally. On hosts that mount a shared binary store
+  read-only at `~/.spindb/bin` (e.g. Layerbase cloud user containers), that
+  chmod threw `EROFS` even though the script was already `0o755`, failing
+  every QuestDB create. Post-extract setup is now a no-op against an
+  already-correct read-only store: the new shared `ensureExecutable()`
+  helper (`core/fs-error-utils.ts`) skips the chmod when the executable bits
+  are already set, tolerates `EROFS`/`EPERM`/`EACCES` only when an
+  `access(X_OK)` check confirms the file is executable, and fails loudly
+  otherwise. Engine-agnostic: any engine needing post-extract exec bits
+  should use the same helper.
+
 ## [0.61.2] - 2026-07-04
 
 ### Fixed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.2'
+export const VERSION = '0.61.3'

--- a/core/fs-error-utils.ts
+++ b/core/fs-error-utils.ts
@@ -4,7 +4,8 @@
  * Shared error detection and file operation functions for filesystem operations.
  */
 
-import { rename, cp, rm } from 'fs/promises'
+import { rename, cp, rm, stat, chmod, access } from 'fs/promises'
+import { constants } from 'fs'
 import { logDebug } from './error-handler'
 
 /**
@@ -55,6 +56,77 @@ export async function moveEntry(
     } else {
       throw error
     }
+  }
+}
+
+/**
+ * Injectable fs operations for ensureExecutable (used by tests to simulate
+ * read-only filesystems without touching real mount options).
+ */
+export type EnsureExecutableOptions = {
+  /** Target mode when a chmod is needed (default 0o755) */
+  mode?: number
+  /** Override for fs.promises.stat (tests) */
+  statFn?: (path: string) => Promise<{ mode: number }>
+  /** Override for fs.promises.chmod (tests) */
+  chmodFn?: (path: string, mode: number) => Promise<void>
+  /** Override for fs.promises.access (tests) */
+  accessFn?: (path: string, mode?: number) => Promise<void>
+}
+
+/**
+ * Ensure a file has its executable bits set, without writing to filesystems
+ * that are already correct.
+ *
+ * Invariant: post-extract setup must be a no-op against an already-correct
+ * read-only binary store. Layerbase cloud mounts a shared binary store
+ * read-only at ~/.spindb/bin inside user containers; an unconditional chmod
+ * against a file that is already 0o755 throws EROFS there and fails the
+ * whole create (seen with QuestDB's questdb.sh).
+ *
+ * Behavior:
+ * 1. If all executable bits are already set, return without writing.
+ * 2. Otherwise attempt chmod(mode).
+ * 3. If chmod fails with EROFS/EPERM/EACCES (read-only or unwritable store),
+ *    tolerate the failure ONLY when an access(X_OK) check confirms the file
+ *    is already executable; otherwise rethrow the original error loudly.
+ */
+export async function ensureExecutable(
+  filePath: string,
+  options: EnsureExecutableOptions = {},
+): Promise<void> {
+  const {
+    mode = 0o755,
+    statFn = stat,
+    chmodFn = chmod,
+    accessFn = access,
+  } = options
+
+  const stats = await statFn(filePath)
+  const execBits = 0o111
+  if ((stats.mode & execBits) === execBits) {
+    // Already executable everywhere - never write (the store may be read-only)
+    return
+  }
+
+  try {
+    await chmodFn(filePath, mode)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    const unwritableCodes = ['EROFS', 'EPERM', 'EACCES']
+    if (typeof code === 'string' && unwritableCodes.includes(code)) {
+      try {
+        await accessFn(filePath, constants.X_OK)
+        logDebug(
+          `chmod failed with ${code} but file is already executable, continuing`,
+          { filePath },
+        )
+        return
+      } catch {
+        // Not executable and we cannot make it so - fall through and fail loudly
+      }
+    }
+    throw error
   }
 }
 

--- a/engines/questdb/binary-manager.ts
+++ b/engines/questdb/binary-manager.ts
@@ -22,10 +22,10 @@ import { normalizeVersion } from './version-maps'
 import { Engine, Platform, type Arch, type ProgressCallback } from '../../types'
 import { existsSync } from 'fs'
 import { join, dirname, relative } from 'path'
-import { chmod, symlink, readdir } from 'fs/promises'
+import { symlink, readdir } from 'fs/promises'
 import { logDebug } from '../../core/error-handler'
 import { getReleasesUrls } from '../../core/hostdb-client'
-import { moveEntry } from '../../core/fs-error-utils'
+import { moveEntry, ensureExecutable } from '../../core/fs-error-utils'
 import { paths } from '../../config/paths'
 
 class QuestDBBinaryManager extends BaseBinaryManager {
@@ -169,17 +169,24 @@ class QuestDBBinaryManager extends BaseBinaryManager {
    */
   async postExtract(binPath: string, platform: Platform): Promise<void> {
     if (platform !== Platform.Win32) {
-      // Make startup script executable - check both locations
+      // Make startup script executable - check both locations.
+      // This also runs on the cached path (ensureBinaries), so it must be a
+      // no-op against an already-correct read-only binary store (Layerbase
+      // cloud mounts a shared store read-only at ~/.spindb/bin); an
+      // unconditional chmod there throws EROFS even when the file is
+      // already 0o755. ensureExecutable() skips the write when the exec
+      // bits are already set and tolerates EROFS/EPERM only when the file
+      // is verifiably executable.
       const shPathRoot = join(binPath, 'questdb.sh')
       const shPathBin = join(binPath, 'bin', 'questdb.sh')
 
       if (existsSync(shPathRoot)) {
-        await chmod(shPathRoot, 0o755)
-        logDebug(`Made questdb.sh executable: ${shPathRoot}`)
+        await ensureExecutable(shPathRoot)
+        logDebug(`Ensured questdb.sh is executable: ${shPathRoot}`)
       }
       if (existsSync(shPathBin)) {
-        await chmod(shPathBin, 0o755)
-        logDebug(`Made questdb.sh executable: ${shPathBin}`)
+        await ensureExecutable(shPathBin)
+        logDebug(`Ensured questdb.sh is executable: ${shPathBin}`)
       }
 
       // For macOS structure: create symlink from 'java' to 'jre/bin/java' at base level

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/fs-error-utils.test.ts
+++ b/tests/unit/fs-error-utils.test.ts
@@ -1,0 +1,173 @@
+/**
+ * fs-error-utils unit tests
+ *
+ * Focus: ensureExecutable must be a no-op against an already-correct
+ * read-only binary store (Layerbase cloud mounts a shared store read-only
+ * at ~/.spindb/bin, where an unconditional chmod throws EROFS even when
+ * the file is already 0o755).
+ */
+
+import { describe, it, before, after } from 'node:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { mkdir, rm, writeFile, chmod, stat } from 'fs/promises'
+import { assert, assertEqual } from '../utils/assertions'
+import { ensureExecutable } from '../../core/fs-error-utils'
+
+function makeFsError(code: string, message: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
+describe('ensureExecutable', () => {
+  const testDir = join(tmpdir(), `fs-error-utils-test-${Date.now()}`)
+
+  before(async () => {
+    await mkdir(testDir, { recursive: true })
+  })
+
+  after(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  it('does not call chmod when exec bits are already set', async () => {
+    const filePath = join(testDir, 'already-exec.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o755)
+
+    let chmodCalled = false
+    await ensureExecutable(filePath, {
+      chmodFn: async () => {
+        chmodCalled = true
+        throw makeFsError('EROFS', 'read-only file system')
+      },
+    })
+
+    assertEqual(chmodCalled, false, 'chmod must not run on a 0o755 file')
+  })
+
+  it('applies chmod when exec bits are missing on a writable fs', async () => {
+    const filePath = join(testDir, 'not-exec.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o644)
+
+    await ensureExecutable(filePath)
+
+    const stats = await stat(filePath)
+    assertEqual(
+      stats.mode & 0o755,
+      0o755,
+      'file should be chmod-ed to 0o755 on a writable fs',
+    )
+  })
+
+  it('tolerates EROFS from chmod when the file is already executable', async () => {
+    // Simulates the read-only shared-store case: stat initially reports
+    // missing exec bits (e.g. group/other), chmod throws EROFS, but the
+    // access(X_OK) confirmation shows the file is executable for us.
+    const filePath = join(testDir, 'ro-store.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o755)
+
+    const realStats = await stat(filePath)
+    let threw = false
+    try {
+      await ensureExecutable(filePath, {
+        statFn: async () => {
+          // Report owner-exec only so the chmod path is exercised
+          const stats = Object.create(realStats) as typeof realStats
+          Object.defineProperty(stats, 'mode', { value: 0o700 })
+          return stats
+        },
+        chmodFn: async () => {
+          throw makeFsError('EROFS', 'read-only file system')
+        },
+      })
+    } catch {
+      threw = true
+    }
+
+    assertEqual(
+      threw,
+      false,
+      'EROFS must be tolerated when the file is already executable',
+    )
+  })
+
+  it('tolerates EPERM from chmod when the file is already executable', async () => {
+    const filePath = join(testDir, 'eperm-store.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o755)
+
+    const realStats = await stat(filePath)
+    let threw = false
+    try {
+      await ensureExecutable(filePath, {
+        statFn: async () => {
+          const stats = Object.create(realStats) as typeof realStats
+          Object.defineProperty(stats, 'mode', { value: 0o700 })
+          return stats
+        },
+        chmodFn: async () => {
+          throw makeFsError('EPERM', 'operation not permitted')
+        },
+      })
+    } catch {
+      threw = true
+    }
+
+    assertEqual(
+      threw,
+      false,
+      'EPERM must be tolerated when the file is already executable',
+    )
+  })
+
+  it('rethrows EROFS when the file is NOT executable', async () => {
+    const filePath = join(testDir, 'broken-store.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o644)
+
+    let caught: NodeJS.ErrnoException | null = null
+    try {
+      await ensureExecutable(filePath, {
+        chmodFn: async () => {
+          throw makeFsError('EROFS', 'read-only file system')
+        },
+      })
+    } catch (error) {
+      caught = error as NodeJS.ErrnoException
+    }
+
+    assert(
+      caught !== null,
+      'EROFS must be rethrown when the file is not executable',
+    )
+    assertEqual(caught.code, 'EROFS', 'original error must be preserved')
+  })
+
+  it('rethrows unrelated chmod errors immediately', async () => {
+    const filePath = join(testDir, 'enoent-like.sh')
+    await writeFile(filePath, '#!/bin/sh\n')
+    await chmod(filePath, 0o644)
+
+    let caught: NodeJS.ErrnoException | null = null
+    try {
+      await ensureExecutable(filePath, {
+        chmodFn: async () => {
+          throw makeFsError('EIO', 'i/o error')
+        },
+      })
+    } catch (error) {
+      caught = error as NodeJS.ErrnoException
+    }
+
+    assert(caught !== null, 'non-permission errors must be rethrown')
+    assertEqual(caught.code, 'EIO', 'original error must be preserved')
+  })
+})


### PR DESCRIPTION
## What

Fixes the QuestDB EROFS failure on Layerbase cloud's read-only shared binary store, which has failed the staging restore drill nightly since 2026-07-06 (and would break the first prod QuestDB create).

## Why

Cloud user containers mount the shared binary store read-only at ~/.spindb/bin. QuestDB's postExtract ran an unconditional chmod on bin/questdb.sh even on the already-installed path, so the (no-op) chmod threw EROFS and the create failed: "QuestDB 9.2.3 not available: EROFS: read-only file system".

## How

New shared helper core/fs-error-utils.ts ensureExecutable(): stats first and returns without writing when all exec bits are set; otherwise chmods 0755; on EROFS/EPERM/EACCES it tolerates the failure only when access(X_OK) confirms the file is executable, else rethrows loudly. QuestDB's postExtract uses it. Invariant: post-extract setup must be a no-op against an already-correct read-only store.

Engine sweep: QuestDB is the only engine with a postExtract hook and the only one writing to the binary store on the cached path. The base download-path chmod loops and FerretDB's fixups run only on fresh downloads (which a ro store cannot reach anyway) and are unchanged.

## Testing

New unit suite for ensureExecutable (6/6); full unit suite 1662/1662; QuestDB integration suite 15/15; eslint + tsc clean. Version 0.61.2 -> 0.61.3, CHANGELOG updated. CHEATSHEET untouched (no CLI-facing change).

## Post-merge

Bump the spindb pin in layerbase-cloud (universal image rebuild + daily rollout sweep) and layerbase-desktop so the fix reaches cloud containers before QuestDB traffic from the 2026-07-13 blog post arrives.