### PR TITLE
release: spindb 0.62.2 (hostdb 0.36.0 / DuckDB 1.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.2] - 2026-07-24
+
+### Changed
+
+- **Pin `hostdb` to `0.36.0`** (was 0.35.0). Adds **DuckDB 1.5.5** and makes it
+  the default for the `1` major: `defaults["1"]` now resolves to 1.5.5, so a bare
+  `spindb create duckdb` (or `--db-version 1`) provisions 1.5.5 instead of 1.4.4.
+  The 1.4 line stays fully supported (`1.4` still resolves to `1.4.4`), and
+  existing containers self-pin their stored full version, so nothing on 1.4 is
+  disturbed. The bundled snapshot matches the live registry, so the hostdb-sync
+  integration test stays green.
+
 ## [0.62.1] - 2026-07-13
 
 ### Documentation

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.0'
+export const VERSION = '0.62.2'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.35.0",
+    "hostdb": "0.36.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.35.0
-        version: 0.35.0
+        specifier: 0.36.0
+        version: 0.36.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.35.0:
-    resolution: {integrity: sha512-YRhAn5d8vkCKMJqts9b0gv8mhCBtrGZNn0XE6bknX4pd3I81XQ5hbZ+gzlLM6NU4zp+yF4m6Nd7sTzIMJ384UQ==}
+  hostdb@0.36.0:
+    resolution: {integrity: sha512-/p6IKzueKVS0i3N+J/wm3mXXFuyr6n5v8bXTgTArsyB/1DIDPlN56Q4ft4ENhqnls85MmehZJHbc75fRFyabpg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.35.0: {}
+  hostdb@0.36.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
spindb 0.62.2 dev->main release.

- **Pin hostdb 0.35.0 -> 0.36.0**, which adds **DuckDB 1.5.5** and shifts the major-1 default to 1.5.5 (`spindb create duckdb` now provisions 1.5.5). The 1.4 line stays supported (`1.4` -> `1.4.4`); existing containers self-pin their stored version and are undisturbed.
- Version-maps auto-rebuilt from the new bundled snapshot (no manual MAP edits). Tests: hostdb-sync 23, unit 1684, cli 54 - all green.

Merging this to main auto-publishes spindb 0.62.2 to npm, which unblocks the cloud image + desktop pin bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DuckDB 1.5.5.
  * Bare DuckDB major-version selection now provisions DuckDB 1.5.5 by default.
  * DuckDB 1.4 continues to resolve to version 1.4.4, while existing containers retain their stored versions.

* **Chores**
  * Released version 0.62.2.
  * Updated release documentation to reflect the new DuckDB version behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->