### PR TITLE
release: spindb 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-07-13
+
+### Added
+
+- **Prerelease (alpha/beta/rc) database support, starting with PostgreSQL
+  19.0.0-beta.1.** hostdb now publishes prerelease binaries, and spindb can
+  create containers from them without ever treating them as GA. The support is
+  end to end:
+  - **Exact-token resolution only.** A prerelease resolves only by its full
+    token: `19.0.0-beta.1` resolves to itself, while `19` resolves to nothing
+    (no bare-major key is created for a prerelease). GA majors are unaffected,
+    so `18` still resolves to `18.4.0`. `SUPPORTED_MAJOR_VERSIONS` deliberately
+    excludes the prerelease major `19`.
+  - **Beta tag in the version picker.** The interactive create flow surfaces
+    prerelease versions with a channel tag so users can opt in explicitly.
+  - **Non-blocking create warning.** Choosing a prerelease prints a yellow
+    caution (via stderr, so `--json` output stays clean) noting it is not
+    recommended for production and that its data directory is not compatible
+    with the GA release.
+  - **Prerelease-aware binary verification.** PostgreSQL prerelease binaries
+    self-report the upstream form (for example `19beta1`), which is matched
+    against hostdb's canonical `19.0.0-beta.1` instead of failing the version
+    check.
+  - **Migration guard.** A prerelease counts as a supported value (identity
+    map) so it is not flagged as outdated, but it exposes no GA migration
+    target for its major, so nothing auto-upgrades onto or off of it.
+  - **`prereleaseVersions` in `engines supported --json`.** PostgreSQL now
+    reports `"prereleaseVersions": { "19.0.0-beta.1": "beta" }` alongside its
+    unchanged `supportedVersions` major buckets (which still omit `19`).
+
+### Changed
+
+- **Pin `hostdb` to `0.35.0`** (was 0.34.1). Adds the PostgreSQL
+  19.0.0-beta.1 prerelease entry and the `getReleaseType` /
+  `listVersions({ includePrerelease })` surface the wrappers now consume. The
+  bundled snapshot matches the live registry, so the hostdb-sync integration
+  check passes against `registry.layerbase.host`.
+
 ## [0.61.7] - 2026-07-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@
 - [docs/ENGINE_NOTES.md](docs/ENGINE_NOTES.md) — Per-engine implementation details
 - [docs/KEYBOARD_SHORTCUTS.md](docs/KEYBOARD_SHORTCUTS.md) — Custom keyboard shortcut guide
 - Other: [TODO.md](TODO.md), [CHANGELOG.md](CHANGELOG.md), [TEST_COVERAGE.md](TEST_COVERAGE.md), [TESTING_STRATEGY.md](TESTING_STRATEGY.md)
-- **Ecosystem docs:** `~/dev/layerbase-architecture/` — Shared architecture, infrastructure inventory, cross-project rules, and agent configs.
-- **Ecosystem invariants:** `~/dev/layerbase-architecture/INVARIANTS.md` — Non-negotiable rules (scripting-first, thin desktop wrapper, platform-agnostic cloud, binary ownership). Read before making architectural changes.
+- **Ecosystem docs:** `~/dev/layerbase-cloud/` — Shared architecture, infrastructure inventory, cross-project rules, and agent configs.
+- **Ecosystem invariants:** `~/dev/layerbase-cloud/INVARIANTS.md` — Non-negotiable rules (scripting-first, thin desktop wrapper, platform-agnostic cloud, binary ownership). Read before making architectural changes.
 
 ## Ecosystem
 
@@ -280,7 +280,7 @@ The focused March 28, 2026 auth sweep passed sequentially for all of the engines
 
 **Target (not scheduled):** A native, pure-TS spindb pgwire proxy for file-based engines - `pg-gateway` plus Node's native SQLite/DuckDB bindings - that exposes a local file DB over the PostgreSQL wire protocol. This would let Layerbase Cloud drop both external binaries (including the maintained duckgres fork) and give desktop a "serve my local file DB over Postgres wire" feature.
 
-**Status:** Recorded as a deliberate FUTURE option from the 2026-06-15 C-033 spindb-convergence decision (`~/dev/layerbase-architecture/tracker.md`, `~/dev/layerbase-cloud/plans/active/spindb-convergence-c033.md`). The decision there was the opposite for now: the proxy/pooler lifecycle is **intentionally kept in Layerbase Cloud** (moving it would force spindb to bundle foreign Go/Rust binaries, violating "spindb ships only database binaries"), and the near-term fix for the fragile restore-restart dance is a cloud-internal supervisor module, not a spindb change. Revisit Model B only as a separate, larger product bet.
+**Status:** Recorded as a deliberate FUTURE option from the 2026-06-15 C-033 spindb-convergence decision (`~/dev/layerbase-cloud/tracker.md`, `~/dev/layerbase-cloud/plans/active/spindb-convergence-c033.md`). The decision there was the opposite for now: the proxy/pooler lifecycle is **intentionally kept in Layerbase Cloud** (moving it would force spindb to bundle foreign Go/Rust binaries, violating "spindb ships only database binaries"), and the near-term fix for the fragile restore-restart dance is a cloud-internal supervisor module, not a spindb change. Revisit Model B only as a separate, larger product bet.
 
 ## Recent Fixes (0.47.3 → 0.47.13)
 

--- a/cli/commands/create.ts
+++ b/cli/commands/create.ts
@@ -27,6 +27,7 @@ import { isValidDatabaseName, exitWithError } from '../../core/error-handler'
 import { resolve } from 'path'
 import { Engine, Platform, ALL_ENGINES } from '../../types'
 import { canCreateDatabase } from '../../core/database-capabilities'
