### PR TITLE
docs: add Layerbase sponsor banner to README (0.62.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.1] - 2026-07-13
+
+### Documentation
+
+- Add a "Sponsored by Layerbase" banner to the README, with the Layerbase icon
+  vendored to `assets/` and a link to [layerbase.com](https://layerbase.com).
+
 ## [0.62.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # SpinDB
 
+<p align="center">
+  <a href="https://layerbase.com">
+    <img src="assets/layerbase-icon.svg" alt="Layerbase" width="20" height="20" align="top" />
+    Sponsored by <strong>Layerbase</strong>
+  </a>
+</p>
+
 [![npm version](https://img.shields.io/npm/v/spindb.svg)](https://www.npmjs.com/package/spindb)
 [![npm downloads](https://img.shields.io/npm/dm/spindb.svg)](https://www.npmjs.com/package/spindb)
 [![License: PolyForm Noncommercial](https://img.shields.io/badge/License-PolyForm%20Noncommercial-blue.svg)](LICENSE)

--- a/assets/layerbase-icon.svg
+++ b/assets/layerbase-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M14,40 C14,22 24,14 38,14 C48,14 56,18 58,26 C60,32 58,38 52,40" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <circle cx="48" cy="22" r="3.5" fill="none" stroke="#3FBFB0" stroke-width="3.5"/>
+  <path d="M14,40 C8,40 4,44 6,48 C8,52 14,52 14,48 C14,46 12,44 10,46" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M22,48 C22,42 24,40 26,42 C28,44 28,48 28,48" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M40,46 C40,40 42,38 44,40 C46,42 46,46 46,46" fill="none" stroke="#3FBFB0" stroke-width="3.5" stroke-linecap="round"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
Adds a 'Sponsored by Layerbase' banner under the README title, linking to https://layerbase.com, with the Layerbase chameleon icon vendored to `assets/layerbase-icon.svg` for reliable GitHub/npm rendering.

Bumps version to 0.62.1 and adds a changelog entry.

Note: GitHub sanitizes README links to `rel="nofollow"`, so this is visibility/click-through only — no SEO backlink value.