### PR TITLE
chore: apply prettier formatting across repo

### DIFF
--- a/.github/workflows/zfs-lifecycle.yml
+++ b/.github/workflows/zfs-lifecycle.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   baseline-2_2_2:
-    name: "lifecycle on Ubuntu apt OpenZFS (2.2.2)"
+    name: 'lifecycle on Ubuntu apt OpenZFS (2.2.2)'
     runs-on: ubuntu-24.04
     steps:
       - name: Install OpenZFS from apt
@@ -56,7 +56,7 @@ jobs:
           sudo rm -f /tmp/lc.img
 
   newer-built:
-    name: "lifecycle on newer OpenZFS (built from latest release)"
+    name: 'lifecycle on newer OpenZFS (built from latest release)'
     runs-on: ubuntu-24.04
     steps:
       - name: Build + install latest OpenZFS release

--- a/cli/commands/engines.ts
+++ b/cli/commands/engines.ts
@@ -1872,11 +1872,7 @@ enginesCommand
           }),
         )
         console.log(
-          JSON.stringify(
-            { ...enginesData, engines: enrichedEngines },
-            null,
-            2,
-          ),
+          JSON.stringify({ ...enginesData, engines: enrichedEngines }, null, 2),
         )
         return
       }

--- a/cli/commands/which.ts
+++ b/cli/commands/which.ts
@@ -79,7 +79,8 @@ function parseConnectionUrl(url: string): {
 } | null {
   try {
     const parsed = new URL(url)
-    const database = parsed.pathname.replace(/^\//, '').split('?')[0] || undefined
+    const database =
+      parsed.pathname.replace(/^\//, '').split('?')[0] || undefined
 
     // If URL has explicit port, use it
     if (parsed.port) {

--- a/config/engines.json
+++ b/config/engines.json
@@ -12,11 +12,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "postgresql",
       "superuser": "postgres",
-      "clientTools": [
-        "psql",
-        "pg_dump",
-        "pg_restore"
-      ],
+      "clientTools": ["psql", "pg_dump", "pg_restore"],
       "notes": "Windows uses EDB binaries instead of hostdb"
     },
     "mysql": {
@@ -30,11 +26,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "mysql",
       "superuser": "root",
-      "clientTools": [
-        "mysql",
-        "mysqldump",
-        "mysqladmin"
-      ],
+      "clientTools": ["mysql", "mysqldump", "mysqladmin"],
       "licensing": "commercial"
     },
     "mariadb": {
@@ -48,11 +40,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "mysql",
       "superuser": "root",
-      "clientTools": [
-        "mariadb",
-        "mariadb-dump",
-        "mariadb-admin"
-      ]
+      "clientTools": ["mariadb", "mariadb-dump", "mariadb-admin"]
     },
     "sqlite": {
       "displayName": "SQLite",
@@ -65,12 +53,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "sqlite",
       "superuser": null,
-      "clientTools": [
-        "sqlite3",
-        "sqldiff",
-        "sqlite3_analyzer",
-        "sqlite3_rsync"
-      ]
+      "clientTools": ["sqlite3", "sqldiff", "sqlite3_analyzer", "sqlite3_rsync"]
     },
     "duckdb": {
       "displayName": "DuckDB",
@@ -83,9 +66,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "duckdb",
       "superuser": null,
-      "clientTools": [
-        "duckdb"
-      ],
+      "clientTools": ["duckdb"],
       "licensing": "MIT",
       "notes": "Embedded OLAP database optimized for analytical queries. File-based like SQLite."
     },
@@ -100,12 +81,7 @@
       "scriptFileLabel": "Run script file",
       "connectionScheme": "mongodb",
       "superuser": null,
-      "clientTools": [
-        "mongod",
-        "mongosh",
-        "mongodump",
-        "mongorestore"
-      ],
+      "clientTools": ["mongod", "mongosh", "mongodump", "mongorestore"],
       "licensing": "commercial"
     },
     "redis": {
@@ -119,15 +95,8 @@
       "scriptFileLabel": "Run command file",
       "connectionScheme": "redis",
       "superuser": null,
-      "clientTools": [
-        "redis-server",
-        "redis-cli"
-      ],
-      "licensing": [
-        "RSALv2",
-        "SSPLv1",
-        "AGPLv3"
-      ]
+      "clientTools": ["redis-server", "redis-cli"],
+      "licensing": ["RSALv2", "SSPLv1", "AGPLv3"]
     },
     "valkey": {
       "displayName": "Valkey",
@@ -140,10 +109,7 @@
       "scriptFileLabel": "Run command file",
       "connectionScheme": "redis",
       "superuser": null,
-      "clientTools": [
-        "valkey-server",
-        "valkey-cli"
-      ],
+      "clientTools": ["valkey-server", "valkey-cli"],
       "licensing": "BSD-3-Clause",
       "notes": "Redis fork with permissive licensing. Shares default port 6379 with Redis; port conflicts are resolved automatically."
     },
@@ -158,17 +124,10 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "clickhouse",
       "superuser": "default",
-      "clientTools": [
-        "clickhouse"
-      ],
+      "clientTools": ["clickhouse"],
       "licensing": "Apache-2.0",
       "notes": "Column-oriented OLAP database. Uses YY.MM.X.build versioning. Native port 9000, HTTP port 8123. WSL only on Windows.",
-      "platforms": [
-        "darwin-arm64",
-        "darwin-x64",
-        "linux-arm64",
-        "linux-x64"
-      ]
+      "platforms": ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]
     },
     "qdrant": {
       "displayName": "Qdrant",
@@ -181,9 +140,7 @@
       "scriptFileLabel": null,
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "qdrant"
-      ],
+      "clientTools": ["qdrant"],
       "licensing": "Apache-2.0",
       "notes": "Vector similarity search engine. REST API on port 6333, gRPC on 6334. Uses collections instead of databases."
     },
@@ -198,9 +155,7 @@
       "scriptFileLabel": null,
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "meilisearch"
-      ],
+      "clientTools": ["meilisearch"],
       "licensing": "MIT",
       "notes": "Full-text search engine. REST API on port 7700. Uses indexes instead of databases."
     },
@@ -215,12 +170,7 @@
       "scriptFileLabel": "Run script file",
       "connectionScheme": "mongodb",
       "superuser": null,
-      "clientTools": [
-        "ferretdb",
-        "mongosh",
-        "mongodump",
-        "mongorestore"
-      ],
+      "clientTools": ["ferretdb", "mongosh", "mongodump", "mongorestore"],
       "licensing": "Apache-2.0",
       "notes": "MongoDB-compatible proxy. v2 uses postgresql-documentdb (macOS/Linux). v1 uses plain PostgreSQL (all platforms incl. Windows)."
     },
@@ -235,9 +185,7 @@
       "scriptFileLabel": null,
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "couchdb"
-      ],
+      "clientTools": ["couchdb"],
       "licensing": "Apache-2.0",
       "notes": "Document database with REST API. Fauxton web UI at /_utils. Uses JSON documents."
     },
@@ -252,13 +200,8 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "postgresql",
       "superuser": "root",
-      "clientTools": [
-        "cockroach"
-      ],
-      "licensing": [
-        "BSL",
-        "Apache-2.0"
-      ],
+      "clientTools": ["cockroach"],
+      "licensing": ["BSL", "Apache-2.0"],
       "notes": "Distributed SQL database with PostgreSQL compatibility. HTTP admin UI at port+1 (default 8080). Single binary handles server and client."
     },
     "surrealdb": {
@@ -272,13 +215,8 @@
       "scriptFileLabel": "Run SurrealQL file",
       "connectionScheme": "ws",
       "superuser": "root",
-      "clientTools": [
-        "surreal"
-      ],
-      "licensing": [
-        "BSL",
-        "Apache-2.0"
-      ],
+      "clientTools": ["surreal"],
+      "licensing": ["BSL", "Apache-2.0"],
       "notes": "Multi-model database supporting document, graph, and relational data. SurrealQL query language. Uses namespace/database hierarchy."
     },
     "questdb": {
@@ -292,9 +230,7 @@
       "scriptFileLabel": "Run SQL file",
       "connectionScheme": "postgresql",
       "superuser": "admin",
-      "clientTools": [
-        "questdb"
-      ],
+      "clientTools": ["questdb"],
       "licensing": "Apache-2.0",
       "notes": "High-performance time-series database. PostgreSQL wire protocol on port 8812. Web Console at port+188. Bundled JRE (no Java required)."
     },
@@ -309,10 +245,7 @@
       "scriptFileLabel": "Run TypeQL file",
       "connectionScheme": "typedb",
       "superuser": "admin",
-      "clientTools": [
-        "typedb",
-        "typedb-console"
-      ],
+      "clientTools": ["typedb", "typedb-console"],
       "licensing": "MPL-2.0",
       "notes": "Strongly-typed database for knowledge representation and reasoning. TypeQL query language. Main port 1729, HTTP port 8000. Default credentials: admin/password."
     },
@@ -327,13 +260,8 @@
       "scriptFileLabel": "Run LP/SQL file",
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "influxdb3"
-      ],
-      "licensing": [
-        "Apache-2.0",
-        "MIT"
-      ],
+      "clientTools": ["influxdb3"],
+      "licensing": ["Apache-2.0", "MIT"],
       "notes": "Purpose-built time-series database with SQL support. InfluxDB 3.x is a Rust rewrite using Apache Arrow/DataFusion. HTTP API on port 8086."
     },
     "weaviate": {
@@ -347,9 +275,7 @@
       "scriptFileLabel": null,
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "weaviate"
-      ],
+      "clientTools": ["weaviate"],
       "licensing": "BSD-3-Clause",
       "notes": "AI-native vector database. REST API on port 8080, gRPC on port+1. Uses classes/collections instead of databases."
     },
@@ -364,9 +290,7 @@
       "scriptFileLabel": null,
       "connectionScheme": null,
       "superuser": null,
-      "clientTools": [
-        "tigerbeetle"
-      ],
+      "clientTools": ["tigerbeetle"],
       "licensing": "Apache-2.0",
       "notes": "High-performance financial ledger database. Custom binary protocol, REPL client. Uses --development flag for local dev."
     },
@@ -381,17 +305,10 @@
       "scriptFileLabel": null,
       "connectionScheme": "http",
       "superuser": null,
-      "clientTools": [
-        "sqld"
-      ],
+      "clientTools": ["sqld"],
       "licensing": "MIT",
       "notes": "SQLite fork by Turso with server mode (sqld), HTTP API, replication support. No Windows binaries. Enhanced clients: litecli, usql.",
-      "platforms": [
-        "darwin-arm64",
-        "darwin-x64",
-        "linux-arm64",
-        "linux-x64"
-      ]
+      "platforms": ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]
     }
   }
 }

