### PR TITLE
release: 0.61.7 - TypeDB 3.12 loader binary support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.7] - 2026-07-10
+
+### Added
+
+- **TypeDB 3.12 `loader` binary is now installed.** TypeDB 3.12 archives bundle a
+  new top-level `loader/typedb_loader_bin` alongside the launcher, server, and
+  console. spindb previously relocated only the launcher, server, and console at
+  extract time and discarded the rest, so `typedb loader` errored with "loader
+  was not included in this distribution." The binary manager now relocates
+  `loader/` into `bin/loader/` (matching the launcher's expected relative path,
+  `${TYPEDB_HOME}/loader/typedb_loader_bin`) whenever the archive contains it, so
+  `typedb loader` works for 3.12+ containers. The relocation is conditional:
+  TypeDB 3.8 and 3.11 archives do not ship a loader, and those extractions stay
+  clean with no failure and no new warnings.
+- The 3.12 `admin` tool (`admin/typedb_admin_bin`) is **deliberately excluded**.
+  spindb disables the 3.12+ admin service (`adminConfigLines()` sets
+  `enabled: false`), so the admin tool cannot connect to a spindb-managed server;
+  shipping it would only present users a tool that always fails to connect. Users
+  and databases continue to be managed through the console binary.
+
 ## [0.61.6] - 2026-07-10
 
 ### Changed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.6'
+export const VERSION = '0.61.7'

--- a/engines/typedb/binary-manager.ts
+++ b/engines/typedb/binary-manager.ts
@@ -12,6 +12,10 @@
  *   │   └── config.yml          (default config)
  *   ├── console/
  *   │   └── typedb_console_bin  (console binary)
+ *   ├── loader/                 (TypeDB 3.12+ only)
+ *   │   └── typedb_loader_bin   (loader binary)
+ *   ├── admin/                  (TypeDB 3.12+ only; NOT relocated, see below)
+ *   │   └── typedb_admin_bin    (admin binary)
  *   └── LICENSE
  *
  * We reorganize this preserving the relative structure the launcher expects:
@@ -21,7 +25,8 @@
  *   │   └── typedb_server_bin   (server binary)
  *   ├── console/
  *   │   └── typedb_console_bin  (console binary)
- *   └── config.yml              (moved for reference)
+ *   └── loader/                 (only when the archive bundles it, 3.12+)
+ *       └── typedb_loader_bin   (loader binary)
  *   server/
  *   └── config.yml              (default config for reference)
  */
@@ -134,6 +139,26 @@ class TypeDBBinaryManager extends BaseBinaryManager {
     if (existsSync(consoleBinPath)) {
       await moveEntry(consoleBinPath, join(destConsoleDir, consoleBinName))
     }
+
+    // Move loader/ directory into bin/ if present (TypeDB 3.12+ bundles it;
+    // 3.8/3.11 archives do not, so this is conditional and must not fail or
+    // warn for older versions). The launcher resolves the loader at
+    // ${TYPEDB_HOME}/loader/typedb_loader_bin and only enables the `loader`
+    // subcommand when that directory exists, so preserving bin/loader/ here is
+    // what makes `typedb loader` work.
+    const loaderBinName = `typedb_loader_bin${ext}`
+    const loaderBinPath = join(sourceDir, 'loader', loaderBinName)
+    if (existsSync(loaderBinPath)) {
+      const destLoaderDir = join(destBinDir, 'loader')
+      await mkdir(destLoaderDir, { recursive: true })
+      await moveEntry(loaderBinPath, join(destLoaderDir, loaderBinName))
+    }
+
+    // NOTE: We deliberately do NOT relocate admin/typedb_admin_bin. spindb
+    // disables the 3.12+ admin service (adminConfigLines() sets enabled: false),
+    // so the admin tool cannot connect to a spindb-managed server. Shipping it
+    // would only confuse users with a tool that always fails to connect. Users
+    // and databases are managed via the console binary instead.
 
     // Preserve server/config.yml as reference config
     const configPath = join(sourceDir, 'server', 'config.yml')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## 0.61.7

- **TypeDB 3.12 loader** (#256): the `loader/` directory from TypeDB 3.12+ archives is now kept at extraction time, so `typedb loader` (bulk import) works from spindb installs. 3.8/3.11 archives (no loader dir) extract unchanged. The `admin/` tool remains deliberately excluded because spindb disables the 3.12+ admin service.

## Verification

- Archive contents confirmed on linux-x64, win32-x64, darwin-arm64 (loader present in all)
- Fresh 3.12.0 extraction: `typedb loader --help` exits 0; fresh 3.11.5 extraction clean with no warnings
- 1664 unit tests, 19 TypeDB integration tests, lint all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the TypeDB 3.12 `loader` command when included in the distribution archive.
  * Older TypeDB archives without the loader continue to work.

* **Bug Fixes**
  * Prevented the TypeDB 3.12 `admin` tool from connecting to managed servers; administration remains available through the console.

* **Release**
  * Updated the release version to 0.61.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->