+import { getReleaseType as getHostdbReleaseType } from 'hostdb'
 import {
   FERRETDB_VERSION_MAP,
   isV1 as isFerretDBv1,
@@ -653,6 +654,24 @@ export const createCommand = new Command('create')
           )
         }
         version = resolvedVersion
+
+        // Warn (non-blocking) when the user opts into a prerelease. Printed to
+        // stderr via console.warn so it is visible in --json mode without
+        // corrupting the JSON on stdout.
+        const releaseChannel = getHostdbReleaseType(dbEngine.name, version)
+        if (releaseChannel && releaseChannel !== 'ga') {
+          const channelLabel =
+            releaseChannel === 'rc'
+              ? 'release candidate'
+              : releaseChannel === 'alpha'
+                ? 'an alpha release'
+                : 'a beta release'
+          console.warn(
+            chalk.yellow(
+              `${dbEngine.displayName} ${version} is ${releaseChannel === 'rc' ? 'a ' : ''}${channelLabel}. Not recommended for production; data directories are not compatible with the GA release.`,
+            ),
+          )
+        }
 
         // SQLite has a simplified flow (no port, no start/stop)
         if (engine === Engine.SQLite) {

--- a/cli/commands/engines.ts
+++ b/cli/commands/engines.ts
@@ -13,6 +13,11 @@ import { getEngine } from '../../engines'
 import { postgresqlBinaryManager } from '../../engines/postgresql/binary-manager'
 import { paths } from '../../config/paths'
 import { getEngineDefaults, type AuxPort } from '../../config/defaults'
+import {
+  getPrereleaseVersions as getHostdbPrereleaseVersions,
+  getReleaseType as getHostdbReleaseType,
+  type ReleaseType,
+} from 'hostdb'
 import { platformService } from '../../core/platform-service'
 import { detectPackageManager, findBinary } from '../../core/dependency-manager'
 import {
@@ -1849,6 +1854,11 @@ enginesCommand
             // source of truth. Additive - existing fields are unchanged.
             let dataSubdir: string | undefined
             let auxPorts: AuxPort[] = []
+            // Prerelease (beta/rc/alpha) versions, keyed by exact version token.
+            // Additive and cross-repo-agreed: layerbase-desktop/cloud render a
+            // Beta badge from this. Omitted entirely when empty so existing
+            // consumers see a stable shape.
+            const prereleaseVersions: Record<string, ReleaseType> = {}
             try {
               const engineInstance = getEngine(name)
               supportedVersions = [...engineInstance.supportedVersions]
@@ -1856,9 +1866,16 @@ enginesCommand
               defaultVersion = defaults.defaultVersion
               dataSubdir = defaults.dataSubdir
               auxPorts = defaults.auxPorts ?? []
+              for (const version of getHostdbPrereleaseVersions(name)) {
+                const type = getHostdbReleaseType(name, version)
+                if (type && type !== 'ga') {
+                  prereleaseVersions[version] = type
+                }
+              }
             } catch {
               // Engine not registered (e.g., status='planned') - leave version fields empty.
             }
+            const hasPrereleases = Object.keys(prereleaseVersions).length > 0
             return [
               name,
               {
@@ -1867,6 +1884,7 @@ enginesCommand
                 defaultVersion,
                 dataSubdir,
                 auxPorts,
+                ...(hasPrereleases ? { prereleaseVersions } : {}),
               },
             ]
           }),

--- a/cli/ui/prompts.ts
+++ b/cli/ui/prompts.ts
@@ -12,7 +12,9 @@ import { listEngines, getEngine } from '../../engines'
 import {
   getDeprecatedVersions,
   getAvailableVersions,
+  getPrereleaseVersions,
 } from '../../core/hostdb-metadata'
+import type { ReleaseType } from 'hostdb'
 import { defaults, getEngineDefaults } from '../../config/defaults'
 import { portManager } from '../../core/port-manager'
 import { containerManager } from '../../core/container-manager'
