### PR TITLE
fix: prerelease review findings

### DIFF
--- a/cli/commands/create.ts
+++ b/cli/commands/create.ts
@@ -23,7 +23,11 @@ import {
 import { platformService } from '../../core/platform-service'
 import { startWithRetry } from '../../core/start-with-retry'
 import { TransactionManager } from '../../core/transaction-manager'
-import { isValidDatabaseName, exitWithError } from '../../core/error-handler'
+import {
+  isValidDatabaseName,
+  exitWithError,
+  logWarning,
+} from '../../core/error-handler'
 import { resolve } from 'path'
 import { Engine, Platform, ALL_ENGINES } from '../../types'
 import { canCreateDatabase } from '../../core/database-capabilities'
@@ -655,21 +659,19 @@ export const createCommand = new Command('create')
         }
         version = resolvedVersion
 
-        // Warn (non-blocking) when the user opts into a prerelease. Printed to
-        // stderr via console.warn so it is visible in --json mode without
-        // corrupting the JSON on stdout.
+        // Warn (non-blocking) when the user opts into a prerelease. Omitted in
+        // --json mode so machine-readable output stays clean; JSON consumers can
+        // detect prereleases from the resolved version token instead.
         const releaseChannel = getHostdbReleaseType(dbEngine.name, version)
