### PR TITLE
release: SpinDB 0.62.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.3] - 2026-07-24
+
+### Fixed
+
+- **File-based creates now honor the exact requested binary version.** DuckDB
+  and SQLite creation ensure the resolved version before checking tools, and
+  versioned binary lookup no longer accepts a differently versioned cached
+  executable. This prevents a request for DuckDB 1.5.5 from recording 1.5.5
+  metadata while silently running a cached DuckDB 1.4.x binary.
+
 ## [0.62.2] - 2026-07-24
 
 ### Changed

--- a/cli/commands/create.ts
+++ b/cli/commands/create.ts
@@ -39,6 +39,36 @@ import {
 import type { BaseEngine } from '../../engines/base-engine'
 import { getEngineMetadata } from '../helpers'
 
+async function ensureFileBasedBinaries(
+  dbEngine: BaseEngine,
+  version: string,
+  json?: boolean,
+): Promise<void> {
+  const binarySpinner = json
+    ? null
+    : createSpinner(`Checking ${dbEngine.displayName} ${version} binaries...`)
+  binarySpinner?.start()
+
+  try {
+    await dbEngine.ensureBinaries(version, ({ stage, message }) => {
+      if (binarySpinner) {
+        binarySpinner.text =
+          stage === 'cached'
+            ? `${dbEngine.displayName} ${version} binaries ready (cached)`
+            : message
+      }
+    })
+    binarySpinner?.succeed(`${dbEngine.displayName} ${version} binaries ready`)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    binarySpinner?.fail(`${dbEngine.displayName} ${version} not available`)
+    return exitWithError({
+      message: `${dbEngine.displayName} ${version} not available: ${detail}`,
+      json,
+    })
+  }
+}
+
 /**
  * Simplified SQLite container creation flow
  * SQLite is file-based, so no port, start/stop, or server management needed
@@ -62,6 +92,10 @@ async function createSqliteContainer(
     force,
     json,
   } = options
+
+  // File-based engines bypass the common server create flow, so ensure the
+  // exact requested binary version here before the generic dependency check.
+  await ensureFileBasedBinaries(dbEngine, version, json)
 
   // Check dependencies
   const depsSpinner = json ? null : createSpinner('Checking required tools...')
@@ -233,6 +267,10 @@ async function createDuckDBContainer(
     force,
     json,
   } = options
+
+  // File-based engines bypass the common server create flow, so ensure the
+  // exact requested binary version here before the generic dependency check.
+  await ensureFileBasedBinaries(dbEngine, version, json)
 
   // Check dependencies
   const depsSpinner = json ? null : createSpinner('Checking required tools...')

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.2'
+export const VERSION = '0.62.3'

--- a/engines/duckdb/index.ts
+++ b/engines/duckdb/index.ts
@@ -99,15 +99,9 @@ export class DuckDBEngine extends BaseEngine {
     return binPath
   }
 
-  // Get path to duckdb binary - checks downloaded binary first
+  // Get path to duckdb binary. Versioned operations must use the exact
+  // requested install and must never fall back to a different cached version.
   override async getDuckDBPath(version?: string): Promise<string | null> {
-    // Check config manager first (cached path from downloaded binaries)
-    const configPath = await configManager.getBinaryPath('duckdb')
-    if (configPath && existsSync(configPath)) {
-      return configPath
-    }
-
-    // If version provided, check downloaded binary path directly
     if (version) {
       const { platform, arch } = platformService.getPlatformInfo()
       const fullVersion = normalizeVersion(version)
@@ -122,6 +116,14 @@ export class DuckDBEngine extends BaseEngine {
       if (existsSync(duckdbPath)) {
         return duckdbPath
       }
+
+      return null
+    }
+
+    // Versionless operations retain the most recently registered binary.
+    const configPath = await configManager.getBinaryPath('duckdb')
+    if (configPath && existsSync(configPath)) {
+      return configPath
     }
 
     // Not found - require download

--- a/engines/sqlite/index.ts
+++ b/engines/sqlite/index.ts
@@ -105,15 +105,9 @@ export class SQLiteEngine extends BaseEngine {
     return binPath
   }
 
-  // Get path to sqlite3 binary - checks downloaded binary first
+  // Get path to sqlite3 binary. Versioned operations must use the exact
+  // requested install and must never fall back to a different cached version.
   override async getSqlite3Path(version?: string): Promise<string | null> {
-    // Check config manager first (cached path from downloaded binaries)
-    const configPath = await configManager.getBinaryPath('sqlite3')
-    if (configPath && existsSync(configPath)) {
-      return configPath
-    }
-
-    // If version provided, check downloaded binary path directly
     if (version) {
       const { platform, arch } = platformService.getPlatformInfo()
       const fullVersion = normalizeVersion(version)
@@ -128,6 +122,14 @@ export class SQLiteEngine extends BaseEngine {
       if (existsSync(sqlite3Path)) {
         return sqlite3Path
       }
+
+      return null
+    }
+
+    // Versionless operations retain the most recently registered binary.
+    const configPath = await configManager.getBinaryPath('sqlite3')
+    if (configPath && existsSync(configPath)) {
+      return configPath
     }
 
     // Not found - require download

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.2",
+  "version": "0.62.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/file-based-binary-resolution.test.ts
+++ b/tests/unit/file-based-binary-resolution.test.ts
@@ -1,0 +1,127 @@
+import { after, afterEach, before, describe, it, mock } from 'node:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { paths } from '../../config/paths'
+import { configManager } from '../../core/config-manager'
+import { platformService } from '../../core/platform-service'
+import { DuckDBEngine } from '../../engines/duckdb/index'
+import { SQLiteEngine } from '../../engines/sqlite/index'
+import { assertEqual, assertNullish } from '../utils/assertions'
+
+describe('file-based binary version resolution', () => {
+  let tempRoot: string
+
+  before(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'spindb-file-binary-test-'))
+  })
+
+  after(async () => {
+    await rm(tempRoot, { recursive: true, force: true })
+  })
+
+  afterEach(async () => {
+    mock.restoreAll()
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = await mkdtemp(join(tmpdir(), 'spindb-file-binary-test-'))
+  })
+
+  async function createBinary(
+    installName: string,
+    executableName: string,
+  ): Promise<{ installPath: string; executablePath: string }> {
+    const installPath = join(tempRoot, installName)
+    const executablePath = join(
+      installPath,
+      'bin',
+      `${executableName}${platformService.getExecutableExtension()}`,
+    )
+    await mkdir(join(installPath, 'bin'), { recursive: true })
+    await writeFile(executablePath, 'test binary')
+    return { installPath, executablePath }
+  }
+
+  it('uses the exact requested DuckDB install instead of a stale cached path', async () => {
+    const stale = await createBinary('duckdb-1.4.3', 'duckdb')
+    const requested = await createBinary('duckdb-1.5.5', 'duckdb')
+
+    mock.method(
+      configManager,
+      'getBinaryPath',
+      async () => stale.executablePath,
+    )
+    mock.method(paths, 'getBinaryPath', () => requested.installPath)
+
+    const engine = new DuckDBEngine()
+    assertEqual(
+      await engine.getDuckDBPath('1.5'),
+      requested.executablePath,
+      'Versioned lookup should use the requested DuckDB install',
+    )
+    assertEqual(
+      await engine.getDuckDBPath(),
+      stale.executablePath,
+      'Versionless lookup should preserve the cached-path behavior',
+    )
+  })
+
+  it('does not satisfy a missing DuckDB version with a stale cached path', async () => {
+    const stale = await createBinary('duckdb-1.4.3', 'duckdb')
+    const missingInstall = join(tempRoot, 'duckdb-1.5.5-missing')
+
+    mock.method(
+      configManager,
+      'getBinaryPath',
+      async () => stale.executablePath,
+    )
+    mock.method(paths, 'getBinaryPath', () => missingInstall)
+
+    const engine = new DuckDBEngine()
+    assertNullish(
+      await engine.getDuckDBPath('1.5'),
+      'Missing requested DuckDB version should return null',
+    )
+  })
+
+  it('uses the exact requested SQLite install instead of a stale cached path', async () => {
+    const stale = await createBinary('sqlite-3.49.0', 'sqlite3')
+    const requested = await createBinary('sqlite-3.51.2', 'sqlite3')
+
+    mock.method(
+      configManager,
+      'getBinaryPath',
+      async () => stale.executablePath,
+    )
+    mock.method(paths, 'getBinaryPath', () => requested.installPath)
+
+    const engine = new SQLiteEngine()
+    assertEqual(
+      await engine.getSqlite3Path('3'),
+      requested.executablePath,
+      'Versioned lookup should use the requested SQLite install',
+    )
+    assertEqual(
+      await engine.getSqlite3Path(),
+      stale.executablePath,
+      'Versionless lookup should preserve the cached-path behavior',
+    )
+  })
+
+  it('does not satisfy a missing SQLite version with a stale cached path', async () => {
+    const stale = await createBinary('sqlite-3.49.0', 'sqlite3')
+    const missingInstall = join(tempRoot, 'sqlite-3.51.2-missing')
+
+    mock.method(
+      configManager,
+      'getBinaryPath',
+      async () => stale.executablePath,
+    )
+    mock.method(paths, 'getBinaryPath', () => missingInstall)
+
+    const engine = new SQLiteEngine()
+    assertNullish(
+      await engine.getSqlite3Path('3'),
+      'Missing requested SQLite version should return null',
+    )
+  })
+})


### PR DESCRIPTION
## Release

Publish SpinDB 0.62.3.

## Fix

File-based creation now ensures the exact requested DuckDB or SQLite binary and versioned lookup cannot fall back to a differently versioned global cache entry.

This fixes the reproduced case where `spindb create --db-version 1.5` recorded DuckDB 1.5.5 metadata but ran a cached DuckDB 1.4.3 executable.

## Verification

- local unit suite: 1,688 passing
- local lint and typecheck: passing
- DuckDB integration: 9 passing
- SQLite integration: 11 passing
- real stale-cache acceptance test: `SELECT version()` returned `v1.5.5`
- npm package build and dry run: passing
- PR #265 GitHub Actions: lint/typecheck, unit tests, and Docker export all passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-based SQLite and DuckDB creations now use the exact requested binary version.
  * Prevented stale cached binaries from being used when they do not match the requested version.
  * Improved error handling when the requested database binary is unavailable.

* **Tests**
  * Added coverage for version-specific and fallback binary resolution.

* **Chores**
  * Updated the application version to 0.62.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->