@@ -565,13 +567,16 @@ export async function promptVersion(
 
   let availableVersions: Record<string, string[]>
   let deprecatedVersions: Set<string> = new Set()
+  let prereleaseVersions: Map<string, ReleaseType> = new Map()
   try {
-    const [versions, deprecated] = await Promise.all([
+    const [versions, deprecated, prereleases] = await Promise.all([
       engine.fetchAvailableVersions(),
       getDeprecatedVersions(engineName),
+      getPrereleaseVersions(engineName),
     ])
     availableVersions = versions
     deprecatedVersions = deprecated
+    prereleaseVersions = prereleases
     spinner.stop()
   } catch {
     spinner.stop()
@@ -594,14 +599,27 @@ export async function promptVersion(
   const latestMajor = majorVersions[0]
   let hiddenDeprecatedCount = 0
 
-  for (let i = 0; i < majorVersions.length; i++) {
-    const major = majorVersions[i]
+  // Prerelease majors (e.g. PostgreSQL '19' while only 19.0.0-beta.1 exists) are
+  // deliberately absent from supportedVersions. Surface them so users can opt
+  // into a prerelease by selecting it - they are never the default or "latest".
+  const prereleaseMajors = Object.keys(availableVersions).filter(
+    (major) =>
+      !majorVersions.includes(major) &&
+      availableVersions[major].some((v) => prereleaseVersions.has(v)),
+  )
+  const allMajors = [...majorVersions, ...prereleaseMajors]
+
+  for (const major of allMajors) {
     const fullVersions = availableVersions[major] || []
     const versionCount = fullVersions.length
     const isLatestMajor = major === latestMajor
     const allDeprecated =
       fullVersions.length > 0 &&
       fullVersions.every((v) => deprecatedVersions.has(v))
+    const firstPrerelease = fullVersions.find((v) => prereleaseVersions.has(v))
+    const allPrerelease =
+      fullVersions.length > 0 &&
+      fullVersions.every((v) => prereleaseVersions.has(v))
 
     // Hide all-deprecated major versions unless --show-deprecated is set
     // TODO: If an engine has ALL majors deprecated, majorChoices will be empty.
@@ -619,9 +637,13 @@ export async function promptVersion(
           )
         : ''
     const deprecatedLabel = allDeprecated ? chalk.yellow(' [deprecated]') : ''
+    const prereleaseLabel =
+      allPrerelease && firstPrerelease
+        ? chalk.yellow(` [${prereleaseVersions.get(firstPrerelease)}]`)
+        : ''
     const label = isLatestMajor
       ? `${engine.displayName} ${major} ${countLabel} ${chalk.green('← latest')}`
-      : `${engine.displayName} ${major} ${countLabel}${deprecatedLabel}`
+      : `${engine.displayName} ${major} ${countLabel}${deprecatedLabel}${prereleaseLabel}`
 
     majorChoices.push({
       name: label,
@@ -680,10 +702,16 @@ export async function promptVersion(
 
   const minorChoices: Choice[] = minorVersions.map((v, i) => {
     const isDeprecated = deprecatedVersions.has(v)
+    const prereleaseType = prereleaseVersions.get(v)
     const deprecatedTag = isDeprecated ? chalk.yellow(' [deprecated]') : ''
-    const latestTag = i === 0 ? ` ${chalk.green('← latest')}` : ''
+    const prereleaseTag = prereleaseType
+      ? chalk.yellow(` [${prereleaseType}]`)
+      : ''
+    // A prerelease is never "latest" even if it sorts first in its major.
+    const latestTag =
+      i === 0 && !prereleaseType ? ` ${chalk.green('← latest')}` : ''
     return {
-      name: `${v}${latestTag}${deprecatedTag}`,
+      name: `${v}${latestTag}${deprecatedTag}${prereleaseTag}`,
       value: v,
       short: v,
     }

--- a/config/paths.ts
+++ b/config/paths.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { readdirSync, existsSync } from 'fs'
 import { getEngineDefaults } from './engine-defaults'
 import { platformService } from '../core/platform-service'
+import { compareVersions } from '../core/version-utils'
 
 /**
  * Get the SpinDB home directory.
@@ -148,27 +149,10 @@ export const paths = {
         }
       }
 
-      // Sort by version descending (newest first)
-      // Handles non-numeric segments (e.g., "1.0.0-beta") by falling back to string comparison
-      return results.sort((a, b) => {
-        const aParts = a.version.split('.')
-        const bParts = b.version.split('.')
-        for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-          const aRaw = aParts[i] || '0'
-          const bRaw = bParts[i] || '0'
-          const aNum = Number(aRaw)
-          const bNum = Number(bRaw)
-          // If both are valid numbers, compare numerically
-          if (!isNaN(aNum) && !isNaN(bNum)) {
-            if (bNum !== aNum) return bNum - aNum
-          } else {
-            // Fall back to string comparison for non-numeric segments
-            const cmp = bRaw.localeCompare(aRaw)
-            if (cmp !== 0) return cmp
-          }
-        }
-        return 0
-      })
+      // Sort by version descending (newest first). compareVersions handles
+      // prerelease suffixes (e.g. "19.0.0-beta.1") and sorts them below the
+      // matching GA release.
+      return results.sort((a, b) => compareVersions(b.version, a.version))
     } catch {
       return []
     }

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.61.7'
+export const VERSION = '0.62.0'

--- a/core/base-server-binary-manager.ts
+++ b/core/base-server-binary-manager.ts
@@ -24,6 +24,7 @@ import { paths } from '../config/paths'
 import { spawnAsync, extractWindowsArchive } from './spawn-utils'
 import { isRenameFallbackError } from './fs-error-utils'
 import { fetchWithRegistryFallback } from './hostdb-client'
+import { prereleaseVersionMatches } from './version-utils'
 import {
   type Engine,
   Platform,
@@ -439,6 +440,12 @@ export abstract class BaseServerBinaryManager {
       const expectedMajor = version.split('.').slice(0, 2).join('.')
       const reportedMajor = reportedVersion.split('.').slice(0, 2).join('.')
       if (expectedMajor === reportedMajor) {
+        return true
+      }
+
+      // Prerelease binaries self-report the upstream form (e.g. "19beta1")
+      // which maps to hostdb's canonical "19.0.0-beta.1".
+      if (prereleaseVersionMatches(fullVersion, reportedVersion)) {
         return true
       }
 

--- a/core/credential-generator.ts
+++ b/core/credential-generator.ts
@@ -23,7 +23,7 @@ const ALPHANUMERIC_CHARSET = LOWERCASE + UPPERCASE + DIGITS
 // Canonical length for a generated database credential.
 //
 // Shared credential spec (ADR-001,
-// layerbase-architecture/decisions/001-credential-charsets.md): the standard
+// layerbase-cloud/docs/decisions/001-credential-charsets.md): the standard
 // generated DB password is 24 alphanumeric characters. The same spec is
 // implemented in layerbase-cloud's `src/lib/credentials.ts`; both repos run
 // conformance tests so the two cannot re-drift.

--- a/core/hostdb-client.ts
+++ b/core/hostdb-client.ts
@@ -10,6 +10,7 @@
  */
 
 import { Platform, type Arch, type Engine } from '../types'
+import type { ReleaseType } from 'hostdb'
 import { logDebug } from './error-handler'
 
 // Registry base URLs
@@ -37,6 +38,7 @@ export type HostdbRelease = {
   releaseTag: string
   releasedAt: string
   deprecated?: boolean
+  releaseType?: ReleaseType
   platforms: Record<string, HostdbPlatform>
 }
 

--- a/core/hostdb-metadata.ts
+++ b/core/hostdb-metadata.ts
@@ -13,6 +13,7 @@
 import {
   loadDatabasesJson as hostdbLoadDatabasesJson,
   loadDownloadsJson as hostdbLoadDownloadsJson,
+  type ReleaseType,
 } from 'hostdb'
 import { logDebug } from './error-handler'
 import { LAYERBASE_REGISTRY_BASE } from './hostdb-client'
@@ -33,6 +34,7 @@ type CliTools = {
 export type VersionEntryObject = {
   enabled?: boolean
   deprecated?: boolean
+  releaseType?: ReleaseType
   note?: string
   platforms?: string[]
   dependencies?: Array<{
@@ -399,6 +401,48 @@ export function isVersionDeprecated(
 ): boolean {
   if (typeof value === 'boolean') return false
   return value.deprecated === true
+}
+
+/**
+ * Get the release type of a version entry (prerelease channel or null for GA).
+ */
+export function getReleaseType(
+  value: boolean | VersionEntryObject,
+): ReleaseType | null {
+  if (typeof value === 'boolean') return null
+  return value.releaseType ?? null
+}
+
+/**
+ * Get the map of prerelease version strings to their release type for an engine
+ * from databases.json. Mirrors getDeprecatedVersions but returns the channel
+ * (alpha/beta/rc) so callers can render the correct tag.
+ * @param engine Engine (e.g., Engine.PostgreSQL or 'postgresql')
+ * @returns Map of version string -> release type, or empty map if fetch fails
+ */
+export async function getPrereleaseVersions(
+  engine: Engine | string,
+): Promise<Map<string, ReleaseType>> {
+  try {
+    const data = await fetchDatabasesJson()
+    const key = engine.toLowerCase()
+    const entry = data[key]
+    if (!entry?.versions) return new Map()
+
+    const result = new Map<string, ReleaseType>()
+    for (const [version, value] of Object.entries(entry.versions)) {
+      if (!isVersionEnabled(value)) continue
+      const type = getReleaseType(value)
+      if (type) result.set(version, type)
+    }
+    return result
+  } catch (error) {
+    logDebug('Failed to fetch prerelease versions from hostdb', {
+      engine,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return new Map()
+  }
 }
 
 /**

--- a/core/hostdb-releases-factory.ts
+++ b/core/hostdb-releases-factory.ts
@@ -13,8 +13,10 @@ import { compareVersions } from './version-utils'
 import {
   getAvailableVersions as getHostdbVersions,
   getDeprecatedVersions as getHostdbDeprecatedVersions,
+  getPrereleaseVersions as getHostdbPrereleaseVersions,
 } from './hostdb-metadata'
 import { logDebug } from './error-handler'
+import type { ReleaseType } from 'hostdb'
 import type { Engine, InstalledBinary } from '../types'
 
 /**
@@ -55,6 +57,7 @@ export type HostdbReleasesModule = {
   fetchAvailableVersions: () => Promise<Record<string, string[]>>
   getLatestVersion: (major: string) => Promise<string>
   fetchDeprecatedVersions: () => Promise<Set<string>>
+  fetchPrereleaseVersions: () => Promise<Map<string, ReleaseType>>
 }
 
 /**
@@ -256,9 +259,32 @@ export function createHostdbReleases(
     }
   }
 
+  // Cache for prerelease versions
+  let cachedPrerelease: Map<string, ReleaseType> | null = null
+  let prereleaseCachedAt = 0
+
+  async function fetchPrereleaseVersions(): Promise<Map<string, ReleaseType>> {
+    const now = Date.now()
+    if (cachedPrerelease && now - prereleaseCachedAt < cacheTTLMs) {
+      return cachedPrerelease
+    }
+
+    try {
+      cachedPrerelease = await getHostdbPrereleaseVersions(engine)
+      prereleaseCachedAt = Date.now()
+      return cachedPrerelease
+    } catch (error) {
+      logDebug(`Failed to fetch prerelease versions for ${displayName}`, {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return new Map()
+    }
+  }
+
   return {
     fetchAvailableVersions: getCachedVersions,
     getLatestVersion,
     fetchDeprecatedVersions,
+    fetchPrereleaseVersions,
   }
 }

--- a/core/version-migration.ts
+++ b/core/version-migration.ts
@@ -11,6 +11,7 @@ import { rm } from 'fs/promises'
 import { paths } from '../config/paths'
 import { containerManager } from './container-manager'
 import { platformService } from './platform-service'
+import { isPrereleaseVersion } from './version-utils'
 import { Engine, isFileBasedEngine, type ContainerConfig } from '../types'
 
 // Import version maps from all engines
@@ -238,12 +239,23 @@ export async function findOutdatedContainers(): Promise<OutdatedContainer[]> {
       continue
     }
 
+    // Never migrate a container that is on a prerelease. Prerelease data
+    // directories are not compatible with the GA release, so moving off (or
+    // onto) a prerelease would corrupt the data dir.
+    if (isPrereleaseVersion(container.version)) {
+      continue
+    }
+
     // Check main version
     if (!isVersionSupported(engine, container.version)) {
       const majorVersion = getMajorVersion(engine, container.version)
       if (majorVersion) {
         const targetVersion = getTargetVersion(engine, majorVersion)
-        if (targetVersion && targetVersion !== container.version) {
+        if (
+          targetVersion &&
+          targetVersion !== container.version &&
+          !isPrereleaseVersion(targetVersion)
+        ) {
           outdated.push({
             container,
             currentVersion: container.version,
@@ -256,12 +268,20 @@ export async function findOutdatedContainers(): Promise<OutdatedContainer[]> {
     }
 
     // Check FerretDB backend version
-    if (engine === Engine.FerretDB && container.backendVersion) {
+    if (
+      engine === Engine.FerretDB &&
+      container.backendVersion &&
+      !isPrereleaseVersion(container.backendVersion)
+    ) {
       if (!isDocumentDBVersionSupported(container.backendVersion)) {
         const majorVersion = getDocumentDBMajorVersion(container.backendVersion)
         if (majorVersion) {
           const targetVersion = getDocumentDBTargetVersion(majorVersion)
-          if (targetVersion && targetVersion !== container.backendVersion) {
+          if (
+            targetVersion &&
+            targetVersion !== container.backendVersion &&
+            !isPrereleaseVersion(targetVersion)
+          ) {
             outdated.push({
               container,
               currentVersion: container.backendVersion,

--- a/core/version-utils.ts
+++ b/core/version-utils.ts
@@ -76,6 +76,70 @@ export function isNewerVersion(versionA: string, versionB: string): boolean {
   return compareVersions(versionA, versionB) > 0
 }
 
+export type PrereleaseType = 'alpha' | 'beta' | 'rc'
+
+/**
+ * Parse a prerelease version string into its components.
+ *
+ * Accepts two shapes:
+ *   - hostdb canonical form: "19.0.0-beta.1" (X.Y.Z-type.N)
+ *   - upstream self-reported form: "19beta1" (X<type>N, e.g. `postgres --version`)
+ *
+ * Returns null for GA versions and any string that is not a recognised
+ * prerelease.
+ */
+export function parsePrereleaseVersion(version: string): {
+  major: number
+  type: PrereleaseType
+  num: number
+} | null {
+  const canonical = version.match(/^(\d+)(?:\.\d+)*-(alpha|beta|rc)\.(\d+)$/)
+  if (canonical) {
+    return {
+      major: parseInt(canonical[1], 10),
+      type: canonical[2] as PrereleaseType,
+      num: parseInt(canonical[3], 10),
+    }
+  }
+
+  const reported = version.match(/^(\d+)(alpha|beta|rc)(\d+)$/)
+  if (reported) {
+    return {
+      major: parseInt(reported[1], 10),
+      type: reported[2] as PrereleaseType,
+      num: parseInt(reported[3], 10),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Return true if a version string is a prerelease (alpha/beta/rc), in either
+ * the canonical "19.0.0-beta.1" or self-reported "19beta1" form.
+ */
+export function isPrereleaseVersion(version: string): boolean {
+  return parsePrereleaseVersion(version) !== null
+}
+
+/**
+ * Verify that an expected prerelease version matches a binary's self-reported
+ * version. This bridges hostdb's canonical form ("19.0.0-beta.1") and the
+ * upstream form a server reports ("19beta1").
+ *
+ * Returns false when either side is not a prerelease so GA verification is
+ * never loosened.
+ */
+export function prereleaseVersionMatches(
+  expected: string,
+  reported: string,
+): boolean {
+  const e = parsePrereleaseVersion(expected)
+  const r = parsePrereleaseVersion(reported)
+  if (!e || !r) return false
+  return e.major === r.major && e.type === r.type && e.num === r.num
+}
+
 /**
  * Regex pattern for validating semver-like version strings.
  * Matches: X, X.Y, or X.Y.Z where each component is numeric.

--- a/engines/base-engine.ts
+++ b/engines/base-engine.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types'
 import { UnsupportedOperationError } from '../core/error-handler'
 import { stopPgweb } from '../core/pgweb-utils'
+import type { ReleaseType } from 'hostdb'
 
 /**
  * Base class for database engines
@@ -264,6 +265,15 @@ export abstract class BaseEngine {
    */
   async fetchDeprecatedVersions(): Promise<Set<string>> {
     return new Set()
+  }
+
+  /**
+   * Fetch the map of prerelease version strings to their release channel
+   * (alpha/beta/rc) from hostdb. Prereleases are opt-in: they are downloadable
+   * but never the default or "latest" pick.
+   */
+  async fetchPrereleaseVersions(): Promise<Map<string, ReleaseType>> {
+    return new Map()
   }
 
   // Create a dump from a remote database using a connection string

--- a/engines/clickhouse/version-maps.ts
+++ b/engines/clickhouse/version-maps.ts
@@ -28,7 +28,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
     // ClickHouse 4-part full versions have a 3-part prefix (e.g., 25.12.3) that
     // should also resolve. Add 3-part prefix to the MAP for spindb's existing

--- a/engines/cockroachdb/version-maps.ts
+++ b/engines/cockroachdb/version-maps.ts
@@ -23,7 +23,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/couchdb/version-maps.ts
+++ b/engines/couchdb/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/duckdb/version-maps.ts
+++ b/engines/duckdb/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/ferretdb/version-maps.ts
+++ b/engines/ferretdb/version-maps.ts
@@ -31,7 +31,10 @@ function buildVersionMap(engine: string): Record<string, string> {
     const r = hostdbResolveVersion(engine, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(engine, { format: 'full' })) {
+  for (const full of listVersions(engine, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/influxdb/version-maps.ts
+++ b/engines/influxdb/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/libsql/version-maps.ts
+++ b/engines/libsql/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/mariadb/version-maps.ts
+++ b/engines/mariadb/version-maps.ts
@@ -29,7 +29,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/meilisearch/version-maps.ts
+++ b/engines/meilisearch/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/mongodb/version-maps.ts
+++ b/engines/mongodb/version-maps.ts
@@ -28,7 +28,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/mysql/version-maps.ts
+++ b/engines/mysql/version-maps.ts
@@ -32,7 +32,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/postgresql/binary-manager.ts
+++ b/engines/postgresql/binary-manager.ts
@@ -17,6 +17,7 @@ import { paths } from '../../config/paths'
 import { spawnAsync } from '../../core/spawn-utils'
 import { getBinaryUrl } from './binary-urls'
 import { normalizeVersion } from './version-maps'
+import { prereleaseVersionMatches } from '../../core/version-utils'
 import { Engine, Platform, type Arch } from '../../types'
 
 class PostgreSQLBinaryManager extends BaseServerBinaryManager {
@@ -40,8 +41,11 @@ class PostgreSQLBinaryManager extends BaseServerBinaryManager {
   }
 
   protected parseVersionFromOutput(stdout: string): string | null {
-    // Extract version from output like "postgres (PostgreSQL) 18.1"
-    const match = stdout.match(/postgres \(PostgreSQL\) ([\d.]+)/)
+    // Extract version from output like "postgres (PostgreSQL) 18.1" or a
+    // prerelease like "postgres (PostgreSQL) 19beta1".
+    const match = stdout.match(
+      /postgres \(PostgreSQL\) ([\d.]+(?:(?:alpha|beta|rc)\d+)?)/,
+    )
     return match?.[1] ?? null
   }
 
@@ -102,6 +106,12 @@ class PostgreSQLBinaryManager extends BaseServerBinaryManager {
     const expectedMajorMinor = fullVersion.split('.').slice(0, 2).join('.')
     const reportedMajorMinor = reportedVersion.split('.').slice(0, 2).join('.')
     if (expectedMajorMinor === reportedMajorMinor) {
+      return true
+    }
+
+    // Prerelease binaries self-report the upstream form (e.g. "19beta1") which
+    // maps to hostdb's canonical "19.0.0-beta.1".
+    if (prereleaseVersionMatches(fullVersion, reportedVersion)) {
       return true
     }
 

--- a/engines/postgresql/index.ts
+++ b/engines/postgresql/index.ts
@@ -239,8 +239,11 @@ export class PostgreSQLEngine extends BaseEngine {
 
   async verifyBinary(binPath: string): Promise<boolean> {
     const { platform: p, arch: a } = this.getPlatformInfo()
-    // Extract version from path like "postgresql-17.7.0-darwin-arm64"
-    const match = binPath.match(/postgresql-(\d+(?:\.\d+)*)/)
+    // Extract version from path like "postgresql-17.7.0-darwin-arm64" or a
+    // prerelease path like "postgresql-19.0.0-beta.1-darwin-arm64".
+    const match = binPath.match(
+      /postgresql-(\d+(?:\.\d+)*(?:-(?:alpha|beta|rc)\.\d+)?)/,
+    )
     if (!match) {
       throw new Error(
         `Could not extract PostgreSQL version from path: ${binPath}`,

--- a/engines/postgresql/version-maps.ts
+++ b/engines/postgresql/version-maps.ts
@@ -23,7 +23,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/qdrant/version-maps.ts
+++ b/engines/qdrant/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/questdb/version-maps.ts
+++ b/engines/questdb/version-maps.ts
@@ -23,7 +23,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/redis/version-maps.ts
+++ b/engines/redis/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/sqlite/version-maps.ts
+++ b/engines/sqlite/version-maps.ts
@@ -29,7 +29,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/surrealdb/version-maps.ts
+++ b/engines/surrealdb/version-maps.ts
@@ -23,7 +23,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/tigerbeetle/version-maps.ts
+++ b/engines/tigerbeetle/version-maps.ts
@@ -27,7 +27,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/typedb/version-maps.ts
+++ b/engines/typedb/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/valkey/version-maps.ts
+++ b/engines/valkey/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/engines/weaviate/version-maps.ts
+++ b/engines/weaviate/version-maps.ts
@@ -24,7 +24,10 @@ function buildVersionMap(): Record<string, string> {
     const r = hostdbResolveVersion(ENGINE, minor)
     if (r) map[minor] = r
   }
-  for (const full of listVersions(ENGINE, { format: 'full' })) {
+  for (const full of listVersions(ENGINE, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
     map[full] = full
   }
   return map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.61.7",
+  "version": "0.62.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.34.0",
+    "hostdb": "0.35.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.34.0
-        version: 0.34.0
+        specifier: 0.35.0
+        version: 0.35.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.34.0:
-    resolution: {integrity: sha512-k9QqQlQOaDZqechBDgQ0FTbCHeSMJdeQ7WECs57s68Y3iagH4orJxsQihNFe7s+zcRc5moQXVwy3pdpEikGSTw==}
+  hostdb@0.35.0:
+    resolution: {integrity: sha512-YRhAn5d8vkCKMJqts9b0gv8mhCBtrGZNn0XE6bknX4pd3I81XQ5hbZ+gzlLM6NU4zp+yF4m6Nd7sTzIMJ384UQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.34.0: {}
+  hostdb@0.35.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/tests/unit/credential-generator.test.ts
+++ b/tests/unit/credential-generator.test.ts
@@ -2,7 +2,7 @@
  * Conformance tests for the credential generator (core/credential-generator.ts).
  *
  * These assert the shared credential spec pinned in ADR-001
- * (layerbase-architecture/decisions/001-credential-charsets.md). The same
+ * (layerbase-cloud/docs/decisions/001-credential-charsets.md). The same
  * spec is implemented and tested in layerbase-cloud (src/lib/credentials.ts +
  * its credentials conformance test); keeping equivalent assertions in both
  * repos is what stops the two security-sensitive generators from re-drifting.

--- a/tests/unit/json-output.test.ts
+++ b/tests/unit/json-output.test.ts
@@ -181,6 +181,39 @@ describe('JSON Output Validation', () => {
       if (!parsed.engines.postgresql) {
         throw new Error('engines supported --json should include postgresql')
       }
+
+      // PostgreSQL ships a prerelease (19.0.0-beta.1); it must surface via the
+      // additive prereleaseVersions map keyed by exact token -> channel.
+      const pg = parsed.engines.postgresql
+      if (
+        !pg.prereleaseVersions ||
+        pg.prereleaseVersions['19.0.0-beta.1'] !== 'beta'
+      ) {
+        throw new Error(
+          'engines supported --json postgresql should expose prereleaseVersions with 19.0.0-beta.1: beta',
+        )
+      }
+
+      // The prerelease token must NOT leak into supportedVersions (those are
+      // major-version buckets and exclude the beta major).
+      if (pg.supportedVersions.includes('19.0.0-beta.1')) {
+        throw new Error(
+          'engines supported --json postgresql supportedVersions should not include the beta token',
+        )
+      }
+
+      // Engines with no prereleases must omit the key entirely (stable shape).
+      if (
+        parsed.engines.mysql &&
+        Object.prototype.hasOwnProperty.call(
+          parsed.engines.mysql,
+          'prereleaseVersions',
+        )
+      ) {
+        throw new Error(
+          'engines supported --json mysql should omit prereleaseVersions when it has none',
+        )
+      }
     })
 
     it('spindb config show --json', () => {

--- a/tests/unit/prerelease-support.test.ts
+++ b/tests/unit/prerelease-support.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Prerelease (alpha/beta/rc) support.
+ *
+ * hostdb ships prerelease binaries (first: PostgreSQL 19.0.0-beta.1) that
+ * resolve only by their exact token. These tests lock in the wrapper, metadata,
+ * and migration-guard behavior that keeps prereleases opt-in and never GA.
+ */
+
+import { describe, it } from 'node:test'
+import {
+  POSTGRESQL_VERSION_MAP,
+  SUPPORTED_MAJOR_VERSIONS as PG_MAJORS,
+} from '../../engines/postgresql/version-maps'
+import { getPrereleaseVersions } from '../../core/hostdb-metadata'
+import {
+  getMajorVersion,
+  isVersionSupported,
+  getTargetVersion,
+} from '../../core/version-migration'
+import { isPrereleaseVersion } from '../../core/version-utils'
+import { Engine } from '../../types'
+import { assert } from '../utils/assertions'
+
+const PG_BETA = '19.0.0-beta.1'
+
+describe('prerelease wrapper inclusion (PostgreSQL)', () => {
+  it('MAP contains the exact beta token so it is creatable', () => {
+    assert(
+      POSTGRESQL_VERSION_MAP[PG_BETA] === PG_BETA,
+      `POSTGRESQL_VERSION_MAP should map ${PG_BETA} to itself`,
+    )
+  })
+
+  it('SUPPORTED_MAJOR_VERSIONS excludes the prerelease major 19', () => {
+    assert(
+      !PG_MAJORS.includes('19'),
+      "SUPPORTED_MAJOR_VERSIONS should not include '19' (prerelease-only major)",
+    )
+  })
+
+  it('no bare-major key is created for the prerelease', () => {
+    assert(
+      POSTGRESQL_VERSION_MAP['19'] === undefined,
+      "MAP should not gain a bare '19' key from the prerelease",
+    )
+  })
+})
+
+describe('getPrereleaseVersions (hostdb metadata)', () => {
+  it('returns the beta token mapped to its channel', async () => {
+    const prereleases = await getPrereleaseVersions('postgresql')
+    assert(
+      prereleases.get(PG_BETA) === 'beta',
+      `expected ${PG_BETA} -> 'beta' in prerelease map`,
+    )
+  })
+
+  it('returns an empty map for an engine with no prereleases', async () => {
+    const prereleases = await getPrereleaseVersions('mysql')
+    assert(prereleases.size === 0, 'mysql should have no prereleases')
+  })
+})
+
+describe('migration guard decision inputs', () => {
+  it('a prerelease is detected as such', () => {
+    assert(isPrereleaseVersion(PG_BETA) === true, 'beta token is a prerelease')
+  })
+
+  it('the prerelease major is not a supported migration major', () => {
+    assert(
+      getMajorVersion(Engine.PostgreSQL, PG_BETA) === null,
+      'beta major 19 is not a supported migration target major',
+    )
+  })
+
+  it('the prerelease token counts as supported (identity map), so it is not flagged outdated', () => {
+    assert(
+      isVersionSupported(Engine.PostgreSQL, PG_BETA) === true,
+      'beta token should be a supported value in the map',
+    )
+  })
+
+  it('no GA target exists for the prerelease major', () => {
+    assert(
+      getTargetVersion(Engine.PostgreSQL, '19') === null,
+      "there is no GA target for major '19'",
+    )
+  })
+})

--- a/tests/unit/version-utils.test.ts
+++ b/tests/unit/version-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it } from 'node:test'
-import { isShorthandVersion } from '../../core/version-utils'
+import {
+  isShorthandVersion,
+  parsePrereleaseVersion,
+  isPrereleaseVersion,
+  prereleaseVersionMatches,
+  compareVersions,
+} from '../../core/version-utils'
 import { assert } from '../utils/assertions'
 
 describe('isShorthandVersion', () => {
@@ -74,5 +80,104 @@ describe('isShorthandVersion', () => {
         "'unknown' should not be flagged — caller treats it specially",
       )
     })
+  })
+})
+
+describe('parsePrereleaseVersion', () => {
+  it('parses hostdb canonical form', () => {
+    const parsed = parsePrereleaseVersion('19.0.0-beta.1')
+    assert(parsed !== null, 'should parse canonical form')
+    assert(parsed?.major === 19, 'major should be 19')
+    assert(parsed?.type === 'beta', 'type should be beta')
+    assert(parsed?.num === 1, 'num should be 1')
+  })
+
+  it('parses upstream self-reported form', () => {
+    const parsed = parsePrereleaseVersion('19beta1')
+    assert(parsed !== null, 'should parse reported form')
+    assert(parsed?.major === 19, 'major should be 19')
+    assert(parsed?.type === 'beta', 'type should be beta')
+    assert(parsed?.num === 1, 'num should be 1')
+  })
+
+  it('parses rc and alpha channels', () => {
+    assert(
+      parsePrereleaseVersion('17.0.0-rc.2')?.type === 'rc',
+      'rc channel parsed',
+    )
+    assert(
+      parsePrereleaseVersion('17alpha3')?.type === 'alpha',
+      'alpha channel parsed',
+    )
+  })
+
+  it('returns null for GA versions', () => {
+    assert(parsePrereleaseVersion('18.4.0') === null, 'GA is not a prerelease')
+    assert(parsePrereleaseVersion('19') === null, 'bare major is not prerelease')
+    assert(parsePrereleaseVersion('') === null, 'empty string is not prerelease')
+  })
+})
+
+describe('isPrereleaseVersion', () => {
+  it('is true for prerelease forms', () => {
+    assert(isPrereleaseVersion('19.0.0-beta.1') === true, 'canonical beta')
+    assert(isPrereleaseVersion('19beta1') === true, 'reported beta')
+  })
+
+  it('is false for GA', () => {
+    assert(isPrereleaseVersion('18.4.0') === false, 'GA release')
+  })
+})
+
+describe('prereleaseVersionMatches', () => {
+  it('matches canonical expected against self-reported', () => {
+    assert(
+      prereleaseVersionMatches('19.0.0-beta.1', '19beta1') === true,
+      'expected 19.0.0-beta.1 should accept reported 19beta1',
+    )
+  })
+
+  it('does not match a different channel or number', () => {
+    assert(
+      prereleaseVersionMatches('19.0.0-beta.1', '19beta2') === false,
+      'different prerelease number should not match',
+    )
+    assert(
+      prereleaseVersionMatches('19.0.0-beta.1', '19rc1') === false,
+      'different channel should not match',
+    )
+  })
+
+  it('never matches when either side is GA (does not loosen GA verify)', () => {
+    assert(
+      prereleaseVersionMatches('19.0.0', '19') === false,
+      'GA expected should not match via prerelease path',
+    )
+    assert(
+      prereleaseVersionMatches('19.0.0-beta.1', '19') === false,
+      'GA reported should not match a prerelease expectation',
+    )
+  })
+})
+
+describe('compareVersions prerelease ordering', () => {
+  it('sorts a prerelease below its GA release', () => {
+    assert(
+      compareVersions('19.0.0', '19.0.0-beta.2') > 0,
+      'GA should be greater than beta of same version',
+    )
+    assert(
+      compareVersions('19.0.0-beta.2', '19.0.0') < 0,
+      'beta should be less than GA of same version',
+    )
+  })
+
+  it('descending sort places GA first, then prereleases newest-first', () => {
+    const sorted = ['19.0.0-beta.1', '19.0.0', '18.4.0'].sort((a, b) =>
+      compareVersions(b, a),
+    )
+    assert(sorted[0] === '19.0.0', 'GA 19.0.0 should sort first')
+    assert(sorted[1] === '19.0.0-beta.1', 'beta should follow its GA')
+    assert(sorted[2] === '18.4.0', 'older GA last')
   })
 })


### PR DESCRIPTION
## Release 0.62.0

- PostgreSQL 19.0.0-beta.1 prerelease support (hostdb 0.35.0 pin) - see #259
- Exact-token-only prerelease resolution, beta tag in the version picker, non-blocking create warning
- Prerelease-aware binary verification, installed-binary ordering, and migration guard
- Additive `prereleaseVersions` field in `spindb engines supported --json`

Verification on the feature PR: 1684 unit / 23 live-sync / 54 e2e, all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL alpha, beta, and release-candidate versions.
  * Prerelease versions can be selected interactively and are clearly labeled.
  * `engines supported --json` now reports available prerelease versions and channels.
* **Bug Fixes**
  * Improved prerelease binary verification and version ordering.
  * Prevented automatic migrations between prerelease and general-availability versions.
* **Chores**
  * Updated the release to version 0.62.0 and refreshed bundled version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->