### PR TITLE
chore(deps): bump hostdb 0.36.0 -> 0.38.2 (engine security wave) (0.62.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.4] - 2026-08-06
+
+### Changed
+
+- **Pin `hostdb` to `0.38.2`** (was 0.36.0). Picks up the QuestDB bump from
+  hostdb 0.37.0 and the thirteen-engine security + feature wave from hostdb
+  0.38.0, plus the 0.38.1 metadata republish and the 0.38.2 QuestDB JRE fix.
+  Nineteen new engine versions across thirteen engines; no version was removed,
+  every prior version still resolves, and existing containers self-pin their
+  stored full version, so nothing running is disturbed. The version-map wrappers
+  rebuild from hostdb's bundled snapshot at load time, so no MAP edits were
+  needed.
+
+  **Pin `0.38.2`, never `0.38.0` or `0.38.1`.** Two earlier releases of this
+  wave are unsafe to pin. `0.38.0` published to npm while four release workflows
+  were still building, so its bundled `releases.json` snapshot is missing
+  `valkey 9.0.5`, `redis 8.4.5`, `influxdb 3.10.5` and `mariadb 11.8.8`; on that
+  snapshot `getReleaseInfo` returns null for those four and the binaries cannot
+  be downloaded even though they are on R2. `0.38.1` fixed the snapshot but
+  still bundled an Adoptium Temurin **21** JRE with QuestDB 9.4.3 on
+  darwin-arm64, darwin-x64 and linux-arm64, which cannot start it (see below).
+  `0.38.2` is the first release of this wave that is correct on both counts.
+
+  **Security fixes in this wave:**
+  - **Valkey 9.0.5 and 8.0.10** - `CVE-2026-56684` (TLS use-after-free reachable
+    by an authenticated client via `CLIENT KILL`) and `CVE-2026-63639` (corrupt
+    stream RDB sharing a NACK across consumers, leading to RCE).
+  - **Redis 7.2.15, 8.4.5 and 7.4.10** - `CVE-2026-66373` (a crafted stream
+    `RESTORE` payload makes two consumers share a NACK, a use-after-free leading
+    to RCE). 7.2.15 stays BSD-3-Clause, so the managed-service-safe line takes
+    the fix without a license change.
+  - **MongoDB 8.0.28, 8.2.12 and 7.0.39** - the July 2026 MongoDB security
+    batch, including `CVE-2026-13072` and `CVE-2026-13074`.
+  - **MySQL 8.4.11 and 9.7.2** - the July 2026 Oracle Critical Patch Update for
+    the MySQL Server tree, including `CVE-2026-60311`.
+  - **MariaDB 11.8.8** - `CVE-2026-44171`.
+
+  **Also new:** QuestDB 9.4.3, TypeDB 3.12.1, Meilisearch 1.52.0, Qdrant 1.18.3,
+  Weaviate 1.38.8, InfluxDB 3.10.5, SQLite 3.53.4, CouchDB 3.5.2.
+
+  **Default patches shifted** so a bare major resolves to the fixed or newest
+  patch: valkey `'9'` 9.0.4 to 9.0.5 and `'8'` 8.0.9 to 8.0.10; redis `'7'`
+  7.2.14 to 7.2.15 and `'8'` 8.4.0 to 8.4.5; mongodb `'8'` 8.0.23 to 8.0.28 and
+  `'7'` 7.0.34 to 7.0.39 (`'8'` deliberately stays on the 8.0 LTS line and is
+  NOT pointed at 8.2.x); mysql `'8'` 8.4.9 to 8.4.11 and `'9'` 9.6.0 to 9.7.2;
+  mariadb `'11'` 11.8.6 to 11.8.8 (the 10.11 line is untouched); questdb `'9'`
+  9.2.3 to 9.4.3; typedb `'3'` 3.12.0 to 3.12.1; meilisearch `'1'` 1.43.1 to
+  1.52.0; qdrant `'1'` 1.16.3 to 1.18.3; weaviate `'1'` 1.35.7 to 1.38.8;
+  influxdb `'3'` 3.8.0 to 3.10.5; sqlite `'3'` 3.53.1 to 3.53.4; couchdb `'3'`
+  3.5.1 to 3.5.2.
+
+  The bundled snapshot matches the live registry, so the hostdb-sync integration
+  test stays green.
+
+### Fixed
+
+- **QuestDB 9.4.3 now starts on darwin-arm64, darwin-x64 and linux-arm64**
+  (via the hostdb 0.38.2 JRE fix). QuestDB 9.4.3's own `questdb.sh` launcher
+  passes `--sun-misc-unsafe-memory-access=allow`, a flag that only exists on
+  JDK 24 and newer, but hostdb 0.38.0/0.38.1 bundled an Adoptium Temurin **21**
+  JRE for exactly those three platforms. The JVM refused the option and exited
+  with `Unrecognized option: --sun-misc-unsafe-memory-access=allow` /
+  `Could not create the Java Virtual Machine`, so a bare `spindb create questdb`
+  would have failed on macOS the moment 9.4.3 became the default for major `9`.
+  hostdb 0.38.2 bundles a JDK 25 JRE on those platforms. `linux-x64` and
+  `win32-x64` use QuestDB's official `-rt-` runtime bundles, which always
+  carried a correct JRE, and were never affected.
+
 ## [0.62.3] - 2026-07-24
 
 ### Fixed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.3'
