### PR TITLE
chore(deps): bump hostdb to 0.34.0 for TypeDB 3.12.0 (0.61.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.5] - 2026-07-10
+
+### Changed
+
+- **Pin `hostdb` to `0.34.0`** (was 0.33.5). Adds **TypeDB 3.12.0** and makes it
+  the default for the `3` major: `defaults["3"]` now resolves to 3.12.0, so new
+  `typedb 3` containers provision the current release instead of 3.11.5. TypeDB
+  **3.11.5** is deprecated in hostdb (hidden from discovery) but remains fully
+  resolvable and downloadable for existing containers. The TypeDB version-map
+  wrapper rebuilds from hostdb's bundled snapshot at load time, so no MAP edits
+  were needed; `TYPEDB_VERSION_MAP["3"]` is now `3.12.0`. `pnpm test:hostdb-sync`
+  and the unit suite pass against the new snapshot.
+
 ## [0.61.4] - 2026-07-07
 
 ### Fixed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.4'
+export const VERSION = '0.61.5'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.33.5",
+    "hostdb": "0.34.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.33.5
-        version: 0.33.5
+        specifier: 0.34.0
+        version: 0.34.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.33.5:
-    resolution: {integrity: sha512-m7EHNbl5jAGZy/WoHEvD8BWKZVcc2lfktxeVkYHVXhAzjBFiFyaTtKRNGsCwccWCqv9ARtaGGg28tjBnBb2KOQ==}
+  hostdb@0.34.0:
+    resolution: {integrity: sha512-k9QqQlQOaDZqechBDgQ0FTbCHeSMJdeQ7WECs57s68Y3iagH4orJxsQihNFe7s+zcRc5moQXVwy3pdpEikGSTw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.33.5: {}
+  hostdb@0.34.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Summary

Bumps the exact `hostdb` pin `0.33.5 → 0.34.0` and releases spindb `0.61.4 → 0.61.5`.

hostdb 0.34.0 adds **TypeDB 3.12.0** and flips the defaults block so major `3` resolves to 3.12.0. TypeDB **3.11.5** is deprecated in hostdb (hidden from discovery) but stays fully resolvable/downloadable for existing containers.

The TypeDB version-map wrapper rebuilds from hostdb's bundled snapshot at load time — no MAP hand-edits. After the bump `TYPEDB_VERSION_MAP["3"]` is `3.12.0` and `SUPPORTED_MAJOR_VERSIONS` stays `["3"]`.

## Changes

- `package.json`: `hostdb` `0.33.5 → 0.34.0` (exact pin), `version` `0.61.4 → 0.61.5`
- `pnpm-lock.yaml`: regenerated
- `config/version.ts`: regenerated via `pnpm prep`
- `CHANGELOG.md`: `0.61.5` entry

## Verification

- `pnpm lint` (eslint + tsc): clean
- `pnpm test:hostdb-sync`: 23/23 pass (bundled snapshot matches live registry)
- `pnpm test:unit`: 1664/1664 pass (version maps auto-rebuild from new snapshot)
- `pnpm test:engine typedb`: 19/19 pass against the freshly downloaded `typedb-3.12.0` binary (major `3` resolved to 3.12.0 end-to-end)
- Resolver spot-check: `resolveVersion('typedb','3') === '3.12.0'`, `isVersionDeprecated('typedb','3.11.5') === true`