### PR TITLE
fix: DuckDB branch and reset fail with engine-scoped config lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.61.3] - 2026-07-07
+## [0.61.4] - 2026-07-07
+
+### Fixed
+
+- **`spindb branch` now works for DuckDB (and any file-based engine) when the
+  engine is passed explicitly.** Branching a DuckDB container failed
+  deterministically with `Failed to read branched container config`:
+  after cloning the backing file and registering the new entry,
+  `branch-manager` reads the config back via
+  `containerManager.getConfig(name, { engine })`, but that engine-scoped
+  lookup only special-cased SQLite. DuckDB fell through to the filesystem
+  `container.json` path, which never exists for a file-based engine, so
+  `getConfig` returned `null` and the branch aborted. SQLite branched fine
+  purely because it was the one engine handled. `getConfig` (and the matching
+  `exists`) now resolve both file-based engines from their registry when an
+  engine is specified. Surfaced via Layerbase cloud branching of DuckDB
+  databases; also affected `branch reset` for DuckDB.
 
 ### Fixed
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.3'
+export const VERSION = '0.61.4'

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -109,9 +109,18 @@ export class ContainerManager {
     const { engine } = options || {}
 
     if (engine) {
-      // SQLite uses registry instead of filesystem
+      // File-based engines (SQLite, DuckDB) are tracked in a registry, not on
+      // the filesystem as a container.json, so resolve their config from the
+      // registry. Missing DuckDB here made getConfig(name, { engine: 'duckdb' })
+      // fall through to the non-existent filesystem path and return null, which
+      // broke `spindb branch` for DuckDB (branch-manager could not read back the
+      // config it had just registered). SQLite worked only because it was
+      // special-cased.
       if (engine === Engine.SQLite) {
         return this.getSqliteConfig(name)
+      }
+      if (engine === Engine.DuckDB) {
+        return this.getDuckDBConfig(name)
       }
 
       // Look in specific engine directory
@@ -245,9 +254,12 @@ export class ContainerManager {
     const { engine } = options || {}
 
     if (engine) {
-      // SQLite uses registry
+      // File-based engines (SQLite, DuckDB) use a registry, not the filesystem.
       if (engine === Engine.SQLite) {
         return sqliteRegistry.exists(name)
+      }
+      if (engine === Engine.DuckDB) {
+        return duckdbRegistry.exists(name)
       }
       const configPath = paths.getContainerConfigPath(name, { engine })
       return existsSync(configPath)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/container-manager.test.ts
+++ b/tests/unit/container-manager.test.ts
@@ -1,5 +1,11 @@
-import { describe, it } from 'node:test'
-import { ContainerManager } from '../../core/container-manager'
+import { describe, it, afterEach, mock } from 'node:test'
+import {
+  ContainerManager,
+  containerManager,
+} from '../../core/container-manager'
+import { sqliteRegistry } from '../../engines/sqlite/registry'
+import { duckdbRegistry } from '../../engines/duckdb/registry'
+import { Engine } from '../../types'
 import { assert, assertEqual } from '../utils/assertions'
 
 describe('ContainerManager', () => {
@@ -546,4 +552,52 @@ describe('syncDatabases', () => {
       'Should match primary database',
     )
   })
+})
+
+describe('getConfig with engine scope for file-based engines', () => {
+  afterEach(() => mock.restoreAll())
+
+  // Regression: getConfig(name, { engine }) previously special-cased only
+  // SQLite, so DuckDB fell through to the filesystem container.json path (which
+  // never exists for a file-based engine) and returned null. That made
+  // `spindb branch` fail for DuckDB with "Failed to read branched container
+  // config" while SQLite succeeded. Both file-based engines must resolve their
+  // config from the registry when the engine is specified.
+  for (const engine of [Engine.SQLite, Engine.DuckDB] as const) {
+    it(`resolves ${engine} config from the registry`, async () => {
+      const registry =
+        engine === Engine.SQLite ? sqliteRegistry : duckdbRegistry
+      const filePath = `/tmp/${engine}-scope-test${
+        engine === Engine.SQLite ? '.sqlite' : '.duckdb'
+      }`
+      mock.method(registry, 'get', async () => ({
+        name: 'branch_child',
+        filePath,
+        created: '2026-01-01T00:00:00.000Z',
+        lastVerified: '2026-01-01T00:00:00.000Z',
+        branchParent: 'cloud_source',
+        branchedAt: '2026-01-02T00:00:00.000Z',
+      }))
+
+      const config = await containerManager.getConfig('branch_child', {
+        engine,
+      })
+
+      assert(
+        config !== null,
+        `getConfig(name, { engine: '${engine}' }) must not return null`,
+      )
+      assertEqual(config?.engine, engine, 'Config engine should match')
+      assertEqual(
+        config?.database,
+        filePath,
+        'Config database should be the backing file path',
+      )
+      assertEqual(
+        config?.branchParent,
+        'cloud_source',
+        'Branch lineage should be surfaced',
+      )
+    })
+  }
 })


### PR DESCRIPTION
## Summary
DuckDB branching (and branch reset) failed 100% deterministically everywhere (cloud, desktop, CLI) with `Failed to read branched container config`. Root cause: `ContainerManager.getConfig`/`exists` special-cased only SQLite for registry-backed file engines; DuckDB fell through to the filesystem `container.json` path, which never exists for file-based engines, so `createFileBasedBranch` (branch-manager.ts:296) and `resetFileBasedBranch` always threw.

Found 2026-07-07 by the staging ZFS validation battery (cloud plans/active/prod-storage-economics-2026-07.md); reproduced in pure spindb with zero cloud involvement. SQLite and LibSQL are unaffected; hard failure only, no data-loss risk.

## Fix
Engine-scoped `getConfig` and `exists` now resolve DuckDB from its registry exactly like SQLite (the no-engine path already searched both).

## Verification
- New regression test: engine-scoped `getConfig` returns non-null config for BOTH SQLite and DuckDB (fails on old code)
- Full unit suite 1664 pass / 0 fail; eslint + tsc clean; end-to-end branch + reset repro passes post-fix for both engines
- 0.61.4 + CHANGELOG entry + regenerated config/version.ts

## After merge
Propagate per process: spindb release -> bump pinned spindb in layerbase-cloud (universal image + rollout sweep) and layerbase-desktop.