+export const VERSION = '0.62.4'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.3",
+  "version": "0.62.4",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.36.0",
+    "hostdb": "0.38.2",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.36.0
-        version: 0.36.0
+        specifier: 0.38.2
+        version: 0.38.2
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.36.0:
-    resolution: {integrity: sha512-/p6IKzueKVS0i3N+J/wm3mXXFuyr6n5v8bXTgTArsyB/1DIDPlN56Q4ft4ENhqnls85MmehZJHbc75fRFyabpg==}
+  hostdb@0.38.2:
+    resolution: {integrity: sha512-YnegfGDhDgsoaRNCWfCR5jnGS5GiXE8tOfeXdx95byGjXGZheh9QXjL+NC27TFYdMLks+vcEY1ZJxzdvt5MhHA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.36.0: {}
+  hostdb@0.38.2: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/tests/unit/sqlite-binary-manager.test.ts
+++ b/tests/unit/sqlite-binary-manager.test.ts
@@ -20,7 +20,7 @@ describe('SQLite version-maps', () => {
   describe('normalizeVersion', () => {
     it('should map major version 3 to full version', () => {
       const result = normalizeVersion('3')
-      assertEqual(result, '3.53.1', 'Major version 3 should map to 3.53.1')
+      assertEqual(result, '3.53.4', 'Major version 3 should map to 3.53.4')
     })
 
     it('should map minor version 3.51 to full version', () => {
@@ -50,7 +50,7 @@ describe('SQLite version-maps', () => {
   describe('getFullVersion', () => {
     it('should return full version for major version 3', () => {
       const result = getFullVersion('3')
-      assertEqual(result, '3.53.1', 'Should return full version for major 3')
+      assertEqual(result, '3.53.4', 'Should return full version for major 3')
     })
 
     it('should return null for unknown major version', () => {
@@ -169,14 +169,14 @@ describe('SQLite binary-urls', () => {
     it('should include full version in URL', () => {
       const url = getBinaryUrl('3', Platform.Darwin, Arch.ARM64)
 
-      assert(url.includes('3.53.1'), 'URL should include full version 3.53.1')
+      assert(url.includes('3.53.4'), 'URL should include full version 3.53.4')
     })
 
     it('should include sqlite tag in URL', () => {
       const url = getBinaryUrl('3', Platform.Darwin, Arch.ARM64)
 
       assert(
-        url.includes('sqlite-3.53.1'),
+        url.includes('sqlite-3.53.4'),
         'URL should include sqlite version tag',
       )
     })
@@ -209,7 +209,7 @@ describe('SQLiteBinaryManager', () => {
   describe('getFullVersion', () => {
     it('should map major version 3 to full version', () => {
       const result = sqliteBinaryManager.getFullVersion('3')
-      assertEqual(result, '3.53.1', 'Should map major version 3 to 3.53.1')
+      assertEqual(result, '3.53.4', 'Should map major version 3 to 3.53.4')
     })
 
     it('should return full version unchanged', () => {
@@ -230,7 +230,7 @@ describe('SQLiteBinaryManager', () => {
         url.includes('registry.layerbase.host'),
         'URL should use layerbase registry',
       )
-      assert(url.includes('3.53.1'), 'URL should include full version')
+      assert(url.includes('3.53.4'), 'URL should include full version')
       assert(url.includes('darwin-arm64'), 'URL should include platform')
     })
 
@@ -264,7 +264,7 @@ describe('SQLiteBinaryManager', () => {
         path.includes('bin/sqlite3') || path.includes('bin\\sqlite3'),
         'Path should include bin/sqlite3',
       )
-      assert(path.includes('3.53.1'), 'Path should use full version')
+      assert(path.includes('3.53.4'), 'Path should use full version')
       assert(path.includes('darwin-arm64'), 'Path should include platform')
     })
 
@@ -447,7 +447,7 @@ describe('SQLiteBinaryManager', () => {
       )
 
       assert(typeof binPath === 'string', 'Should return path string')
-      assert(binPath.includes('3.53.1'), 'Path should include full version')
+      assert(binPath.includes('3.53.4'), 'Path should include full version')
       assert(binPath.includes('darwin-arm64'), 'Path should include platform')
     })
   })


### PR DESCRIPTION
Pins `hostdb` to **0.38.2** (was 0.36.0), bringing in 19 new engine versions across 13 engines: the QuestDB 9.4.3 bump from hostdb 0.37.0 and the 12-engine security + feature wave from hostdb 0.38.0.

Version-map wrappers rebuild from hostdb's bundled snapshot, so no MAP files were edited. No version was removed, every prior version still resolves, and existing containers self-pin their stored full version.

## Why 0.38.2 and not 0.38.0 / 0.38.1

Both earlier releases of this wave are unsafe to pin:

- **0.38.0** published while four release workflows were still building, so its bundled `releases.json` is missing `valkey 9.0.5`, `redis 8.4.5`, `influxdb 3.10.5` and `mariadb 11.8.8`. `getReleaseInfo` returns null for those and the binaries cannot be downloaded even though they are on R2.
- **0.38.1** fixed the snapshot but still bundled a Temurin **21** JRE with QuestDB 9.4.3 on darwin-arm64 / darwin-x64 / linux-arm64. QuestDB 9.4.x's `questdb.sh` passes `--sun-misc-unsafe-memory-access=allow`, a JDK 24+ flag, so the JVM exited with `Unrecognized option` before QuestDB ever started. Since 9.4.3 is now the default for major `9`, that would have broken a bare `spindb create questdb` on macOS.

## Security fixes

| Engine | Versions | CVEs |
| --- | --- | --- |
| Valkey | 9.0.5, 8.0.10 | CVE-2026-56684, CVE-2026-63639 |
| Redis | 7.2.15, 8.4.5, 7.4.10 | CVE-2026-66373 |
| MongoDB | 8.0.28, 8.2.12, 7.0.39 | July 2026 batch (incl. CVE-2026-13072, CVE-2026-13074) |
| MySQL | 8.4.11, 9.7.2 | July 2026 Oracle CPU (incl. CVE-2026-60311) |
| MariaDB | 11.8.8 | CVE-2026-44171 |

Also new: QuestDB 9.4.3, TypeDB 3.12.1, Meilisearch 1.52.0, Qdrant 1.18.3, Weaviate 1.38.8, InfluxDB 3.10.5, SQLite 3.53.4, CouchDB 3.5.2.

## Verification

`test:hostdb-sync` (23), `test:unit` (1688), `test:cli` (54) and `lint` all pass locally.

All 19 new versions were boot-tested end to end on darwin-arm64 (download -> create -> start -> query), including all 11 CVE-fix versions. QuestDB 9.4.3 was re-verified against the 0.38.2 artifact: it bundles Temurin 25.0.4, starts cleanly, and accepts `CREATE TABLE ... TIMESTAMP(ts) PARTITION BY DAY FORMAT PARQUET WAL` over the pg wire on 8812 (insert + count verified).

`tests/unit/sqlite-binary-manager.test.ts` expectations were realigned from 3.53.1 to the new 3.53.4 default, matching the precedent in 8a215c9.