### PR TITLE
release: 0.61.5 - hostdb 0.34.0 / TypeDB 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.5] - 2026-07-10
+
+### Changed
+
+- **Pin `hostdb` to `0.34.0`** (was 0.33.5). Adds **TypeDB 3.12.0** and makes it
+  the default for the `3` major: `defaults["3"]` now resolves to 3.12.0, so new
+  `typedb 3` containers provision the current release instead of 3.11.5. TypeDB
+  **3.11.5** is deprecated in hostdb (hidden from discovery) but remains fully
+  resolvable and downloadable for existing containers. The TypeDB version-map
+  wrapper rebuilds from hostdb's bundled snapshot at load time, so no MAP edits
+  were needed; `TYPEDB_VERSION_MAP["3"]` is now `3.12.0`. `pnpm test:hostdb-sync`
+  and the unit suite pass against the new snapshot.
+
 ## [0.61.4] - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.61.5] - 2026-07-10
 
+### Fixed
+
+- **TypeDB 3.12 clone / backup-restore now works on Windows.** TypeDB 3.12 moved
+  the local admin service off the network onto an OS socket (UDS on Unix, a
+  DACL-guarded named object on Windows) and made it **off by default**:
+  `server.admin.port` was replaced by `server.admin.socket-path`. spindb still
+  generated `admin: { enabled: true, port: <unique> }`, which 3.12 accepts for a
+  single server but — because the `port` no longer selects a distinct endpoint —
+  makes two concurrent containers collide on the same default admin socket. On
+  Windows the second server exited early (`TypeDB process exited early (code: 0)`),
+  breaking `clone` and backup/restore (both start a second server while the source
+  is running); connection-refused (os error 10061) cascaded from there. spindb
+  never uses the admin tool (users/databases go through the console binary), so
+  the admin block is now version-gated: **3.11.x** keeps its unique TCP admin
+  port, **3.12+** explicitly disables the admin service (matching the vendor
+  default), and pre-3.11 still omits the block. Fixes the `TypeDB 🪟 Win x64`
+  clone/backup-restore integration failures.
+
 ### Changed
 
 - **Pin `hostdb` to `0.34.0`** (was 0.33.5). Adds **TypeDB 3.12.0** and makes it

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.4'
+export const VERSION = '0.61.5'