-        if (releaseChannel && releaseChannel !== 'ga') {
+        if (releaseChannel && releaseChannel !== 'ga' && !options.json) {
           const channelLabel =
             releaseChannel === 'rc'
               ? 'release candidate'
               : releaseChannel === 'alpha'
                 ? 'an alpha release'
                 : 'a beta release'
-          console.warn(
-            chalk.yellow(
-              `${dbEngine.displayName} ${version} is ${releaseChannel === 'rc' ? 'a ' : ''}${channelLabel}. Not recommended for production; data directories are not compatible with the GA release.`,
-            ),
+          logWarning(
+            `${dbEngine.displayName} ${version} is ${releaseChannel === 'rc' ? 'a ' : ''}${channelLabel}. Not recommended for production; data directories are not compatible with the GA release.`,
           )
         }
 

--- a/engines/clickhouse/version-maps.ts
+++ b/engines/clickhouse/version-maps.ts
@@ -9,33 +9,21 @@
  * is 2-part to preserve that convention; '25' still resolves via the MAP.
  */
 
-import {
-  resolveVersion as hostdbResolveVersion,
-  getSupportedMajorVersions,
-  listVersions,
-} from 'hostdb'
+import { resolveVersion as hostdbResolveVersion, listVersions } from 'hostdb'
+import { buildVersionMap as buildBaseVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'clickhouse'
 
 function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
+  const map = buildBaseVersionMap(ENGINE)
+  // ClickHouse 4-part full versions have a 3-part prefix (e.g., 25.12.3) that
+  // should also resolve. Add 3-part prefix to the MAP for spindb's existing
+  // identity-match call paths.
   for (const full of listVersions(ENGINE, {
     format: 'full',
     includePrerelease: true,
   })) {
-    map[full] = full
-    // ClickHouse 4-part full versions have a 3-part prefix (e.g., 25.12.3) that
-    // should also resolve. Add 3-part prefix to the MAP for spindb's existing
-    // identity-match call paths.
     const parts = full.split('.')
     if (parts.length === 4) {
       const threePartPrefix = `${parts[0]}.${parts[1]}.${parts[2]}`

--- a/engines/cockroachdb/version-maps.ts
+++ b/engines/cockroachdb/version-maps.ts
@@ -8,31 +8,12 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'cockroachdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const COCKROACHDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const COCKROACHDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/couchdb/version-maps.ts
+++ b/engines/couchdb/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'couchdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const COUCHDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const COUCHDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/duckdb/version-maps.ts
+++ b/engines/duckdb/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'duckdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const DUCKDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const DUCKDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/ferretdb/version-maps.ts
+++ b/engines/ferretdb/version-maps.ts
@@ -14,31 +14,12 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'ferretdb'
 const DOCUMENTDB_ENGINE = 'postgresql-documentdb'
-
-function buildVersionMap(engine: string): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(engine)) {
-    const r = hostdbResolveVersion(engine, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(engine, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(engine, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(engine, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
 
 export const FERRETDB_VERSION_MAP: Record<string, string> =
   buildVersionMap(ENGINE)

--- a/engines/influxdb/version-maps.ts
+++ b/engines/influxdb/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'influxdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const INFLUXDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const INFLUXDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/libsql/version-maps.ts
+++ b/engines/libsql/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'libsql'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const LIBSQL_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const LIBSQL_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/mariadb/version-maps.ts
+++ b/engines/mariadb/version-maps.ts
@@ -12,33 +12,14 @@
 
 import {
   resolveVersion as hostdbResolveVersion,
-  getSupportedMajorVersions,
   listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'mariadb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const MARIADB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const MARIADB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/meilisearch/version-maps.ts
+++ b/engines/meilisearch/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'meilisearch'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const MEILISEARCH_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const MEILISEARCH_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/mongodb/version-maps.ts
+++ b/engines/mongodb/version-maps.ts
@@ -11,33 +11,14 @@
 
 import {
   resolveVersion as hostdbResolveVersion,
-  getSupportedMajorVersions,
   listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'mongodb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const MONGODB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const MONGODB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/mysql/version-maps.ts
+++ b/engines/mysql/version-maps.ts
@@ -15,33 +15,14 @@
 
 import {
   resolveVersion as hostdbResolveVersion,
-  getSupportedMajorVersions,
   listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'mysql'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const MYSQL_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const MYSQL_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/postgresql/version-maps.ts
+++ b/engines/postgresql/version-maps.ts
@@ -8,31 +8,12 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'postgresql'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const POSTGRESQL_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const POSTGRESQL_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/qdrant/version-maps.ts
+++ b/engines/qdrant/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'qdrant'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const QDRANT_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const QDRANT_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/questdb/version-maps.ts
+++ b/engines/questdb/version-maps.ts
@@ -8,31 +8,12 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'questdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const QUESTDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const QUESTDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/redis/version-maps.ts
+++ b/engines/redis/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'redis'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const REDIS_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const REDIS_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/sqlite/version-maps.ts
+++ b/engines/sqlite/version-maps.ts
@@ -13,32 +13,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'sqlite'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const SQLITE_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const SQLITE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/surrealdb/version-maps.ts
+++ b/engines/surrealdb/version-maps.ts
@@ -8,31 +8,12 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'surrealdb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const SURREALDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const SURREALDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/tigerbeetle/version-maps.ts
+++ b/engines/tigerbeetle/version-maps.ts
@@ -10,33 +10,14 @@
 
 import {
   resolveVersion as hostdbResolveVersion,
-  getSupportedMajorVersions,
   listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'tigerbeetle'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const TIGERBEETLE_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const TIGERBEETLE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/typedb/version-maps.ts
+++ b/engines/typedb/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'typedb'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const TYPEDB_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const TYPEDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/valkey/version-maps.ts
+++ b/engines/valkey/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'valkey'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const VALKEY_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const VALKEY_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/version-map-builder.ts
+++ b/engines/version-map-builder.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared version-map builder for the per-engine `hostdb` wrappers.
+ *
+ * Every engine's version-maps module builds an identical MAP from hostdb: bare
+ * majors, major-minor keys (for engines that expose them), and full versions
+ * (including prereleases) mapped to themselves. Centralizing it here keeps the
+ * 20+ wrappers in sync when the shape changes (e.g., the prerelease rollout).
+ *
+ * Engines with extra keys (ClickHouse adds 3-part prefixes for its 4-part
+ * versions) call this and then augment the returned map.
+ */
+
+import {
+  resolveVersion as hostdbResolveVersion,
+  getSupportedMajorVersions,
+  listVersions,
+} from 'hostdb'
+
+export function buildVersionMap(engine: string): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const major of getSupportedMajorVersions(engine)) {
+    const r = hostdbResolveVersion(engine, major)
+    if (r) map[major] = r
+  }
+  for (const minor of listVersions(engine, { format: 'major-minor' })) {
+    const r = hostdbResolveVersion(engine, minor)
+    if (r) map[minor] = r
+  }
+  for (const full of listVersions(engine, {
+    format: 'full',
+    includePrerelease: true,
+  })) {
+    map[full] = full
+  }
+  return map
+}

--- a/engines/weaviate/version-maps.ts
+++ b/engines/weaviate/version-maps.ts
@@ -8,32 +8,13 @@
 import {
   resolveVersion as hostdbResolveVersion,
   getSupportedMajorVersions,
-  listVersions,
 } from 'hostdb'
+import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'weaviate'
 
-function buildVersionMap(): Record<string, string> {
-  const map: Record<string, string> = {}
-  for (const major of getSupportedMajorVersions(ENGINE)) {
-    const r = hostdbResolveVersion(ENGINE, major)
-    if (r) map[major] = r
-  }
-  for (const minor of listVersions(ENGINE, { format: 'major-minor' })) {
-    const r = hostdbResolveVersion(ENGINE, minor)
-    if (r) map[minor] = r
-  }
-  for (const full of listVersions(ENGINE, {
-    format: 'full',
-    includePrerelease: true,
-  })) {
-    map[full] = full
-  }
-  return map
-}
-
-export const WEAVIATE_VERSION_MAP: Record<string, string> = buildVersionMap()
+export const WEAVIATE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 


### PR DESCRIPTION
Addresses review findings on #259:

- create.ts: prerelease warning now guarded by `!options.json` and routed through `logWarning()` (the finding suggested `logDebug()`, but that writes only to the log file and would have silently dropped the warning for interactive users; `logWarning` is the codebase's user-facing warning mechanism). Text unchanged.
- Extracted the 21 duplicated `buildVersionMap` implementations into shared `engines/version-map-builder.ts`. ferretdb keeps its two parameterized calls; clickhouse keeps a thin wrapper for its 3-part-prefix keys. Before/after comparison of all 26 version maps + SUPPORTED_MAJOR_VERSIONS: identical.

Skipped (verified stale):
- engines.ts prereleaseVersions loop: it uses the hostdb package's `getPrereleaseVersions(engine): string[]` (not the metadata Map variant), so the per-version release-type lookup is required, not redundant.
- prerelease-support tests: already deterministic; they read the hostdb snapshot bundled in node_modules, no network involved (matches hostdb-metadata.test.ts).

Validation: typecheck, lint, build clean; unit 1684/1684.