### PR TITLE
feat(typedb): install 3.12 loader binary so `typedb loader` works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.7] - 2026-07-10
+
+### Added
+
+- **TypeDB 3.12 `loader` binary is now installed.** TypeDB 3.12 archives bundle a
+  new top-level `loader/typedb_loader_bin` alongside the launcher, server, and
+  console. spindb previously relocated only the launcher, server, and console at
+  extract time and discarded the rest, so `typedb loader` errored with "loader
+  was not included in this distribution." The binary manager now relocates
+  `loader/` into `bin/loader/` (matching the launcher's expected relative path,
+  `${TYPEDB_HOME}/loader/typedb_loader_bin`) whenever the archive contains it, so
+  `typedb loader` works for 3.12+ containers. The relocation is conditional:
+  TypeDB 3.8 and 3.11 archives do not ship a loader, and those extractions stay
+  clean with no failure and no new warnings.
+- The 3.12 `admin` tool (`admin/typedb_admin_bin`) is **deliberately excluded**.
+  spindb disables the 3.12+ admin service (`adminConfigLines()` sets
+  `enabled: false`), so the admin tool cannot connect to a spindb-managed server;
+  shipping it would only present users a tool that always fails to connect. Users
+  and databases continue to be managed through the console binary.
+
 ## [0.61.6] - 2026-07-10
 
 ### Changed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.6'
+export const VERSION = '0.61.7'

--- a/engines/typedb/binary-manager.ts
+++ b/engines/typedb/binary-manager.ts
@@ -12,6 +12,10 @@
  *   │   └── config.yml          (default config)
  *   ├── console/
  *   │   └── typedb_console_bin  (console binary)
+ *   ├── loader/                 (TypeDB 3.12+ only)
+ *   │   └── typedb_loader_bin   (loader binary)
+ *   ├── admin/                  (TypeDB 3.12+ only; NOT relocated, see below)
+ *   │   └── typedb_admin_bin    (admin binary)
  *   └── LICENSE
  *
  * We reorganize this preserving the relative structure the launcher expects:
@@ -21,7 +25,8 @@
  *   │   └── typedb_server_bin   (server binary)
  *   ├── console/
  *   │   └── typedb_console_bin  (console binary)
- *   └── config.yml              (moved for reference)
+ *   └── loader/                 (only when the archive bundles it, 3.12+)
+ *       └── typedb_loader_bin   (loader binary)
  *   server/
  *   └── config.yml              (default config for reference)
  */
@@ -134,6 +139,26 @@ class TypeDBBinaryManager extends BaseBinaryManager {
     if (existsSync(consoleBinPath)) {
       await moveEntry(consoleBinPath, join(destConsoleDir, consoleBinName))
     }
+
+    // Move loader/ directory into bin/ if present (TypeDB 3.12+ bundles it;
+    // 3.8/3.11 archives do not, so this is conditional and must not fail or
+    // warn for older versions). The launcher resolves the loader at
+    // ${TYPEDB_HOME}/loader/typedb_loader_bin and only enables the `loader`
+    // subcommand when that directory exists, so preserving bin/loader/ here is
+    // what makes `typedb loader` work.
+    const loaderBinName = `typedb_loader_bin${ext}`
+    const loaderBinPath = join(sourceDir, 'loader', loaderBinName)
+    if (existsSync(loaderBinPath)) {
+      const destLoaderDir = join(destBinDir, 'loader')
+      await mkdir(destLoaderDir, { recursive: true })
+      await moveEntry(loaderBinPath, join(destLoaderDir, loaderBinName))
+    }
+
+    // NOTE: We deliberately do NOT relocate admin/typedb_admin_bin. spindb
+    // disables the 3.12+ admin service (adminConfigLines() sets enabled: false),
+    // so the admin tool cannot connect to a spindb-managed server. Shipping it
+    // would only confuse users with a tool that always fails to connect. Users
+    // and databases are managed via the console binary instead.
 
     // Preserve server/config.yml as reference config
     const configPath = join(sourceDir, 'server', 'config.yml')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## Summary

TypeDB 3.12 archives bundle a new top-level `loader/typedb_loader_bin` next to the launcher, server, and console binaries. spindb's `engines/typedb/binary-manager.ts` relocated only the launcher, server, and console at extract time and discarded the rest, so `typedb loader` errored with "loader was not included in this distribution."

This change relocates `loader/` into `bin/loader/` whenever the extracted archive contains it, matching the launcher's expected relative path (`${TYPEDB_HOME}/loader/typedb_loader_bin`), so `typedb loader` works for 3.12+ containers.

## Details

- **Conditional relocation.** TypeDB 3.8 and 3.11 archives do not ship a loader; those extractions stay clean with no failure and no new warning.
- **`admin` deliberately excluded.** spindb disables the 3.12+ admin service (`adminConfigLines()` sets `enabled: false`), so `admin/typedb_admin_bin` cannot connect to a spindb-managed server. Shipping it would only present a tool that always fails to connect. Users and databases continue to be managed via the console binary. A code comment states this exclusion is intentional and why.

## Launcher path resolution

The extracted `typedb` launcher sets `TYPEDB_HOME` to its own directory (spindb places it at `<binPath>/bin/typedb`, so `TYPEDB_HOME` = `<binPath>/bin`) and enables the `loader` subcommand only when `${TYPEDB_HOME}/loader` exists, exec'ing `${TYPEDB_HOME}/loader/typedb_loader_bin`. Placing the loader at `bin/loader/typedb_loader_bin` (mirroring how console/server are relocated) satisfies this exactly. Same mechanism on Windows (`typedb.bat` -> `%TYPEDB_HOME%\loader\typedb_loader_bin.exe`).

## Archive verification (registry.layerbase.host, typedb-3.12.0)

- linux-x64 `.tar.gz`: contains `typedb/loader/typedb_loader_bin` (and `typedb/admin/typedb_admin_bin`)
- win32-x64 `.zip`: contains `typedb/loader/typedb_loader_bin.exe` and `typedb/typedb.bat` launcher (and `typedb/admin/typedb_admin_bin.exe`)

## Local verification

- Deleted cached extract, created a fresh 3.12.0 container (forcing re-extraction): `bin/loader/typedb_loader_bin` now present, `bin/admin` correctly absent. `<binPath>/bin/typedb loader --help` exits 0 with the loader usage.
- Recreated a 3.11.5 container: no `bin/loader`, launcher usage output omits the Loader line, extraction clean with no warnings.
- Both verification containers deleted afterward.

## Tests

- `pnpm lint` clean
- `pnpm test:unit`: 1664 pass / 0 fail
- `pnpm test:engine typedb`: 19 pass / 0 fail

Ship as 0.61.7.