--- a/engines/typedb/index.ts
+++ b/engines/typedb/index.ts
@@ -180,16 +180,45 @@ export class TypeDBEngine extends BaseEngine {
    * Initialize a new TypeDB data directory
    * Creates the directory structure and config.yml for TypeDB
    */
-  // TypeDB 3.11+ binds a dedicated localhost admin port (default 1728, the same
-  // for every server). To let multiple TypeDB containers run at once, give each
-  // its own admin port derived from the container port and offset clear of the
-  // gRPC (port) and HTTP (port + 6271) bands. Returns null for < 3.11, whose
-  // config schema has no `server.admin` block - so existing 3.8.x containers are
-  // left untouched when their config is regenerated.
+  // TypeDB 3.11 introduced a mandatory `server.admin` block whose admin service
+  // listened on a dedicated localhost TCP port (default 1728, the same for every
+  // server). To let multiple 3.11 containers run at once, give each its own admin
+  // port derived from the container port and offset clear of the gRPC (port) and
+  // HTTP (port + 6271) bands.
+  //
+  // TypeDB 3.12 moved the admin service off the network onto an OS socket (UDS on
+  // Unix, DACL-guarded named object on Windows) and made it OFF by default:
+  // `--server.admin.port` was replaced by `--server.admin.socket-path`. Since
+  // spindb never uses the admin tool (users/databases are managed via the console
+  // binary), 3.12+ has no admin TCP port at all - see adminConfigLines().
+  //
+  // Returns the TCP admin port for 3.11.x only; null otherwise (< 3.11 has no
+  // admin block, 3.12+ uses the disabled socket-based default with no port).
   private adminPortFor(version: string, port: number): number | null {
     const [major, minor] = normalizeVersion(version).split('.').map(Number)
-    const supportsAdmin = major > 3 || (major === 3 && minor >= 11)
-    return supportsAdmin ? port + 6372 : null
+    const usesTcpAdminPort = major === 3 && minor === 11
+    return usesTcpAdminPort ? port + 6372 : null
+  }
+
+  // The `server.admin` config lines appropriate for the running TypeDB version.
+  //   < 3.11  -> no admin block (schema predates it)
+  //   3.11.x  -> admin enabled on a unique TCP port (see adminPortFor)
+  //   >= 3.12 -> admin explicitly disabled. The admin service is now an OS socket
+  //              (default socket-path, identical for every server) that spindb
+  //              does not use; leaving it enabled makes concurrent containers
+  //              collide on the same admin socket on Windows, so the second
+  //              server exits early during clone/backup-restore. Disabling it
+  //              matches the vendor default and lets containers run concurrently.
+  private adminConfigLines(version: string, port: number): string[] {
+    const [major, minor] = normalizeVersion(version).split('.').map(Number)
+    if (major < 3 || (major === 3 && minor < 11)) {
+      return []
+    }
+    const adminPort = this.adminPortFor(version, port)
+    if (adminPort !== null) {
+      return ['  admin:', '    enabled: true', `    port: ${adminPort}`]
+    }
+    return ['  admin:', '    enabled: false']
   }
 
   async initDataDir(
@@ -210,7 +239,7 @@ export class TypeDBEngine extends BaseEngine {
     // Get port from options or use default
     const port = (options.port as number) || engineDef.defaultPort
     const httpPort = typedbHttpPort(port) // base + 6271 (8000) by default
-    const adminPort = this.adminPortFor(version, port) // 3.11+ only; null otherwise
+    const adminLines = this.adminConfigLines(version, port) // version-gated block
 
     // Generate config.yml for this container
     // Must include all required sections: server (with authentication, encryption), storage, logging, diagnostics
@@ -224,13 +253,12 @@ export class TypeDBEngine extends BaseEngine {
       '  http:',
       '    enabled: true',
       `    address: ${(options.bindAddress as string) ?? '127.0.0.1'}:${httpPort}`,
-      // TypeDB 3.11+ requires a `server.admin` block (the `port` field is
-      // mandatory). Give each container a unique admin port so concurrent
-      // TypeDB containers don't all fight over the default 1728. Omitted for
-      // < 3.11, which doesn't understand this block.
-      ...(adminPort !== null
-        ? ['  admin:', '    enabled: true', `    port: ${adminPort}`]
-        : []),
+      // TypeDB admin service config, version-gated by adminConfigLines():
+      // 3.11.x gets a unique TCP admin port (avoids the default 1728 collision
+      // between concurrent containers); 3.12+ disables the now-socket-based
+      // admin service (spindb doesn't use it, and enabling it collides on the
+      // shared admin socket across concurrent containers); < 3.11 omits it.
+      ...adminLines,
       '  authentication:',
       '    token-expiration-seconds: 5000',
       '  encryption:',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.33.5",
+    "hostdb": "0.34.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.33.5
-        version: 0.33.5
+        specifier: 0.34.0
+        version: 0.34.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.33.5:
-    resolution: {integrity: sha512-m7EHNbl5jAGZy/WoHEvD8BWKZVcc2lfktxeVkYHVXhAzjBFiFyaTtKRNGsCwccWCqv9ARtaGGg28tjBnBb2KOQ==}
+  hostdb@0.34.0:
+    resolution: {integrity: sha512-k9QqQlQOaDZqechBDgQ0FTbCHeSMJdeQ7WECs57s68Y3iagH4orJxsQihNFe7s+zcRc5moQXVwy3pdpEikGSTw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.33.5: {}
+  hostdb@0.34.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Release 0.61.5

Bumps the exact `hostdb` pin `0.33.5 → 0.34.0`, adding **TypeDB 3.12.0** and making it the default for major `3` (`defaults["3"] → 3.12.0`). TypeDB **3.11.5** is deprecated in hostdb but stays resolvable/downloadable for existing containers. The TypeDB version-map wrapper rebuilds from hostdb's bundled snapshot — no MAP hand-edits.

## Verification

- `pnpm lint` (eslint + tsc): clean
- `pnpm test:hostdb-sync`: 23/23 pass
- `pnpm test:unit`: 1664/1664 pass
- `pnpm test:engine typedb`: 19/19 pass against the downloaded `typedb-3.12.0` binary
- PR #251 (feature → dev) merged with all CI green (Unit Tests, Docker Export, Lint & Type Check, GitGuardian, CodeRabbit)

Merging to `main` triggers the OIDC npm publish of `spindb@0.61.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeDB 3 now defaults to version 3.12.0.
  * Version 3.11.5 remains available when explicitly requested but is no longer shown in discovery.

* **Chores**
  * Updated the application release to version 0.61.5.
  * Updated version information used for TypeDB compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->