### PR TITLE
docs: re-point ecosystem doc references to layerbase-cloud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@
 - [docs/ENGINE_NOTES.md](docs/ENGINE_NOTES.md) — Per-engine implementation details
 - [docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md) — Custom keyboard shortcut guide
 - Other: [TODO.md](TODO.md), [CHANGELOG.md](CHANGELOG.md), [TEST_COVERAGE.md](TEST_COVERAGE.md), [TESTING_STRATEGY.md](TESTING_STRATEGY.md)
-- **Ecosystem docs:** `~/dev/layerbase-architecture/` — Shared architecture, infrastructure inventory, cross-project rules, and agent configs.
-- **Ecosystem invariants:** `~/dev/layerbase-architecture/INVARIANTS.md` — Non-negotiable rules (scripting-first, thin desktop wrapper, platform-agnostic cloud, binary ownership). Read before making architectural changes.
+- **Ecosystem docs:** `~/dev/layerbase-cloud/` — Shared architecture, infrastructure inventory, cross-project rules, and agent configs.
+- **Ecosystem invariants:** `~/dev/layerbase-cloud/INVARIANTS.md` — Non-negotiable rules (scripting-first, thin desktop wrapper, platform-agnostic cloud, binary ownership). Read before making architectural changes.
 
 ## Ecosystem
 
@@ -280,7 +280,7 @@ The focused March 28, 2026 auth sweep passed sequentially for all of the engines
 
 **Target (not scheduled):** A native, pure-TS spindb pgwire proxy for file-based engines - `pg-gateway` plus Node's native SQLite/DuckDB bindings - that exposes a local file DB over the PostgreSQL wire protocol. This would let Layerbase Cloud drop both external binaries (including the maintained duckgres fork) and give desktop a "serve my local file DB over Postgres wire" feature.
 
-**Status:** Recorded as a deliberate FUTURE option from the 2026-06-15 C-033 spindb-convergence decision (`~/dev/layerbase-architecture/tracker.md`, `~/dev/layerbase-cloud/plans/active/spindb-convergence-c033.md`). The decision there was the opposite for now: the proxy/pooler lifecycle is **intentionally kept in Layerbase Cloud** (moving it would force spindb to bundle foreign Go/Rust binaries, violating "spindb ships only database binaries"), and the near-term fix for the fragile restore-restart dance is a cloud-internal supervisor module, not a spindb change. Revisit Model B only as a separate, larger product bet.
+**Status:** Recorded as a deliberate FUTURE option from the 2026-06-15 C-033 spindb-convergence decision (`~/dev/layerbase-cloud/tracker.md`, `~/dev/layerbase-cloud/plans/active/spindb-convergence-c033.md`). The decision there was the opposite for now: the proxy/pooler lifecycle is **intentionally kept in Layerbase Cloud** (moving it would force spindb to bundle foreign Go/Rust binaries, violating "spindb ships only database binaries"), and the near-term fix for the fragile restore-restart dance is a cloud-internal supervisor module, not a spindb change. Revisit Model B only as a separate, larger product bet.
 
 ## Recent Fixes (0.47.3 → 0.47.13)
 

--- a/core/credential-generator.ts
+++ b/core/credential-generator.ts
@@ -23,7 +23,7 @@ const ALPHANUMERIC_CHARSET = LOWERCASE + UPPERCASE + DIGITS
 // Canonical length for a generated database credential.
 //
 // Shared credential spec (ADR-001,
-// layerbase-architecture/decisions/001-credential-charsets.md): the standard
+// layerbase-cloud/docs/decisions/001-credential-charsets.md): the standard
 // generated DB password is 24 alphanumeric characters. The same spec is
 // implemented in layerbase-cloud's `src/lib/credentials.ts`; both repos run
 // conformance tests so the two cannot re-drift.

--- a/tests/unit/credential-generator.test.ts
+++ b/tests/unit/credential-generator.test.ts
@@ -2,7 +2,7 @@
  * Conformance tests for the credential generator (core/credential-generator.ts).
  *
  * These assert the shared credential spec pinned in ADR-001
- * (layerbase-architecture/decisions/001-credential-charsets.md). The same
+ * (layerbase-cloud/docs/decisions/001-credential-charsets.md). The same
  * spec is implemented and tested in layerbase-cloud (src/lib/credentials.ts +
  * its credentials conformance test); keeping equivalent assertions in both
  * repos is what stops the two security-sensitive generators from re-drifting.


### PR DESCRIPTION
The `layerbase-architecture` repo was deprecated (archived read-only) on 2026-07-11. Its living docs moved into `layerbase-cloud`. This re-points every reference in this repo to the new canonical paths (INVARIANTS.md, tracker.md, DIVERGENCES.md, docs/decisions/*, plans/). Docs/comments only, no runtime changes.