--- a/core/dependency-manager.ts
+++ b/core/dependency-manager.ts
@@ -234,9 +234,7 @@ export async function getMissingDependencies(
  * `true` for `--start`, and `undefined` when neither is passed (check still
  * runs, since the container will be started).
  */
-export function clientToolCheckRequired(options: {
-  start?: boolean
-}): boolean {
+export function clientToolCheckRequired(options: { start?: boolean }): boolean {
   return options.start !== false
 }
 

--- a/core/pg-binary-resolver.ts
+++ b/core/pg-binary-resolver.ts
@@ -45,7 +45,10 @@ export function getBundledBinaryPath(
 
   for (const entry of installed) {
     // Match same-major installs (version === "18" or starts with "18.")
-    if (entry.version !== majorVersion && !entry.version.startsWith(majorPrefix)) {
+    if (
+      entry.version !== majorVersion &&
+      !entry.version.startsWith(majorPrefix)
+    ) {
       continue
     }
 

--- a/core/query-parser.ts
+++ b/core/query-parser.ts
@@ -28,7 +28,9 @@ export function parseCSVToQueryResult(csv: string): QueryResult {
   const nonEmptyLines = lines.filter((l) => l.trim())
   if (nonEmptyLines.every((l) => PG_COMMAND_TAG.test(l.trim()))) {
     const lastTag = nonEmptyLines[nonEmptyLines.length - 1].trim()
-    const countMatch = lastTag.match(/^(?:INSERT \d+ |UPDATE |DELETE |MERGE |COPY |SELECT )(\d+)$/)
+    const countMatch = lastTag.match(
+      /^(?:INSERT \d+ |UPDATE |DELETE |MERGE |COPY |SELECT )(\d+)$/,
+    )
     return {
       columns: [],
       rows: [],

--- a/engines/clickhouse/backup.ts
+++ b/engines/clickhouse/backup.ts
@@ -11,23 +11,29 @@ import { spawn } from 'child_process'
 import { stat, mkdir, writeFile } from 'fs/promises'
 import { existsSync, createWriteStream } from 'fs'
 import { dirname } from 'path'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug, logWarning } from '../../core/error-handler'
 import {
   requireClickHousePath,
   validateClickHouseIdentifier,
   escapeClickHouseIdentifier,
 } from './cli-utils'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 type ClickHouseLocalAuth = {
   user?: string
   password?: string
 }
 
-function buildClickHouseEnv(
-  auth?: ClickHouseLocalAuth,
-): NodeJS.ProcessEnv {
+function buildClickHouseEnv(auth?: ClickHouseLocalAuth): NodeJS.ProcessEnv {
   const env = { ...process.env }
   if (auth?.user) {
     env.CLICKHOUSE_USER = auth.user

--- a/engines/clickhouse/restore.ts
+++ b/engines/clickhouse/restore.ts
@@ -6,7 +6,10 @@
 import { spawn } from 'child_process'
 import { open } from 'fs/promises'
 import { existsSync, statSync, createReadStream } from 'fs'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug, logWarning } from '../../core/error-handler'
 import {
   requireClickHousePath,
@@ -34,9 +37,7 @@ type ClickHouseLocalAuth = {
   password?: string
 }
 
-function buildClickHouseEnv(
-  auth?: ClickHouseLocalAuth,
-): NodeJS.ProcessEnv {
+function buildClickHouseEnv(auth?: ClickHouseLocalAuth): NodeJS.ProcessEnv {
   const env = { ...process.env }
   if (auth?.user) {
     env.CLICKHOUSE_USER = auth.user
@@ -434,8 +435,13 @@ export async function restoreBackup(
   backupPath: string,
   options: RestoreOptions,
 ): Promise<RestoreResult> {
-  const { containerName, port, database = 'default', version, clean = false } =
-    options
+  const {
+    containerName,
+    port,
+    database = 'default',
+    version,
+    clean = false,
+  } = options
 
   if (!existsSync(backupPath)) {
     throw new Error(`Backup file not found: ${backupPath}`)

--- a/engines/cockroachdb/cli-utils.ts
+++ b/engines/cockroachdb/cli-utils.ts
@@ -83,7 +83,10 @@ export async function requireCockroachPath(version?: string): Promise<string> {
 }
 
 export function getCockroachCertsDir(containerName: string): string {
-  return join(paths.getContainerPath(containerName, { engine: 'cockroachdb' }), 'certs')
+  return join(
+    paths.getContainerPath(containerName, { engine: 'cockroachdb' }),
+    'certs',
+  )
 }
 
 export function getCockroachCaCertPath(containerName: string): string {

--- a/engines/cockroachdb/index.ts
+++ b/engines/cockroachdb/index.ts
@@ -703,11 +703,7 @@ export class CockroachDBEngine extends BaseEngine {
     }
 
     return new Promise((resolve, reject) => {
-      const proc = spawn(
-        cockroach,
-        args,
-        spawnOptions,
-      )
+      const proc = spawn(cockroach, args, spawnOptions)
 
       proc.on('error', reject)
       proc.on('close', () => resolve())
@@ -835,7 +831,10 @@ export class CockroachDBEngine extends BaseEngine {
       containerName: name,
       port,
     })
-    args.push('--execute', `ALTER DATABASE ${escapedOld} RENAME TO ${escapedNew}`)
+    args.push(
+      '--execute',
+      `ALTER DATABASE ${escapedOld} RENAME TO ${escapedNew}`,
+    )
 
     await new Promise<void>((resolve, reject) => {
       const proc = spawn(cockroach, args, {
@@ -1388,16 +1387,17 @@ export class CockroachDBEngine extends BaseEngine {
     // authenticate as root via the generated client certificate, while end users
     // connect with password-based auth over TLS.
     const escapedPassword = password.replace(/'/g, "''")
-    const sql = [
-      `CREATE USER IF NOT EXISTS ${escapedUser}`,
-      `ALTER USER ${escapedUser} WITH PASSWORD '${escapedPassword}'`,
-      `GRANT ALL ON DATABASE ${escapedDb} TO ${escapedUser}`,
-      `GRANT ALL ON SCHEMA public TO ${escapedUser}`,
-      `GRANT ALL ON ALL TABLES IN SCHEMA public TO ${escapedUser}`,
-      `GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO ${escapedUser}`,
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${escapedUser}`,
-      `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${escapedUser}`,
-    ].join('; ') + ';'
+    const sql =
+      [
+        `CREATE USER IF NOT EXISTS ${escapedUser}`,
+        `ALTER USER ${escapedUser} WITH PASSWORD '${escapedPassword}'`,
+        `GRANT ALL ON DATABASE ${escapedDb} TO ${escapedUser}`,
+        `GRANT ALL ON SCHEMA public TO ${escapedUser}`,
+        `GRANT ALL ON ALL TABLES IN SCHEMA public TO ${escapedUser}`,
+        `GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO ${escapedUser}`,
+        `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ${escapedUser}`,
+        `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ${escapedUser}`,
+      ].join('; ') + ';'
 
     const args = buildLocalCockroachSqlArgs({
       containerName: name,

--- a/engines/couchdb/backup.ts
+++ b/engines/couchdb/backup.ts
@@ -11,9 +11,17 @@ import { mkdir, stat, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { dirname } from 'path'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { couchdbApiRequest } from './api-client'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 // Backup operations may take longer than the default timeout
 const BACKUP_TIMEOUT_MS = 600000 // 10 minutes

--- a/engines/couchdb/restore.ts
+++ b/engines/couchdb/restore.ts
@@ -6,7 +6,10 @@
 import { readFile, open } from 'fs/promises'
 import { existsSync, statSync } from 'fs'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { couchdbApiRequest } from './api-client'
 import { Engine, type BackupFormat, type RestoreResult } from '../../types'
 

--- a/engines/ferretdb/backup.ts
+++ b/engines/ferretdb/backup.ts
@@ -12,10 +12,21 @@ import { existsSync } from 'fs'
 import { dirname, join } from 'path'
 import { mkdir } from 'fs/promises'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { buildMongoUri } from '../mongo-uri'
-import { getMongodumpPath, MONGODUMP_NOT_FOUND_ERROR } from '../mongodb/cli-utils'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  getMongodumpPath,
+  MONGODUMP_NOT_FOUND_ERROR,
+} from '../mongodb/cli-utils'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 function redactMongoUri(uri: string): string {
   try {
@@ -73,22 +84,20 @@ export async function createBackup(
   const args: string[] = savedCreds
     ? [
         '--uri',
-        buildMongoUri(port, database, {
-          username: savedCreds.username,
-          password: savedCreds.password,
-          authDatabase: savedCreds.database || 'admin',
-        }, container.bindAddress ?? '127.0.0.1'),
+        buildMongoUri(
+          port,
+          database,
+          {
+            username: savedCreds.username,
+            password: savedCreds.password,
+            authDatabase: savedCreds.database || 'admin',
+          },
+          container.bindAddress ?? '127.0.0.1',
+        ),
         '--db',
         database,
       ]
-    : [
-        '--host',
-        '127.0.0.1',
-        '--port',
-        String(port),
-        '--db',
-        database,
-      ]
+    : ['--host', '127.0.0.1', '--port', String(port), '--db', database]
 
   // FerretDB now uses Mongo-compatible backup formats under the hood:
   // - archive: single compressed file

--- a/engines/ferretdb/index.ts
+++ b/engines/ferretdb/index.ts
@@ -34,7 +34,10 @@ import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
 import { platformService, isWindows } from '../../core/platform-service'
 import { configManager } from '../../core/config-manager'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { containerManager } from '../../core/container-manager'
 import {
   logDebug,
@@ -1275,14 +1278,7 @@ export class FerretDBEngine extends BaseEngine {
     const savedCreds = await this.getLocalAuth(container.name)
     const connectHost = normalizeMongoHost(container.bindAddress)
     const args = savedCreds
-      ? [
-          buildMongoUri(
-            container.port,
-            database,
-            savedCreds,
-            connectHost,
-          ),
-        ]
+      ? [buildMongoUri(container.port, database, savedCreds, connectHost)]
       : ['--host', connectHost, '--port', String(container.port), database]
 
     if (options?.quiet) {
@@ -1295,7 +1291,12 @@ export class FerretDBEngine extends BaseEngine {
   private async runLocalMongosh(
     container: ContainerConfig,
     database: string,
-    options: { eval?: string; file?: string; quiet?: boolean; timeoutMs?: number },
+    options: {
+      eval?: string
+      file?: string
+      quiet?: boolean
+      timeoutMs?: number
+    },
   ): Promise<{ stdout: string; stderr: string }> {
     const mongosh = await this.getMongoshPath()
     const args = await this.buildLocalMongoshArgs(container, database, {
@@ -1408,7 +1409,8 @@ export class FerretDBEngine extends BaseEngine {
     backupPath: string,
     options: Record<string, unknown> = {},
   ): Promise<RestoreResult> {
-    const database = (options.database as string) || container.database || 'test'
+    const database =
+      (options.database as string) || container.database || 'test'
 
     // Validate database name before restore (defense-in-depth)
     assertValidDatabaseName(database)
@@ -1716,12 +1718,7 @@ export class FerretDBEngine extends BaseEngine {
       const connectHost = normalizeMongoHost(container.bindAddress)
       args = savedCreds
         ? [
-            buildMongoUri(
-              port,
-              db,
-              savedCreds,
-              connectHost,
-            ),
+            buildMongoUri(port, db, savedCreds, connectHost),
             '--quiet',
             '--eval',
             script,

--- a/engines/ferretdb/version-maps.ts
+++ b/engines/ferretdb/version-maps.ts
@@ -37,7 +37,8 @@ function buildVersionMap(engine: string): Record<string, string> {
   return map
 }
 
-export const FERRETDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const FERRETDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const DOCUMENTDB_VERSION_MAP: Record<string, string> =
   buildVersionMap(DOCUMENTDB_ENGINE)

--- a/engines/influxdb/backup.ts
+++ b/engines/influxdb/backup.ts
@@ -7,10 +7,18 @@ import { mkdir, readFile, stat, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { dirname } from 'path'
 import { paths } from '../../config/paths'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { influxdbApiRequest } from './api-client'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 const ADMIN_TOKEN_FILE = 'admin-token.json'
 
@@ -34,7 +42,11 @@ async function loadInfluxAuthToken(
     // Fall back to saved credentials
   }
 
-  const savedCreds = await loadCredentials(containerName, Engine.InfluxDB, username)
+  const savedCreds = await loadCredentials(
+    containerName,
+    Engine.InfluxDB,
+    username,
+  )
   return savedCreds?.apiKey
 }
 

--- a/engines/influxdb/binary-manager.ts
+++ b/engines/influxdb/binary-manager.ts
@@ -65,7 +65,9 @@ class InfluxDBBinaryManager extends BaseBinaryManager {
    * Windows only searches the application directory by default. Adding
    * bin/python/ to PATH makes it discoverable.
    */
-  protected override getSpawnEnv(binPath: string): Record<string, string> | undefined {
+  protected override getSpawnEnv(
+    binPath: string,
+  ): Record<string, string> | undefined {
     return getWindowsDllEnv(join(binPath, 'bin', 'python'))
   }
 

--- a/engines/influxdb/index.ts
+++ b/engines/influxdb/index.ts
@@ -183,9 +183,9 @@ async function readAdminToken(
   }
 
   try {
-    const parsed = JSON.parse(await readFile(tokenPath, 'utf-8')) as Partial<
-      StoredAdminToken
-    >
+    const parsed = JSON.parse(
+      await readFile(tokenPath, 'utf-8'),
+    ) as Partial<StoredAdminToken>
 
     if (!parsed.token || !parsed.name) {
       throw new Error('is missing token or name')
@@ -535,7 +535,9 @@ export class InfluxDBEngine extends BaseEngine {
     }
 
     // On Windows, influxdb3.exe needs python313.dll from the co-located python/ dir
-    const pythonDllEnv = getWindowsDllEnv(join(dirname(influxdbServer), 'python'))
+    const pythonDllEnv = getWindowsDllEnv(
+      join(dirname(influxdbServer), 'python'),
+    )
 
     // InfluxDB runs in foreground, so we need to spawn detached
     if (isWindows()) {
@@ -561,11 +563,7 @@ export class InfluxDBEngine extends BaseEngine {
           if (settled) return
           settled = true
           const reason = signal ? `signal ${signal}` : `code ${code}`
-          reject(
-            new Error(
-              `InfluxDB process exited unexpectedly (${reason}).`,
-            ),
-          )
+          reject(new Error(`InfluxDB process exited unexpectedly (${reason}).`))
         })
 
         proc.unref()
@@ -589,7 +587,8 @@ export class InfluxDBEngine extends BaseEngine {
 
           const ready =
             (await this.waitForReady(port)) &&
-            (!adminToken || (await this.waitForAuthReady(port, adminToken.token)))
+            (!adminToken ||
+              (await this.waitForAuthReady(port, adminToken.token)))
           if (settled) return
 
           if (ready) {

--- a/engines/influxdb/restore.ts
+++ b/engines/influxdb/restore.ts
@@ -7,7 +7,10 @@ import { open, readFile as readFileAsync } from 'fs/promises'
 import { existsSync, statSync } from 'fs'
 import { join } from 'path'
 import { paths } from '../../config/paths'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { influxdbApiRequest } from './api-client'
 import { Engine, type BackupFormat, type RestoreResult } from '../../types'
@@ -34,7 +37,11 @@ async function loadInfluxAuthToken(
     // Fall back to saved credentials
   }
 
-  const savedCreds = await loadCredentials(containerName, Engine.InfluxDB, username)
+  const savedCreds = await loadCredentials(
+    containerName,
+    Engine.InfluxDB,
+    username,
+  )
   return savedCreds?.apiKey
 }
 

--- a/engines/mariadb/backup.ts
+++ b/engines/mariadb/backup.ts
@@ -10,9 +10,7 @@ import { stat } from 'fs/promises'
 import { join } from 'path'
 import { createGzip } from 'zlib'
 import { pipeline } from 'stream/promises'
-import {
-  platformService,
-} from '../../core/platform-service'
+import { platformService } from '../../core/platform-service'
 import { getEngineDefaults } from '../../config/defaults'
 import { paths } from '../../config/paths'
 import { normalizeVersion } from './version-maps'

--- a/engines/mariadb/index.ts
+++ b/engines/mariadb/index.ts
@@ -11,10 +11,7 @@ import { BaseEngine } from '../base-engine'
 import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
 import { memoryBudgetArgs } from '../../core/memory-budget'
-import {
-  platformService,
-  isWindows,
-} from '../../core/platform-service'
+import { platformService, isWindows } from '../../core/platform-service'
 import { configManager } from '../../core/config-manager'
 import {
   getDefaultUsername,
@@ -1066,16 +1063,18 @@ export class MariaDBEngine extends BaseEngine {
     ]
 
     try {
-      const { stdout } = await runMariaDbBinary(getIdsArgs[0], getIdsArgs.slice(1), {
-        password: auth.password,
-      })
+      const { stdout } = await runMariaDbBinary(
+        getIdsArgs[0],
+        getIdsArgs.slice(1),
+        {
+          password: auth.password,
+        },
+      )
       const lines = stdout
         .trim()
         .split('\n')
         .filter((l) => l.trim())
-      const ids = lines
-        .map((l) => l.trim())
-        .filter((l) => /^\d+$/.test(l))
+      const ids = lines.map((l) => l.trim()).filter((l) => /^\d+$/.test(l))
 
       for (const id of ids) {
         const killArgs = [
@@ -1113,15 +1112,7 @@ export class MariaDBEngine extends BaseEngine {
     const mysql = await this.getMariadbClientPath()
     const auth = await this.getLocalAdminAuth(name)
 
-    const args = [
-      '-h',
-      '127.0.0.1',
-      '-P',
-      String(port),
-      '-u',
-      auth.user,
-      db,
-    ]
+    const args = ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user, db]
 
     if (options.sql) {
       args.push('-e', options.sql)
@@ -1353,14 +1344,7 @@ export class MariaDBEngine extends BaseEngine {
     const sql = `CREATE USER IF NOT EXISTS '${username}'@'%' IDENTIFIED BY '${escapedPass}'; CREATE USER IF NOT EXISTS '${username}'@'localhost' IDENTIFIED BY '${escapedPass}'; ALTER USER '${username}'@'%' IDENTIFIED BY '${escapedPass}'; ALTER USER '${username}'@'localhost' IDENTIFIED BY '${escapedPass}'; GRANT ALL ON \`${db}\`.* TO '${username}'@'%'; GRANT ALL ON \`${db}\`.* TO '${username}'@'localhost'; FLUSH PRIVILEGES;`
 
     // Send SQL via stdin to avoid leaking password in process argv
-    const args = [
-      '-h',
-      '127.0.0.1',
-      '-P',
-      String(port),
-      '-u',
-      auth.user,
-    ]
+    const args = ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user]
 
     await new Promise<void>((resolve, reject) => {
       const proc = spawn(mariadb, args, {

--- a/engines/meilisearch/backup.ts
+++ b/engines/meilisearch/backup.ts
@@ -6,11 +6,19 @@
 import { mkdir, stat, copyFile, readdir } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { paths } from '../../config/paths'
 import { meilisearchApiRequest } from './api-client'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 // Backup operations may take longer than the default timeout
 const BACKUP_TIMEOUT_MS = 600000 // 10 minutes

--- a/engines/meilisearch/index.ts
+++ b/engines/meilisearch/index.ts
@@ -1226,14 +1226,13 @@ export class MeilisearchEngine extends BaseEngine {
     options?: QueryOptions,
   ): Promise<QueryResult> {
     const { name, port } = container
-    const savedCreds =
-      options?.password
-        ? null
-        : await loadCredentials(
-            name,
-            Engine.Meilisearch,
-            getDefaultUsername(Engine.Meilisearch),
-          )
+    const savedCreds = options?.password
+      ? null
+      : await loadCredentials(
+          name,
+          Engine.Meilisearch,
+          getDefaultUsername(Engine.Meilisearch),
+        )
     const apiKey = options?.password || savedCreds?.apiKey
 
     // Parse the query string: METHOD /path [body]

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -168,7 +168,17 @@ export class MySQLEngine extends BaseEngine {
 
     await execFileAsync(
       mysql,
-      ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user, '-N', '-e', 'SELECT 1'],
+      [
+        '-h',
+        '127.0.0.1',
+        '-P',
+        String(port),
+        '-u',
+        auth.user,
+        '-N',
+        '-e',
+        'SELECT 1',
+      ],
       {
         env: buildMysqlEnv(auth.password),
       },
@@ -184,7 +194,17 @@ export class MySQLEngine extends BaseEngine {
 
     await execFileAsync(
       mysql,
-      ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user, '-N', '-e', 'SHUTDOWN'],
+      [
+        '-h',
+        '127.0.0.1',
+        '-P',
+        String(port),
+        '-u',
+        auth.user,
+        '-N',
+        '-e',
+        'SHUTDOWN',
+      ],
       {
         env: buildMysqlEnv(auth.password),
         timeout: 5000,
@@ -934,18 +954,22 @@ export class MySQLEngine extends BaseEngine {
     const auth = await this.getLocalAdminAuth(name)
 
     try {
-      await execFileAsync(mysql, [
-        '-h',
-        '127.0.0.1',
-        '-P',
-        String(port),
-        '-u',
-        auth.user,
-        '-e',
-        `CREATE DATABASE IF NOT EXISTS \`${database}\``,
-      ], {
-        env: buildMysqlEnv(auth.password),
-      })
+      await execFileAsync(
+        mysql,
+        [
+          '-h',
+          '127.0.0.1',
+          '-P',
+          String(port),
+          '-u',
+          auth.user,
+          '-e',
+          `CREATE DATABASE IF NOT EXISTS \`${database}\``,
+        ],
+        {
+          env: buildMysqlEnv(auth.password),
+        },
+      )
     } catch (error) {
       const err = error as Error
       if (!err.message.includes('database exists')) {
@@ -965,18 +989,22 @@ export class MySQLEngine extends BaseEngine {
     const auth = await this.getLocalAdminAuth(name)
 
     try {
-      await execFileAsync(mysql, [
-        '-h',
-        '127.0.0.1',
-        '-P',
-        String(port),
-        '-u',
-        auth.user,
-        '-e',
-        `DROP DATABASE IF EXISTS \`${database}\``,
-      ], {
-        env: buildMysqlEnv(auth.password),
-      })
+      await execFileAsync(
+        mysql,
+        [
+          '-h',
+          '127.0.0.1',
+          '-P',
+          String(port),
+          '-u',
+          auth.user,
+          '-e',
+          `DROP DATABASE IF EXISTS \`${database}\``,
+        ],
+        {
+          env: buildMysqlEnv(auth.password),
+        },
+      )
     } catch (error) {
       const err = error as Error
       if (!err.message.includes("database doesn't exist")) {
@@ -995,19 +1023,23 @@ export class MySQLEngine extends BaseEngine {
       const mysql = await this.getMysqlClientPath()
       const auth = await this.getLocalAdminAuth(name)
 
-      const { stdout } = await execFileAsync(mysql, [
-        '-h',
-        '127.0.0.1',
-        '-P',
-        String(port),
-        '-u',
-        auth.user,
-        '-N',
-        '-e',
-        `SELECT COALESCE(SUM(data_length + index_length), 0) FROM information_schema.tables WHERE table_schema = '${db}'`,
-      ], {
-        env: buildMysqlEnv(auth.password),
-      })
+      const { stdout } = await execFileAsync(
+        mysql,
+        [
+          '-h',
+          '127.0.0.1',
+          '-P',
+          String(port),
+          '-u',
+          auth.user,
+          '-N',
+          '-e',
+          `SELECT COALESCE(SUM(data_length + index_length), 0) FROM information_schema.tables WHERE table_schema = '${db}'`,
+        ],
+        {
+          env: buildMysqlEnv(auth.password),
+        },
+      )
       const size = parseInt(stdout.trim(), 10)
       return isNaN(size) ? null : size
     } catch {
@@ -1101,19 +1133,23 @@ export class MySQLEngine extends BaseEngine {
     // Get all connection IDs for the target database and kill them
     // We need to do this in two steps since MySQL doesn't support subqueries in KILL
     try {
-      const { stdout } = await execFileAsync(mysql, [
-        '-h',
-        '127.0.0.1',
-        '-P',
-        String(port),
-        '-u',
-        auth.user,
-        '-N',
-        '-e',
-        `SELECT ID FROM information_schema.PROCESSLIST WHERE DB = '${database}' AND ID != CONNECTION_ID()`,
-      ], {
-        env: buildMysqlEnv(auth.password),
-      })
+      const { stdout } = await execFileAsync(
+        mysql,
+        [
+          '-h',
+          '127.0.0.1',
+          '-P',
+          String(port),
+          '-u',
+          auth.user,
+          '-N',
+          '-e',
+          `SELECT ID FROM information_schema.PROCESSLIST WHERE DB = '${database}' AND ID != CONNECTION_ID()`,
+        ],
+        {
+          env: buildMysqlEnv(auth.password),
+        },
+      )
       const lines = stdout
         .trim()
         .split('\n')
@@ -1126,18 +1162,22 @@ export class MySQLEngine extends BaseEngine {
 
       for (const id of ids) {
         try {
-          await execFileAsync(mysql, [
-            '-h',
-            '127.0.0.1',
-            '-P',
-            String(port),
-            '-u',
-            auth.user,
-            '-e',
-            `KILL CONNECTION ${id}`,
-          ], {
-            env: buildMysqlEnv(auth.password),
-          })
+          await execFileAsync(
+            mysql,
+            [
+              '-h',
+              '127.0.0.1',
+              '-P',
+              String(port),
+              '-u',
+              auth.user,
+              '-e',
+              `KILL CONNECTION ${id}`,
+            ],
+            {
+              env: buildMysqlEnv(auth.password),
+            },
+          )
         } catch {
           // Connection may already be gone
         }
@@ -1158,15 +1198,7 @@ export class MySQLEngine extends BaseEngine {
     const mysql = await this.getMysqlClientPath()
     const auth = await this.getLocalAdminAuth(name)
 
-    const args = [
-      '-h',
-      '127.0.0.1',
-      '-P',
-      String(port),
-      '-u',
-      auth.user,
-      db,
-    ]
+    const args = ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user, db]
 
     if (options.sql) {
       args.push('-e', options.sql)
@@ -1407,14 +1439,7 @@ export class MySQLEngine extends BaseEngine {
     const sql = `CREATE USER IF NOT EXISTS '${escapedUser}'@'%' IDENTIFIED BY '${escapedPass}'; CREATE USER IF NOT EXISTS '${escapedUser}'@'localhost' IDENTIFIED BY '${escapedPass}'; ALTER USER '${escapedUser}'@'%' IDENTIFIED BY '${escapedPass}'; ALTER USER '${escapedUser}'@'localhost' IDENTIFIED BY '${escapedPass}'; GRANT ALL ON \`${escapedDb}\`.* TO '${escapedUser}'@'%'; GRANT ALL ON \`${escapedDb}\`.* TO '${escapedUser}'@'localhost'; FLUSH PRIVILEGES;`
 
     // Send SQL via stdin to avoid leaking password in process argv
-    const args = [
-      '-h',
-      '127.0.0.1',
-      '-P',
-      String(port),
-      '-u',
-      auth.user,
-    ]
+    const args = ['-h', '127.0.0.1', '-P', String(port), '-u', auth.user]
 
     await new Promise<void>((resolve, reject) => {
       const proc = spawn(mysql, args, {

--- a/engines/qdrant/backup.ts
+++ b/engines/qdrant/backup.ts
@@ -6,11 +6,19 @@
 import { mkdir, stat, copyFile, readdir } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { paths } from '../../config/paths'
 import { qdrantApiRequest } from './api-client'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 // Backup operations may take longer than the default timeout
 const BACKUP_TIMEOUT_MS = 600000 // 10 minutes

--- a/engines/qdrant/index.ts
+++ b/engines/qdrant/index.ts
@@ -569,7 +569,9 @@ export class QdrantEngine extends BaseEngine {
     let snapshotApplied = false
     if (existsSync(pendingSnapshotMarker)) {
       try {
-        const snapshotPath = (await readFile(pendingSnapshotMarker, 'utf-8')).trim()
+        const snapshotPath = (
+          await readFile(pendingSnapshotMarker, 'utf-8')
+        ).trim()
         if (snapshotPath && existsSync(snapshotPath)) {
           args.push(
             '--storage-snapshot',

--- a/engines/qdrant/restore.ts
+++ b/engines/qdrant/restore.ts
@@ -88,7 +88,9 @@ async function restoreSnapshotBackup(
   containerName: string,
   dataDir?: string,
 ): Promise<RestoreResult> {
-  const containerDir = paths.getContainerPath(containerName, { engine: 'qdrant' })
+  const containerDir = paths.getContainerPath(containerName, {
+    engine: 'qdrant',
+  })
   const targetDir =
     dataDir || paths.getContainerDataPath(containerName, { engine: 'qdrant' })
   const snapshotsDir = join(targetDir, 'snapshots')
@@ -118,8 +120,7 @@ async function restoreSnapshotBackup(
 
   return {
     format: 'snapshot',
-    stdout:
-      `Restored snapshot to ${targetPath}. Next start will load the storage snapshot automatically.`,
+    stdout: `Restored snapshot to ${targetPath}. Next start will load the storage snapshot automatically.`,
     code: 0,
   }
 }

--- a/engines/questdb/backup.ts
+++ b/engines/questdb/backup.ts
@@ -15,7 +15,11 @@ import { writeFile, stat } from 'fs/promises'
 import { spawn } from 'child_process'
 import { configManager } from '../../core/config-manager'
 import { logDebug, logWarning } from '../../core/error-handler'
-import { type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 import { loadLocalQuestAuth, type QuestLocalAuth } from './auth'
 
 /**

--- a/engines/redis/backup.ts
+++ b/engines/redis/backup.ts
@@ -70,11 +70,7 @@ async function execRedisCommand(
 
     proc.on('close', (code, signal) => {
       const combinedOutput = `${stdout}\n${stderr}`.trim()
-      const hasCliError = hasRedisCliError(
-        stdout,
-        stderr,
-        inspectStdoutErrors,
-      )
+      const hasCliError = hasRedisCliError(stdout, stderr, inspectStdoutErrors)
       const libraryError = detectLibraryError(combinedOutput, 'Redis')
 
       if (libraryError) {

--- a/engines/redis/cli-common.ts
+++ b/engines/redis/cli-common.ts
@@ -7,16 +7,12 @@ type RedisCliAuth = {
 }
 
 function getRedisCliErrorMarkers(): RegExp[] {
-  return [
-    /^ERR\b/m,
-    /\bNOAUTH\b/,
-    /\bWRONGPASS\b/,
-    /\bNOPERM\b/,
-    /\bACL\b/,
-  ]
+  return [/^ERR\b/m, /\bNOAUTH\b/, /\bWRONGPASS\b/, /\bNOPERM\b/, /\bACL\b/]
 }
 
-export function shouldPassRedisCliUsername(username?: string): username is string {
+export function shouldPassRedisCliUsername(
+  username?: string,
+): username is string {
   if (!username) {
     return false
   }

--- a/engines/redis/index.ts
+++ b/engines/redis/index.ts
@@ -72,9 +72,7 @@ function escapeKeyForCommand(key: string): string {
 }
 const engineDef = getEngineDefaults(ENGINE)
 
-function buildRedisCliEnv(
-  password?: string,
-): NodeJS.ProcessEnv {
+function buildRedisCliEnv(password?: string): NodeJS.ProcessEnv {
   return password
     ? { ...process.env, REDISCLI_AUTH: password }
     : { ...process.env }

--- a/engines/redis/resp-client.ts
+++ b/engines/redis/resp-client.ts
@@ -82,7 +82,9 @@ function parseReply(
       return { value: items, offset: cur }
     }
     default:
-      throw new Error(`Unsupported RESP reply type: ${String.fromCharCode(type)}`)
+      throw new Error(
+        `Unsupported RESP reply type: ${String.fromCharCode(type)}`,
+      )
   }
 }
 
@@ -114,13 +116,12 @@ export class RespClient {
     this.socket = socket
     socket.on('data', (chunk: Buffer) => this.onData(chunk))
     socket.on('error', (err: Error) => this.onFatal(err))
-    socket.on('close', () =>
-      this.onFatal(new Error('Redis connection closed')),
-    )
+    socket.on('close', () => this.onFatal(new Error('Redis connection closed')))
   }
 
   private onData(chunk: Buffer): void {
-    this.inbox = this.inbox.length === 0 ? chunk : Buffer.concat([this.inbox, chunk])
+    this.inbox =
+      this.inbox.length === 0 ? chunk : Buffer.concat([this.inbox, chunk])
     let offset = 0
     for (;;) {
       const parsed = parseReply(this.inbox, offset)
@@ -222,7 +223,10 @@ export class RespClient {
 
   // One SCAN step. Returns the next cursor ('0' when complete) and the batch of
   // keys as Buffers (binary-safe).
-  async scan(cursor: string, count: number): Promise<{
+  async scan(
+    cursor: string,
+    count: number,
+  ): Promise<{
     cursor: string
     keys: Buffer[]
   }> {

--- a/engines/redis/restore.ts
+++ b/engines/redis/restore.ts
@@ -328,7 +328,6 @@ async function restoreTextBackup(
       fileStream.destroy()
       lineReader.close()
     })
-
     ;(async () => {
       try {
         for await (const rawLine of lineReader) {

--- a/engines/surrealdb/backup.ts
+++ b/engines/surrealdb/backup.ts
@@ -11,7 +11,10 @@ import { readFile, rename, rm, stat, mkdir, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { dirname } from 'path'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import {
   addSurrealAuthArgs,
   getBootstrapSurrealAuth,
@@ -19,7 +22,12 @@ import {
   sanitizeSurrealAuthArgs,
 } from './auth'
 import { requireSurrealPath } from './cli-utils'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 function shouldStripSurrealStatement(statement: string): boolean {
   const normalized = statement.trim().replace(/\s+/g, ' ').toUpperCase()

--- a/engines/surrealdb/index.ts
+++ b/engines/surrealdb/index.ts
@@ -22,7 +22,10 @@ import { paths } from '../../config/paths'
 import { getEngineDefaults } from '../../config/defaults'
 import { platformService } from '../../core/platform-service'
 import { configManager } from '../../core/config-manager'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import {
   logDebug,
   logWarning,
@@ -199,9 +202,7 @@ export class SurrealDBEngine extends BaseEngine {
     )
   }
 
-  private async getLocalAuth(
-    containerName: string,
-  ): Promise<LocalSurrealAuth> {
+  private async getLocalAuth(containerName: string): Promise<LocalSurrealAuth> {
     const savedCreds = await loadCredentials(
       containerName,
       Engine.SurrealDB,
@@ -237,7 +238,11 @@ export class SurrealDBEngine extends BaseEngine {
     logDebug(
       `Loading credentials for ${name} engine=${Engine.SurrealDB} username=${defaultUser}`,
     )
-    const savedCreds = await loadCredentials(name, Engine.SurrealDB, defaultUser)
+    const savedCreds = await loadCredentials(
+      name,
+      Engine.SurrealDB,
+      defaultUser,
+    )
     logDebug(
       `loadCredentials result: ${savedCreds ? `user=${savedCreds.username}` : 'null (using root/root fallback)'}`,
     )

--- a/engines/surrealdb/restore.ts
+++ b/engines/surrealdb/restore.ts
@@ -7,7 +7,10 @@ import { spawn } from 'child_process'
 import { open } from 'fs/promises'
 import { existsSync, statSync } from 'fs'
 import { logDebug } from '../../core/error-handler'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import {
   addSurrealAuthArgs,
   getBootstrapSurrealAuth,

--- a/engines/typedb/backup.ts
+++ b/engines/typedb/backup.ts
@@ -9,10 +9,18 @@ import { spawn } from 'child_process'
 import { mkdir } from 'fs/promises'
 import { stat } from 'fs/promises'
 import { dirname } from 'path'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { requireTypeDBConsolePath, getConsoleBaseArgs } from './cli-utils'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 /**
  * Create a TypeQL backup using typedb console export

--- a/engines/typedb/restore.ts
+++ b/engines/typedb/restore.ts
@@ -6,7 +6,10 @@
 import { spawn } from 'child_process'
 import { open } from 'fs/promises'
 import { existsSync, statSync } from 'fs'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import {
   requireTypeDBConsolePath,

--- a/engines/valkey/backup.ts
+++ b/engines/valkey/backup.ts
@@ -28,9 +28,7 @@ type ValkeyCliAuth = {
   password?: string
 }
 
-function shouldPassValkeyCliUsername(
-  username?: string,
-): username is string {
+function shouldPassValkeyCliUsername(username?: string): username is string {
   if (!username) {
     return false
   }

--- a/engines/valkey/index.ts
+++ b/engines/valkey/index.ts
@@ -59,9 +59,7 @@ type ValkeyCliAuth = {
   password?: string
 }
 
-function shouldPassValkeyCliUsername(
-  username?: string,
-): username is string {
+function shouldPassValkeyCliUsername(username?: string): username is string {
   if (!username) {
     return false
   }
@@ -807,10 +805,7 @@ export class ValkeyEngine extends BaseEngine {
             }
 
             // Check for library loading errors first
-            const libError = detectLibraryError(
-              logContent,
-              'Valkey',
-            )
+            const libError = detectLibraryError(logContent, 'Valkey')
             if (libError) {
               reject(new Error(libError))
               return

--- a/engines/valkey/restore.ts
+++ b/engines/valkey/restore.ts
@@ -23,9 +23,7 @@ type ValkeyCliAuth = {
   password?: string
 }
 
-function shouldPassValkeyCliUsername(
-  username?: string,
-): username is string {
+function shouldPassValkeyCliUsername(username?: string): username is string {
   if (!username) {
     return false
   }

--- a/engines/weaviate/backup.ts
+++ b/engines/weaviate/backup.ts
@@ -10,11 +10,19 @@
 import { mkdir, stat, cp, readdir } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
-import { getDefaultUsername, loadCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  loadCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { paths } from '../../config/paths'
 import { weaviateApiRequest } from './api-client'
-import { Engine, type ContainerConfig, type BackupOptions, type BackupResult } from '../../types'
+import {
+  Engine,
+  type ContainerConfig,
+  type BackupOptions,
+  type BackupResult,
+} from '../../types'
 
 /**
  * Create a snapshot backup using Weaviate's REST API.

--- a/scripts/flip-hostdb-pin.mjs
+++ b/scripts/flip-hostdb-pin.mjs
@@ -67,13 +67,19 @@ if (!targetVersion) {
 }
 
 if (!/^\d+\.\d+\.\d+$/.test(targetVersion)) {
-  console.error(`Target version must be exact semver (e.g., 0.31.0). Got: ${targetVersion}`)
+  console.error(
+    `Target version must be exact semver (e.g., 0.31.0). Got: ${targetVersion}`,
+  )
   process.exit(2)
 }
 
 console.log(`\nVerifying hostdb@${targetVersion} exists on npm...`)
 try {
-  const published = execCapture('npm', ['view', `hostdb@${targetVersion}`, 'version'])
+  const published = execCapture('npm', [
+    'view',
+    `hostdb@${targetVersion}`,
+    'version',
+  ])
   if (published !== targetVersion) {
     throw new Error(`npm returned ${published}, not ${targetVersion}`)
   }
@@ -82,15 +88,17 @@ try {
   console.error(
     `\n✗ hostdb@${targetVersion} is NOT on npm yet. The publish workflow needs to complete first.`,
   )
+  console.error(`  Check: gh workflow view publish.yml (in ~/dev/hostdb)`)
   console.error(
-    `  Check: gh workflow view publish.yml (in ~/dev/hostdb)`,
+    `  Or:    npm view hostdb version  (should return ${targetVersion})`,
   )
-  console.error(`  Or:    npm view hostdb version  (should return ${targetVersion})`)
   console.error(`\nUnderlying error: ${err.message}`)
   process.exit(3)
 }
 
-console.log(`\nUpdating package.json: hostdb -> ${targetVersion} (exact pin)...`)
+console.log(
+  `\nUpdating package.json: hostdb -> ${targetVersion} (exact pin)...`,
+)
 const pkgPath = join(ROOT, 'package.json')
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
 const previous = pkg.dependencies.hostdb
@@ -119,4 +127,6 @@ console.log(
   `  git add package.json pnpm-lock.yaml && git commit -m "chore(deps): pin hostdb ${targetVersion}"`,
 )
 console.log(`  git push`)
-console.log(`\nNow safe to merge upgrade/spindb-hostdb-integration -> dev -> main.`)
+console.log(
+  `\nNow safe to merge upgrade/spindb-hostdb-integration -> dev -> main.`,
+)

--- a/tests/integration/cli-e2e.test.ts
+++ b/tests/integration/cli-e2e.test.ts
@@ -283,11 +283,17 @@ describe('CLI PostgreSQL Workflow', () => {
     )
     assert(qExit === 0, `Branch query should succeed. stdout: ${q}`)
     const parsed = JSON.parse(q.trim())
-    assertEqual(Number(parsed.rows[0].n), 2, 'Branch should contain seeded rows')
+    assertEqual(
+      Number(parsed.rows[0].n),
+      2,
+      'Branch should contain seeded rows',
+    )
 
     // Clean up the branch so later source assertions are unaffected
     await runCLI(`branch delete ${branchName} --force`)
-    console.log('   Branched running container; data copied and source stayed up')
+    console.log(
+      '   Branched running container; data copied and source stayed up',
+    )
   })
 
   it('should stop container via CLI', async () => {
@@ -467,7 +473,11 @@ describe('CLI Branch Workflow (SQLite)', () => {
     assert(exitCode === 0, `Branch should succeed. stderr: ${stderr}`)
     const result = JSON.parse(stdout.trim())
     assertEqual(result.success, true, 'Branch should report success')
-    assertEqual(result.branchParent, source, 'branchParent should be the source')
+    assertEqual(
+      result.branchParent,
+      source,
+      'branchParent should be the source',
+    )
     assert(
       result.method === 'reflink' || result.method === 'copy',
       'Branch should report a copy method',
@@ -1063,7 +1073,11 @@ describe('CLI Git Branching (PostgreSQL)', () => {
       'feature branch should be running',
     )
     const featureConfig = await containerManager.getConfig(result.container)
-    assertEqual(featureConfig?.port, testPort, 'feature runs on the stable port')
+    assertEqual(
+      featureConfig?.port,
+      testPort,
+      'feature runs on the stable port',
+    )
     assert(
       !(await processManager.isRunning(base, { engine: Engine.PostgreSQL })),
       'base should be stopped while the feature branch is active',

--- a/tests/integration/clickhouse.test.ts
+++ b/tests/integration/clickhouse.test.ts
@@ -39,7 +39,10 @@ import {
   executeQuery,
 } from './helpers'
 import { assert, assertEqual, assertDeepEqual } from '../utils/assertions'
-import { getDefaultUsername, saveCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  saveCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { containerManager } from '../../core/container-manager'
 import { processManager } from '../../core/process-manager'
@@ -623,18 +626,18 @@ describe(
         if (sourceConfig) {
           await engine.stop(sourceConfig).catch(() => {})
           await waitForStopped(sourceName, ENGINE, 90000).catch(() => false)
-          await containerManager.delete(sourceName, { force: true }).catch(
-            () => {},
-          )
+          await containerManager
+            .delete(sourceName, { force: true })
+            .catch(() => {})
         }
 
         const targetConfig = await containerManager.getConfig(targetName)
         if (targetConfig) {
           await engine.stop(targetConfig).catch(() => {})
           await waitForStopped(targetName, ENGINE, 90000).catch(() => false)
-          await containerManager.delete(targetName, { force: true }).catch(
-            () => {},
-          )
+          await containerManager
+            .delete(targetName, { force: true })
+            .catch(() => {})
         }
       }
     })

--- a/tests/integration/cockroachdb.test.ts
+++ b/tests/integration/cockroachdb.test.ts
@@ -250,7 +250,9 @@ describe('CockroachDB Integration Tests', () => {
   })
 
   it('clean restore (--into-existing semantics) REPLACES contents into the live DB without dropping it', async () => {
-    console.log(`\n Testing clean restore replaces (not merges) into live DB...`)
+    console.log(
+      `\n Testing clean restore replaces (not merges) into live DB...`,
+    )
 
     const config = await containerManager.getConfig(containerName)
     assert(config !== null, 'Source container config should exist')
@@ -258,7 +260,12 @@ describe('CockroachDB Integration Tests', () => {
     const engine = getEngine(ENGINE)
 
     // 1. Capture current row count of the live, running source DB
-    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+    const before = await getRowCount(
+      ENGINE,
+      testPorts[0],
+      DATABASE,
+      'test_user',
+    )
 
     // 2. Back up the current state (this snapshot does NOT contain the extra row)
     const { tmpdir } = await import('os')

--- a/tests/integration/couchdb.test.ts
+++ b/tests/integration/couchdb.test.ts
@@ -392,10 +392,7 @@ describe('CouchDB Integration Tests', () => {
     ]
     const { tmpdir } = await import('os')
     const { mkdir, rm, writeFile } = await import('fs/promises')
-    const backupPath = join(
-      tmpdir(),
-      `couchdb-auth-backup-${Date.now()}.json`,
-    )
+    const backupPath = join(tmpdir(), `couchdb-auth-backup-${Date.now()}.json`)
     const engine = getEngine(ENGINE)
 
     const writeDefaultCredentialFile = async (
@@ -449,7 +446,10 @@ describe('CouchDB Integration Tests', () => {
       assert(restartedConfig !== null, 'Restarted config should exist')
       await engine.start(restartedConfig!)
       await containerManager.updateConfig(containerName, { status: 'running' })
-      assert(await waitForReady(ENGINE, port), 'Auth-enabled container should be ready')
+      assert(
+        await waitForReady(ENGINE, port),
+        'Auth-enabled container should be ready',
+      )
     }
 
     try {

--- a/tests/integration/ferretdb.test.ts
+++ b/tests/integration/ferretdb.test.ts
@@ -300,7 +300,12 @@ describe('FerretDB Integration Tests', () => {
     )
 
     // 1. Capture current document count of the seeded collection
-    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+    const before = await getRowCount(
+      ENGINE,
+      testPorts[0],
+      DATABASE,
+      'test_user',
+    )
     assertEqual(
       before,
       EXPECTED_ROW_COUNT,

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -314,7 +314,10 @@ export async function executeSQL(
         `Could not find CockroachDB container config for port ${port}`,
       )
     }
-    const certsDir = join(paths.getContainerPath(config.name, { engine }), 'certs')
+    const certsDir = join(
+      paths.getContainerPath(config.name, { engine }),
+      'certs',
+    )
     const cmd = `"${cockroachPath}" sql --certs-dir "${certsDir}" --user root --host 127.0.0.1:${port} --database ${database} --execute "${sql.replace(/"/g, '\\"')}"`
     return execAsync(cmd)
   } else if (engine === Engine.SurrealDB) {
@@ -378,9 +381,8 @@ export async function executeSQL(
     const consolePath = await engineImpl.getTypeDBConsolePath(
       TEST_VERSIONS.typedb,
     )
-    const { getConsoleBaseArgs } = await import(
-      '../../engines/typedb/cli-utils'
-    )
+    const { getConsoleBaseArgs } =
+      await import('../../engines/typedb/cli-utils')
     const { spawn } = await import('child_process')
     const { writeFile, unlink } = await import('fs/promises')
     const { tmpdir } = await import('os')
@@ -519,7 +521,10 @@ export async function executeSQLFile(
         `Could not find CockroachDB container config for port ${port}`,
       )
     }
-    const certsDir = join(paths.getContainerPath(config.name, { engine }), 'certs')
+    const certsDir = join(
+      paths.getContainerPath(config.name, { engine }),
+      'certs',
+    )
     // CockroachDB uses --file flag for SQL files
     const cmd = `"${cockroachPath}" sql --certs-dir "${certsDir}" --user root --host 127.0.0.1:${port} --database ${database} --file "${filePath}"`
     return execAsync(cmd)
@@ -550,9 +555,8 @@ export async function executeSQLFile(
     const consolePath = await engineImpl.getTypeDBConsolePath(
       TEST_VERSIONS.typedb,
     )
-    const { getConsoleBaseArgs } = await import(
-      '../../engines/typedb/cli-utils'
-    )
+    const { getConsoleBaseArgs } =
+      await import('../../engines/typedb/cli-utils')
     const args = [...getConsoleBaseArgs(port), '--script', filePath]
     const cmd = `"${consolePath}" ${args.map((a) => `"${a}"`).join(' ')}`
     return execAsync(cmd)
@@ -605,7 +609,9 @@ export async function getRowCount(
 
     const rawCount = result.rows[0]?.count
     const count =
-      typeof rawCount === 'number' ? rawCount : Number.parseInt(String(rawCount), 10)
+      typeof rawCount === 'number'
+        ? rawCount
+        : Number.parseInt(String(rawCount), 10)
 
     if (!Number.isNaN(count)) {
       return count
@@ -875,18 +881,13 @@ export async function waitForReady(
           const upData = (await upResponse.json()) as { status?: string }
           if (upData?.status !== 'ok') {
             clearTimeout(timeoutId)
-            throw new Error(
-              `CouchDB /_up status=${upData?.status}, not ready`,
-            )
+            throw new Error(`CouchDB /_up status=${upData?.status}, not ready`)
           }
           const probeResponse = await fetch(
             `http://127.0.0.1:${port}/_spindb_test_probe`,
             { signal: controller.signal },
           )
-          if (
-            probeResponse.status !== 404 &&
-            probeResponse.status !== 401
-          ) {
+          if (probeResponse.status !== 404 && probeResponse.status !== 401) {
             clearTimeout(timeoutId)
             throw new Error(
               `CouchDB DB-lookup probe returned ${probeResponse.status}, cluster not ready`,
@@ -1605,7 +1606,9 @@ export async function createCouchDBDatabase(
     const err = error as Error & { cause?: { code?: string; message?: string } }
     console.error(
       `createCouchDBDatabase PUT ${url} threw ${err.name}: ${err.message}` +
-        (err.cause ? ` (cause.code=${err.cause.code} cause.message=${err.cause.message})` : ''),
+        (err.cause
+          ? ` (cause.code=${err.cause.code} cause.message=${err.cause.message})`
+          : ''),
     )
     return false
   }

--- a/tests/integration/libsql.test.ts
+++ b/tests/integration/libsql.test.ts
@@ -441,7 +441,10 @@ describe('libSQL Integration Tests', () => {
   it('should backup and restore with JWT auth enabled on both source and target', async () => {
     console.log('\n Testing auth-backed libSQL backup/restore...')
 
-    const allPorts = await findConsecutiveFreePorts(4, TEST_PORTS.libsql.base + 20)
+    const allPorts = await findConsecutiveFreePorts(
+      4,
+      TEST_PORTS.libsql.base + 20,
+    )
     const [sourcePort, targetPort] = [allPorts[0], allPorts[2]]
     const sourceName = generateTestName('libsql-auth-source')
     const targetName = generateTestName('libsql-auth-target')
@@ -484,7 +487,10 @@ describe('libSQL Integration Tests', () => {
       assertTruthy(sourceCreds.apiKey, 'Source JWT token should exist')
 
       const sourceAuthedReady = await waitForReady(ENGINE, sourcePort)
-      assert(sourceAuthedReady, 'Source libSQL should be ready after auth restart')
+      assert(
+        sourceAuthedReady,
+        'Source libSQL should be ready after auth restart',
+      )
 
       await containerManager.create(targetName, {
         engine: ENGINE,
@@ -509,7 +515,10 @@ describe('libSQL Integration Tests', () => {
       assertTruthy(targetCreds.apiKey, 'Target JWT token should exist')
 
       const targetAuthedReady = await waitForReady(ENGINE, targetPort)
-      assert(targetAuthedReady, 'Target libSQL should be ready after auth restart')
+      assert(
+        targetAuthedReady,
+        'Target libSQL should be ready after auth restart',
+      )
 
       await engine.backup(sourceConfig!, backupPath, {
         database: DATABASE,
@@ -526,7 +535,11 @@ describe('libSQL Integration Tests', () => {
       )
       assertEqual(restored.rowCount, 1, 'Should return a single count row')
       const row = restored.rows[0] as Record<string, unknown>
-      assertEqual(Number(row.count), 3, 'Restored auth-backed libSQL data should match source')
+      assertEqual(
+        Number(row.count),
+        3,
+        'Restored auth-backed libSQL data should match source',
+      )
 
       console.log('   JWT-authenticated libSQL backup/restore succeeded')
     } finally {
@@ -536,18 +549,18 @@ describe('libSQL Integration Tests', () => {
       if (sourceConfig) {
         await engine.stop(sourceConfig).catch(() => {})
         await waitForStopped(sourceName, ENGINE, 60000).catch(() => false)
-        await containerManager.delete(sourceName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(sourceName, { force: true })
+          .catch(() => {})
       }
 
       const targetConfig = await containerManager.getConfig(targetName)
       if (targetConfig) {
         await engine.stop(targetConfig).catch(() => {})
         await waitForStopped(targetName, ENGINE, 60000).catch(() => false)
-        await containerManager.delete(targetName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(targetName, { force: true })
+          .catch(() => {})
       }
     }
   })

--- a/tests/integration/mariadb.test.ts
+++ b/tests/integration/mariadb.test.ts
@@ -848,7 +848,10 @@ describe('MariaDB Integration Tests', () => {
       )
     }
 
-    const waitForAuthedReady = async (containerName: string, timeoutMs = 30000) => {
+    const waitForAuthedReady = async (
+      containerName: string,
+      timeoutMs = 30000,
+    ) => {
       const start = Date.now()
       let lastError: string | null = null
 
@@ -856,11 +859,9 @@ describe('MariaDB Integration Tests', () => {
         try {
           const config = await containerManager.getConfig(containerName)
           if (config) {
-            const result = await engine.executeQuery(
-              config,
-              'SELECT 1 AS ok',
-              { database: DATABASE },
-            )
+            const result = await engine.executeQuery(config, 'SELECT 1 AS ok', {
+              database: DATABASE,
+            })
             if (result.rowCount === 1) {
               return { ready: true, lastError: null }
             }
@@ -896,7 +897,10 @@ describe('MariaDB Integration Tests', () => {
       await writeDefaultCredentialFile(containerName, port, password)
 
       const config = await containerManager.getConfig(containerName)
-      assert(config !== null, 'Container config should exist before auth restart')
+      assert(
+        config !== null,
+        'Container config should exist before auth restart',
+      )
       await engine.stop(config!)
       await containerManager.updateConfig(containerName, { status: 'stopped' })
       const stopped = await waitForStopped(containerName, ENGINE)

--- a/tests/integration/meilisearch.test.ts
+++ b/tests/integration/meilisearch.test.ts
@@ -367,9 +367,9 @@ describe('Meilisearch Integration Tests', () => {
           if (config) {
             await engine.stop(config).catch(() => {})
             await waitForStopped(cleanupName, ENGINE).catch(() => false)
-            await containerManager.delete(cleanupName, { force: true }).catch(
-              () => {},
-            )
+            await containerManager
+              .delete(cleanupName, { force: true })
+              .catch(() => {})
           }
         }
         await rm(backupPath, { force: true })

--- a/tests/integration/mongo-ferret-interop.test.ts
+++ b/tests/integration/mongo-ferret-interop.test.ts
@@ -75,7 +75,10 @@ describe('MongoDB <-> FerretDB backup/restore interoperability', () => {
     await cleanupTestContainers()
     // Separate port blocks so the two engines (ferret reserves aux ports for its
     // backend) never collide.
-    const mongoPorts = await findConsecutiveFreePorts(3, TEST_PORTS.mongodb.base)
+    const mongoPorts = await findConsecutiveFreePorts(
+      3,
+      TEST_PORTS.mongodb.base,
+    )
     const ferretPorts = await findConsecutiveFreePorts(
       3,
       TEST_PORTS.ferretdb.base,

--- a/tests/integration/mongodb.test.ts
+++ b/tests/integration/mongodb.test.ts
@@ -395,7 +395,12 @@ describe('MongoDB Integration Tests', () => {
     assert(config !== null, 'Container config should exist')
 
     // 1. Capture the current document count of the seeded collection
-    const before = await getRowCount(ENGINE, testPorts[0], DATABASE, 'test_user')
+    const before = await getRowCount(
+      ENGINE,
+      testPorts[0],
+      DATABASE,
+      'test_user',
+    )
 
     // 2. Back up the live database (archive format, same as the backup tests above)
     const { tmpdir } = await import('os')
@@ -767,7 +772,10 @@ describe('MongoDB Integration Tests', () => {
     const targetPassword = 'targetpass456'
     const { tmpdir } = await import('os')
     const { mkdir, rm, writeFile } = await import('fs/promises')
-    const backupPath = join(tmpdir(), `mongodb-auth-backup-${Date.now()}.archive`)
+    const backupPath = join(
+      tmpdir(),
+      `mongodb-auth-backup-${Date.now()}.archive`,
+    )
     const engine = getEngine(ENGINE)
 
     const writeDefaultCredentialFile = async (
@@ -961,7 +969,9 @@ describe('MongoDB Integration Tests', () => {
       }
     }
 
-    console.log('   ✓ Backup and restore work with password-authenticated MongoDB')
+    console.log(
+      '   ✓ Backup and restore work with password-authenticated MongoDB',
+    )
   })
 
   it('should have no test containers remaining', async () => {

--- a/tests/integration/mysql.test.ts
+++ b/tests/integration/mysql.test.ts
@@ -814,7 +814,9 @@ describe('MySQL Integration Tests', () => {
   })
 
   it('should backup and restore with password-authenticated local root credentials', async () => {
-    console.log(`\n🔐 Testing auth-aware MySQL backup/restore on local containers...`)
+    console.log(
+      `\n🔐 Testing auth-aware MySQL backup/restore on local containers...`,
+    )
 
     const [sourcePort, targetPort] = await findConsecutiveFreePorts(
       2,
@@ -855,7 +857,10 @@ describe('MySQL Integration Tests', () => {
       )
     }
 
-    const waitForAuthedReady = async (containerName: string, timeoutMs = 30000) => {
+    const waitForAuthedReady = async (
+      containerName: string,
+      timeoutMs = 30000,
+    ) => {
       const start = Date.now()
       let lastError: string | null = null
 
@@ -863,11 +868,9 @@ describe('MySQL Integration Tests', () => {
         try {
           const config = await containerManager.getConfig(containerName)
           if (config) {
-            const result = await engine.executeQuery(
-              config,
-              'SELECT 1 AS ok',
-              { database: DATABASE },
-            )
+            const result = await engine.executeQuery(config, 'SELECT 1 AS ok', {
+              database: DATABASE,
+            })
             if (result.rowCount === 1) {
               return { ready: true, lastError: null }
             }
@@ -904,7 +907,10 @@ describe('MySQL Integration Tests', () => {
       await writeDefaultCredentialFile(containerName, port, password)
 
       const config = await containerManager.getConfig(containerName)
-      assert(config !== null, 'Container config should exist before auth restart')
+      assert(
+        config !== null,
+        'Container config should exist before auth restart',
+      )
       await engine.stop(config!)
       await containerManager.updateConfig(containerName, { status: 'stopped' })
       const stopped = await waitForStopped(containerName, ENGINE)
@@ -934,7 +940,10 @@ describe('MySQL Integration Tests', () => {
       assert(sourceConfig !== null, 'Source config should exist')
       await engine.start(sourceConfig!)
       await containerManager.updateConfig(sourceName, { status: 'running' })
-      assert(await waitForReady(ENGINE, sourcePort), 'Source MySQL should be ready')
+      assert(
+        await waitForReady(ENGINE, sourcePort),
+        'Source MySQL should be ready',
+      )
       await engine.createDatabase(sourceConfig!, DATABASE)
       await runScriptFile(sourceName, SEED_FILE, DATABASE)
 
@@ -952,7 +961,10 @@ describe('MySQL Integration Tests', () => {
       assert(targetConfig !== null, 'Target config should exist')
       await engine.start(targetConfig!)
       await containerManager.updateConfig(targetName, { status: 'running' })
-      assert(await waitForReady(ENGINE, targetPort), 'Target MySQL should be ready')
+      assert(
+        await waitForReady(ENGINE, targetPort),
+        'Target MySQL should be ready',
+      )
       await engine.createDatabase(targetConfig!, DATABASE)
 
       await enableRootPasswordAuth(targetName, targetPort, targetPassword)

--- a/tests/integration/postgresql.test.ts
+++ b/tests/integration/postgresql.test.ts
@@ -1041,11 +1041,19 @@ describe('PostgreSQL Integration Tests', () => {
       await engine.createDatabase(targetConfig!, DATABASE)
       await enablePasswordAuth(targetName, targetPort, targetPassword)
 
-      const backupResult = await engine.backup(sourceAuthedConfig!, backupPath, {
-        database: DATABASE,
-        format: 'custom',
-      })
-      assertEqual(backupResult.format, 'custom', 'Backup should use custom format')
+      const backupResult = await engine.backup(
+        sourceAuthedConfig!,
+        backupPath,
+        {
+          database: DATABASE,
+          format: 'custom',
+        },
+      )
+      assertEqual(
+        backupResult.format,
+        'custom',
+        'Backup should use custom format',
+      )
 
       const targetAuthedConfig = await containerManager.getConfig(targetName)
       assert(targetAuthedConfig !== null, 'Target auth config should exist')
@@ -1074,9 +1082,11 @@ describe('PostgreSQL Integration Tests', () => {
       for (const containerName of [sourceName, targetName]) {
         const config = await containerManager.getConfig(containerName)
         if (config) {
-          const running = await processManager.isRunning(containerName, {
-            engine: ENGINE,
-          }).catch(() => false)
+          const running = await processManager
+            .isRunning(containerName, {
+              engine: ENGINE,
+            })
+            .catch(() => false)
           if (running) {
             await engine.stop(config).catch(() => {})
             await containerManager
@@ -1084,11 +1094,15 @@ describe('PostgreSQL Integration Tests', () => {
               .catch(() => {})
           }
         }
-        await containerManager.delete(containerName, { force: true }).catch(() => {})
+        await containerManager
+          .delete(containerName, { force: true })
+          .catch(() => {})
       }
     }
 
-    console.log('   ✓ Backup and restore work with password-authenticated PostgreSQL')
+    console.log(
+      '   ✓ Backup and restore work with password-authenticated PostgreSQL',
+    )
   })
 
   it('should have no test containers remaining', async () => {

--- a/tests/integration/qdrant.test.ts
+++ b/tests/integration/qdrant.test.ts
@@ -26,7 +26,10 @@ import {
   executeQuery,
 } from './helpers'
 import { assert, assertEqual, assertTruthy } from '../utils/assertions'
-import { getDefaultUsername, saveCredentials } from '../../core/credential-manager'
+import {
+  getDefaultUsername,
+  saveCredentials,
+} from '../../core/credential-manager'
 import { logDebug } from '../../core/error-handler'
 import { branchManager } from '../../core/branch-manager'
 import { containerManager } from '../../core/container-manager'
@@ -335,7 +338,10 @@ describe('Qdrant Integration Tests', () => {
 
     console.log(`\n🔐 Testing auth-aware Qdrant backup/restore...`)
 
-    const allPorts = await findConsecutiveFreePorts(4, TEST_PORTS.qdrant.base + 20)
+    const allPorts = await findConsecutiveFreePorts(
+      4,
+      TEST_PORTS.qdrant.base + 20,
+    )
     const [sourcePort, targetPort] = [allPorts[0], allPorts[2]]
     const sourceName = generateTestName('qdrant-auth-test-source')
     const targetName = generateTestName('qdrant-auth-test-target')
@@ -470,18 +476,18 @@ describe('Qdrant Integration Tests', () => {
       if (sourceConfig) {
         await engine.stop(sourceConfig).catch(() => {})
         await waitForStopped(sourceName, ENGINE, 90000).catch(() => false)
-        await containerManager.delete(sourceName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(sourceName, { force: true })
+          .catch(() => {})
       }
 
       const targetConfig = await containerManager.getConfig(targetName)
       if (targetConfig) {
         await engine.stop(targetConfig).catch(() => {})
         await waitForStopped(targetName, ENGINE, 90000).catch(() => false)
-        await containerManager.delete(targetName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(targetName, { force: true })
+          .catch(() => {})
       }
     }
   })
@@ -570,7 +576,10 @@ describe('Qdrant Integration Tests', () => {
         await waitForReady(ENGINE, branchPort),
         'Branched Qdrant should be ready on its own port',
       )
-      const branchPoints = await getQdrantPointCount(branchPort, TEST_COLLECTION)
+      const branchPoints = await getQdrantPointCount(
+        branchPort,
+        TEST_COLLECTION,
+      )
       assertEqual(
         branchPoints,
         3,

--- a/tests/integration/questdb.test.ts
+++ b/tests/integration/questdb.test.ts
@@ -355,7 +355,10 @@ describe('QuestDB Integration Tests', () => {
   it('should prefer saved admin credentials over legacy generic credentials', async () => {
     console.log('\n Testing saved QuestDB auth-backed backup/restore...')
 
-    const allPorts = await findConsecutiveFreePorts(4, TEST_PORTS.questdb.base + 20)
+    const allPorts = await findConsecutiveFreePorts(
+      4,
+      TEST_PORTS.questdb.base + 20,
+    )
     const targetPort = allPorts[2]
     const targetName = generateTestName('questdb-auth-target')
     const { tmpdir } = await import('os')
@@ -459,9 +462,9 @@ describe('QuestDB Integration Tests', () => {
       if (targetConfig) {
         await engine.stop(targetConfig).catch(() => {})
         await waitForStopped(targetName, ENGINE, 90000).catch(() => false)
-        await containerManager.delete(targetName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(targetName, { force: true })
+          .catch(() => {})
       }
     }
   })

--- a/tests/integration/redis-version-smoke.test.ts
+++ b/tests/integration/redis-version-smoke.test.ts
@@ -88,11 +88,9 @@ describe('Redis version coverage smoke', () => {
         )
         assertEqual(setResult.rows[0]?.result, 'OK', 'SET should return OK')
 
-        const getResult = await engine.executeQuery(
-          config!,
-          'GET smoke:key',
-          { database: DATABASE },
-        )
+        const getResult = await engine.executeQuery(config!, 'GET smoke:key', {
+          database: DATABASE,
+        })
         assertEqual(
           getResult.rows[0]?.result,
           'smoke_value_works',

--- a/tests/integration/redis.test.ts
+++ b/tests/integration/redis.test.ts
@@ -886,10 +886,14 @@ describe('Redis Integration Tests', () => {
       assert(await waitForReady(ENGINE, targetPort), 'Target should be ready')
       await enableRequirePass(targetName, targetPort, targetPassword)
 
-      const backupResult = await engine.backup(sourceAuthedConfig!, backupPath, {
-        database: DATABASE,
-        format: 'text',
-      })
+      const backupResult = await engine.backup(
+        sourceAuthedConfig!,
+        backupPath,
+        {
+          database: DATABASE,
+          format: 'text',
+        },
+      )
       assertEqual(backupResult.format, 'text', 'Backup should use text format')
 
       const targetAuthedConfig = await containerManager.getConfig(targetName)
@@ -919,9 +923,11 @@ describe('Redis Integration Tests', () => {
       for (const containerName of [sourceName, targetName]) {
         const config = await containerManager.getConfig(containerName)
         if (config) {
-          const running = await processManager.isRunning(containerName, {
-            engine: ENGINE,
-          }).catch(() => false)
+          const running = await processManager
+            .isRunning(containerName, {
+              engine: ENGINE,
+            })
+            .catch(() => false)
           if (running) {
             await engine.stop(config).catch(() => {})
             await containerManager
@@ -929,11 +935,15 @@ describe('Redis Integration Tests', () => {
               .catch(() => {})
           }
         }
-        await containerManager.delete(containerName, { force: true }).catch(() => {})
+        await containerManager
+          .delete(containerName, { force: true })
+          .catch(() => {})
       }
     }
 
-    console.log('   ✓ Backup and restore work with password-authenticated Redis')
+    console.log(
+      '   ✓ Backup and restore work with password-authenticated Redis',
+    )
   })
 
   it('should have no test containers remaining', async () => {

--- a/tests/integration/sqlite.test.ts
+++ b/tests/integration/sqlite.test.ts
@@ -271,7 +271,9 @@ describe('SQLite Integration Tests', () => {
       'Explicit-path parent directory should be preserved after deleting the branch',
     )
 
-    console.log(`   ✓ Branched to ${branchPath} — lineage + data + cleanup verified`)
+    console.log(
+      `   ✓ Branched to ${branchPath} — lineage + data + cleanup verified`,
+    )
   })
 
   it('should backup database (SQL format)', async () => {

--- a/tests/integration/surrealdb.test.ts
+++ b/tests/integration/surrealdb.test.ts
@@ -780,11 +780,7 @@ describe('SurrealDB Integration Tests', () => {
         'Source should be ready',
       )
       await runScriptFile(sourceName, SEED_FILE, DATABASE)
-      await createSavedRootScopedUser(
-        sourceConfig!,
-        sourceName,
-        sourcePort,
-      )
+      await createSavedRootScopedUser(sourceConfig!, sourceName, sourcePort)
 
       sourceConfig = await containerManager.getConfig(sourceName)
       assert(sourceConfig !== null, 'Source auth config should exist')
@@ -816,11 +812,7 @@ describe('SurrealDB Integration Tests', () => {
         await waitForReady(ENGINE, targetPort, 60000),
         'Target should be ready',
       )
-      await createSavedRootScopedUser(
-        targetConfig!,
-        targetName,
-        targetPort,
-      )
+      await createSavedRootScopedUser(targetConfig!, targetName, targetPort)
 
       const backupResult = await engine.backup(sourceConfig!, backupPath, {
         database: DATABASE,

--- a/tests/integration/typedb.test.ts
+++ b/tests/integration/typedb.test.ts
@@ -413,7 +413,10 @@ describe('TypeDB Integration Tests', () => {
   it('should backup and restore with saved TypeDB credentials', async () => {
     console.log('\n Testing auth-backed TypeDB backup/restore...')
 
-    const allPorts = await findConsecutiveFreePorts(4, TEST_PORTS.typedb.base + 20)
+    const allPorts = await findConsecutiveFreePorts(
+      4,
+      TEST_PORTS.typedb.base + 20,
+    )
     const targetPort = allPorts[2]
     const targetName = generateTestName('typedb-auth-test-target')
     const username = getDefaultUsername(ENGINE)
@@ -481,9 +484,16 @@ describe('TypeDB Integration Tests', () => {
         },
       )
 
-      assertEqual(restored.rowCount, 1, 'TypeDB executeQuery should return raw output')
+      assertEqual(
+        restored.rowCount,
+        1,
+        'TypeDB executeQuery should return raw output',
+      )
       const output = restored.rows[0].result as string
-      assert(output.includes('Alice'), 'Restored TypeDB data should include Alice')
+      assert(
+        output.includes('Alice'),
+        'Restored TypeDB data should include Alice',
+      )
       assert(output.includes('Bob'), 'Restored TypeDB data should include Bob')
 
       console.log('   Saved-credential TypeDB backup/restore succeeded')
@@ -498,9 +508,9 @@ describe('TypeDB Integration Tests', () => {
       if (targetConfig) {
         await engine.stop(targetConfig).catch(() => {})
         await waitForStopped(targetName, ENGINE, 90000).catch(() => false)
-        await containerManager.delete(targetName, { force: true }).catch(
-          () => {},
-        )
+        await containerManager
+          .delete(targetName, { force: true })
+          .catch(() => {})
       }
     }
   })

--- a/tests/integration/valkey.test.ts
+++ b/tests/integration/valkey.test.ts
@@ -694,9 +694,8 @@ describe('Valkey Integration Tests', () => {
     const sourcePassword = 'sourcepass123'
     const targetPassword = 'targetpass456'
     const { tmpdir } = await import('os')
-    const { appendFile, mkdir, readFile, rm, writeFile } = await import(
-      'fs/promises'
-    )
+    const { appendFile, mkdir, readFile, rm, writeFile } =
+      await import('fs/promises')
     const backupPath = join(tmpdir(), `valkey-auth-backup-${Date.now()}.valkey`)
     const engine = getEngine(ENGINE)
 
@@ -841,10 +840,14 @@ describe('Valkey Integration Tests', () => {
       assert(await waitForReady(ENGINE, targetPort), 'Target should be ready')
       await enableRequirePass(targetName, targetPort, targetPassword)
 
-      const backupResult = await engine.backup(sourceAuthedConfig!, backupPath, {
-        database: DATABASE,
-        format: 'text',
-      })
+      const backupResult = await engine.backup(
+        sourceAuthedConfig!,
+        backupPath,
+        {
+          database: DATABASE,
+          format: 'text',
+        },
+      )
       assertEqual(backupResult.format, 'text', 'Backup should use text format')
       const backupContent = await readFile(backupPath, 'utf-8')
       assert(
@@ -854,10 +857,14 @@ describe('Valkey Integration Tests', () => {
 
       const targetAuthedConfig = await containerManager.getConfig(targetName)
       assert(targetAuthedConfig !== null, 'Target auth config should exist')
-      const restoreResult = await engine.restore(targetAuthedConfig!, backupPath, {
-        database: DATABASE,
-        flush: true,
-      })
+      const restoreResult = await engine.restore(
+        targetAuthedConfig!,
+        backupPath,
+        {
+          database: DATABASE,
+          flush: true,
+        },
+      )
       assert(
         !restoreResult.stdout?.includes('NOAUTH') &&
           !restoreResult.stdout?.includes('WRONGPASS') &&

--- a/tests/integration/weaviate.test.ts
+++ b/tests/integration/weaviate.test.ts
@@ -373,7 +373,10 @@ describe('Weaviate Integration Tests', () => {
     async () => {
       console.log('\n Testing auth-backed Weaviate backup/restore...')
 
-      const allPorts = await findConsecutiveFreePorts(4, TEST_PORTS.weaviate.base + 20)
+      const allPorts = await findConsecutiveFreePorts(
+        4,
+        TEST_PORTS.weaviate.base + 20,
+      )
       const [sourcePort, targetPort] = [allPorts[0], allPorts[2]]
       const sourceName = generateTestName('weaviate-auth-test-source')
       const targetName = generateTestName('weaviate-auth-test-target')
@@ -424,7 +427,10 @@ describe('Weaviate Integration Tests', () => {
         await saveCredentials(sourceName, ENGINE, sourceCreds)
 
         const sourceAuthedReady = await waitForReady(ENGINE, sourcePort)
-        assert(sourceAuthedReady, 'Source Weaviate should be ready after auth restart')
+        assert(
+          sourceAuthedReady,
+          'Source Weaviate should be ready after auth restart',
+        )
 
         await containerManager.create(targetName, {
           engine: ENGINE,
@@ -440,7 +446,10 @@ describe('Weaviate Integration Tests', () => {
         await containerManager.updateConfig(targetName, { status: 'running' })
 
         const targetReady = await waitForReady(ENGINE, targetPort)
-        assert(targetReady, 'Target Weaviate should be ready before auth config')
+        assert(
+          targetReady,
+          'Target Weaviate should be ready before auth config',
+        )
 
         const targetCreds = await engine.createUser(targetConfig!, {
           username,
@@ -449,7 +458,10 @@ describe('Weaviate Integration Tests', () => {
         await saveCredentials(targetName, ENGINE, targetCreds)
 
         const targetAuthedReady = await waitForReady(ENGINE, targetPort)
-        assert(targetAuthedReady, 'Target Weaviate should be ready after auth restart')
+        assert(
+          targetAuthedReady,
+          'Target Weaviate should be ready after auth restart',
+        )
 
         await engine.stop(targetConfig!)
         await containerManager.updateConfig(targetName, { status: 'stopped' })
@@ -491,7 +503,10 @@ describe('Weaviate Integration Tests', () => {
             }),
           },
         )
-        assert(restoreResponse.ok, 'Auth-backed restore API call should succeed')
+        assert(
+          restoreResponse.ok,
+          'Auth-backed restore API call should succeed',
+        )
 
         let restored = false
         for (let attempt = 0; attempt < 30; attempt++) {
@@ -539,18 +554,18 @@ describe('Weaviate Integration Tests', () => {
         if (sourceConfig) {
           await engine.stop(sourceConfig).catch(() => {})
           await waitForStopped(sourceName, ENGINE, 90000).catch(() => false)
-          await containerManager.delete(sourceName, { force: true }).catch(
-            () => {},
-          )
+          await containerManager
+            .delete(sourceName, { force: true })
+            .catch(() => {})
         }
 
         const targetConfig = await containerManager.getConfig(targetName)
         if (targetConfig) {
           await engine.stop(targetConfig).catch(() => {})
           await waitForStopped(targetName, ENGINE, 90000).catch(() => false)
-          await containerManager.delete(targetName, { force: true }).catch(
-            () => {},
-          )
+          await containerManager
+            .delete(targetName, { force: true })
+            .catch(() => {})
         }
       }
     },

--- a/tests/unit/backup-formats.test.ts
+++ b/tests/unit/backup-formats.test.ts
@@ -12,7 +12,10 @@ describe('BACKUP_FORMATS', () => {
   it('mongodb + ferretdb expose an uncompressed archive-plain format', () => {
     for (const engine of [Engine.MongoDB, Engine.FerretDB] as const) {
       const { formats, defaultFormat } = BACKUP_FORMATS[engine]
-      assert('archive' in formats, `${engine} should keep the compressed archive`)
+      assert(
+        'archive' in formats,
+        `${engine} should keep the compressed archive`,
+      )
       assert(
         'archive-plain' in formats,
         `${engine} should expose archive-plain`,
@@ -23,7 +26,11 @@ describe('BACKUP_FORMATS', () => {
         `${engine} archive-plain extension`,
       )
       // the default stays the compressed archive (no behavior change)
-      assertEqual(defaultFormat, 'archive', `${engine} default format unchanged`)
+      assertEqual(
+        defaultFormat,
+        'archive',
+        `${engine} default format unchanged`,
+      )
     }
   })
 })

--- a/tests/unit/clickhouse-pid-write.test.ts
+++ b/tests/unit/clickhouse-pid-write.test.ts
@@ -71,11 +71,7 @@ describe('ClickHouse writePidFromPort (BUG-2 regression)', () => {
         intervalMs: 50,
       })
       assert.equal(wrote, true, 'should report PID file was written')
-      assert.equal(
-        existsSync(pidFile),
-        true,
-        'PID file should exist on disk',
-      )
+      assert.equal(existsSync(pidFile), true, 'PID file should exist on disk')
       const contents = (await readFile(pidFile, 'utf8')).trim()
       assert.match(contents, /^\d+$/, 'PID file should contain a numeric PID')
       // The lsof scrape may return any process holding the port — at minimum

--- a/tests/unit/cow-copy.test.ts
+++ b/tests/unit/cow-copy.test.ts
@@ -153,7 +153,10 @@ describe('cow-copy: isTransientReflinkError (EAGAIN retry classifier)', () => {
       ),
       false,
     )
-    assert.equal(isTransientReflinkError(new Error('some other failure')), false)
+    assert.equal(
+      isTransientReflinkError(new Error('some other failure')),
+      false,
+    )
     assert.equal(isTransientReflinkError('plain string error'), false)
   })
 })

--- a/tests/unit/json-output.test.ts
+++ b/tests/unit/json-output.test.ts
@@ -602,7 +602,9 @@ describe('JSON Output Validation', () => {
       // TypeDB's HTTP-API offset is runtime-configurable (SPINDB_TYPEDB_HTTP_OFFSET),
       // so it is deliberately NOT a static auxPort.
       if (engines.typedb.auxPorts.length !== 0) {
-        throw new Error('typedb.auxPorts should be empty (offset is env-driven)')
+        throw new Error(
+          'typedb.auxPorts should be empty (offset is env-driven)',
+        )
       }
     })
 

--- a/tests/unit/mongo-archive-detection.test.ts
+++ b/tests/unit/mongo-archive-detection.test.ts
@@ -12,7 +12,9 @@ import { detectBackupFormat as detectFerret } from '../../engines/ferretdb/resto
 // classified it as 'unknown' and defaulted to --gzip, failing with
 // "gzip: invalid header" on every archive-plain backup (its own AND FerretDB's,
 // breaking cross-engine restore). The gzip magic (1f 8b) is the compressed case.
-const ARCHIVE_MAGIC = Buffer.from([0x6d, 0xe2, 0x99, 0x81, 0x10, 0x20, 0x30, 0x40])
+const ARCHIVE_MAGIC = Buffer.from([
+  0x6d, 0xe2, 0x99, 0x81, 0x10, 0x20, 0x30, 0x40,
+])
 const GZIP_MAGIC = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x11, 0x22, 0x33, 0x44])
 
 describe('Mongo-wire uncompressed archive detection (archive-plain)', () => {
@@ -20,7 +22,9 @@ describe('Mongo-wire uncompressed archive detection (archive-plain)', () => {
   let seq = 0
 
   after(async () => {
-    await Promise.all(created.map((p) => rm(p, { force: true }).catch(() => {})))
+    await Promise.all(
+      created.map((p) => rm(p, { force: true }).catch(() => {})),
+    )
   })
 
   async function fixture(label: string, buf: Buffer): Promise<string> {

--- a/tests/unit/postgresql-restore.test.ts
+++ b/tests/unit/postgresql-restore.test.ts
@@ -39,7 +39,10 @@ describe('PostgreSQL Restore Module', () => {
       // object so the result REPLACES the contents (not merges into them), while
       // leaving the database itself (and its open connections) untouched.
       const cmd = buildPgRestoreCommand({ ...base, clean: true })
-      assert(cmd.includes('--clean --if-exists'), 'includes --clean --if-exists')
+      assert(
+        cmd.includes('--clean --if-exists'),
+        'includes --clean --if-exists',
+      )
       // ordering: clean flags before the format flag and the file
       assert(
         cmd.indexOf('--clean --if-exists') < cmd.indexOf('-Fc'),

--- a/tests/unit/query-parser.test.ts
+++ b/tests/unit/query-parser.test.ts
@@ -393,9 +393,7 @@ describe('Query Parser', () => {
     it('should ignore SurrealDB prompt lines before JSON output', () => {
       const json = [
         'surrealdb_test/test> SELECT * FROM test_user;',
-        JSON.stringify([
-          [{ id: 'test_user:1', name: 'Alice' }],
-        ]),
+        JSON.stringify([[{ id: 'test_user:1', name: 'Alice' }]]),
       ].join('\n')
       const result = parseSurrealDBResult(json)
 
@@ -411,7 +409,11 @@ describe('Query Parser', () => {
       const result = parseSurrealDBResult(json)
 
       assertEqual(result.rowCount, 1, 'Should parse the first JSON document')
-      assertEqual(result.rows[0].name, 'Alice', 'Trailing prompt should be ignored')
+      assertEqual(
+        result.rows[0].name,
+        'Alice',
+        'Trailing prompt should be ignored',
+      )
     })
   })
 

--- a/tests/unit/remote-container.test.ts
+++ b/tests/unit/remote-container.test.ts
@@ -403,7 +403,11 @@ describe('remote-container', () => {
         provider: 'neon',
       })
       assertEqual(config.host, 'db.neon.tech', 'host should match')
-      assertEqual(config.origin, 'external', 'origin should default to external')
+      assertEqual(
+        config.origin,
+        'external',
+        'origin should default to external',
+      )
       assertEqual(config.ssl, true, 'SSL should be true for remote host')
       assertEqual(config.provider, 'neon', 'provider should be neon')
       assert(

--- a/tests/unit/version-utils.test.ts
+++ b/tests/unit/version-utils.test.ts
@@ -13,7 +13,10 @@ describe('isShorthandVersion', () => {
     it('2-part is shorthand', () => {
       assert(isShorthandVersion('8.4') === true, "'8.4' should be shorthand")
       assert(isShorthandVersion('11.8') === true, "'11.8' should be shorthand")
-      assert(isShorthandVersion('25.12') === true, "'25.12' should be shorthand")
+      assert(
+        isShorthandVersion('25.12') === true,
+        "'25.12' should be shorthand",
+      )
     })
 
     it('3-part is full', () => {
@@ -21,14 +24,8 @@ describe('isShorthandVersion', () => {
         isShorthandVersion('17.10.0') === false,
         "'17.10.0' should be full",
       )
-      assert(
-        isShorthandVersion('11.8.6') === false,
-        "'11.8.6' should be full",
-      )
-      assert(
-        isShorthandVersion('8.0.23') === false,
-        "'8.0.23' should be full",
-      )
+      assert(isShorthandVersion('11.8.6') === false, "'11.8.6' should be full")
+      assert(isShorthandVersion('8.0.23') === false, "'8.0.23' should be full")
     })
 
     it('4-part ClickHouse is full', () => {

--- a/tests/unit/which-select.test.ts
+++ b/tests/unit/which-select.test.ts
@@ -111,9 +111,7 @@ describe('selectContainerForWhich', () => {
   })
 
   it('returns null when no container matches the port', () => {
-    const containers = [
-      container({ name: 'a', port: 5432, status: 'running' }),
-    ]
+    const containers = [container({ name: 'a', port: 5432, status: 'running' })]
     const match = selectContainerForWhich(containers, { targetPort: 9999 })
     assertNullish(match, 'Should return null when nothing matches')
   })


### PR DESCRIPTION
Formatting-only: output of `pnpm format` on current dev (76 files, prettier drift that had accumulated). No functional changes; `pnpm lint` (eslint + tsc) passes. Kept separate from the 0.61.5 release changes.