### PR TITLE
chore(deps): bump hostdb pin 0.38.2 -> 0.38.3 (Linux qdrant + couchdb fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,24 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Pin `hostdb` to `0.38.2`** (was 0.36.0). Picks up the QuestDB bump from
+- **Pin `hostdb` to `0.38.3`** (was 0.36.0). Picks up the QuestDB bump from
   hostdb 0.37.0 and the thirteen-engine security + feature wave from hostdb
-  0.38.0, plus the 0.38.1 metadata republish and the 0.38.2 QuestDB JRE fix.
-  Nineteen new engine versions across thirteen engines; no version was removed,
-  every prior version still resolves, and existing containers self-pin their
-  stored full version, so nothing running is disturbed. The version-map wrappers
-  rebuild from hostdb's bundled snapshot at load time, so no MAP edits were
-  needed.
+  0.38.0, plus the 0.38.1 metadata republish, the 0.38.2 QuestDB JRE fix and the
+  0.38.3 Linux fixes for Qdrant and CouchDB. Nineteen new engine versions across
+  thirteen engines; no version was removed, every prior version still resolves,
+  and existing containers self-pin their stored full version, so nothing running
+  is disturbed. The version-map wrappers rebuild from hostdb's bundled snapshot
+  at load time, so no MAP edits were needed.
 
-  **Pin `0.38.2`, never `0.38.0` or `0.38.1`.** Two earlier releases of this
-  wave are unsafe to pin. `0.38.0` published to npm while four release workflows
-  were still building, so its bundled `releases.json` snapshot is missing
-  `valkey 9.0.5`, `redis 8.4.5`, `influxdb 3.10.5` and `mariadb 11.8.8`; on that
-  snapshot `getReleaseInfo` returns null for those four and the binaries cannot
-  be downloaded even though they are on R2. `0.38.1` fixed the snapshot but
-  still bundled an Adoptium Temurin **21** JRE with QuestDB 9.4.3 on
-  darwin-arm64, darwin-x64 and linux-arm64, which cannot start it (see below).
-  `0.38.2` is the first release of this wave that is correct on both counts.
+  **Pin `0.38.3`.** Every earlier release of this wave is unsafe to pin, each
+  for a different reason:
+  - `0.38.0` published to npm while four release workflows were still building,
+    so its bundled `releases.json` snapshot is missing `valkey 9.0.5`,
+    `redis 8.4.5`, `influxdb 3.10.5` and `mariadb 11.8.8`. On that snapshot
+    `getReleaseInfo` returns null for those four and the binaries cannot be
+    downloaded even though they are on R2.
+  - `0.38.1` fixed the snapshot but still bundled an Adoptium Temurin **21** JRE
+    with QuestDB 9.4.3 on darwin-arm64, darwin-x64 and linux-arm64, which cannot
+    start it (see below).
+  - `0.38.2` fixed the JRE but shipped two broken Linux artifacts: the Qdrant
+    1.18.3 `linux-x64` build required `GLIBC_2.38`, so it failed its own
+    `--version` verify on Ubuntu 22.04 (glibc 2.35) and inside the Docker E2E
+    image, and CouchDB 3.5.2 `linux-x64` failed to start at all on both Ubuntu
+    22.04 and 24.04. `0.38.3` reworks both: Qdrant `linux-x64` moves to the
+    static musl asset, and CouchDB is rebuilt from the official Apache jammy
+    package instead of a docker-extract that had inherited Debian 13's glibc
+    2.41 and OpenSSL 3.5. Both rebuilt artifacts are verified booting on
+    `ubuntu:22.04`.
 
   **Security fixes in this wave:**
   - **Valkey 9.0.5 and 8.0.10** - `CVE-2026-56684` (TLS use-after-free reachable

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.38.2",
+    "hostdb": "0.38.3",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.38.2
-        version: 0.38.2
+        specifier: 0.38.3
+        version: 0.38.3
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.38.2:
-    resolution: {integrity: sha512-YnegfGDhDgsoaRNCWfCR5jnGS5GiXE8tOfeXdx95byGjXGZheh9QXjL+NC27TFYdMLks+vcEY1ZJxzdvt5MhHA==}
+  hostdb@0.38.3:
+    resolution: {integrity: sha512-CrAKGUbHS48ealZ7QDwPvUIDzyW8WrJzweoKTGGxV8pwjUoUsFJH2b7odsyVL94CUAe1uzWaouFZO976gK5Zhg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.38.2: {}
+  hostdb@0.38.3: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
Follow-up to #267. Moves the `hostdb` pin from **0.38.2** to **0.38.3** to fix the two Linux failures the full CI matrix caught on release PR #268.

spindb stays at **0.62.4** (that version never published, so there is nothing to bump). No engine versions are added or removed by this change: it is the same 19-version wave, with two `linux-x64` artifacts rebuilt.

## What 0.38.2 got wrong

| Job | Failure |
| --- | --- |
| `Qdrant Linux x64 22.04`, `Docker Linux x64` | `qdrant: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found` |
| `CouchDB Linux x64 22.04`, `CouchDB Linux x64 24.04` | `CouchDB failed to start within timeout`, then `ECONNREFUSED` on every REST call |

Qdrant 1.18.3's `linux-x64` build required `GLIBC_2.38`, so it failed its own `--version` verify on Ubuntu 22.04 (glibc 2.35) and inside the Docker E2E image. Ubuntu 24.04 (glibc 2.39) passed, which is why only the 22.04 job went red. CouchDB 3.5.2's `linux-x64` build failed to start on both Ubuntu versions.

## What 0.38.3 changes

- **Qdrant `linux-x64` moves to the static musl asset**, removing the host-glibc dependency entirely.
- **CouchDB is rebuilt from the official Apache jammy package** instead of a docker-extract that had inherited Debian 13's glibc 2.41 and OpenSSL 3.5, with symlink / ini / `vm.args` normalizations included.

Both rebuilt artifacts were verified booting on `ubuntu:22.04` pulled from `registry.layerbase.host`.

## Verification

`test:hostdb-sync` (23), `test:unit` (1688) and `lint` all pass. Boot spot-checked qdrant 1.18.3 and couchdb 3.5.2 on darwin-arm64 to confirm the rebuilds did not regress the platform that was already working: both download, start, and serve (`GET /collections` and `GET /_all_dbs` respectively).

The Linux side is covered by the full matrix, which re-runs on #268 once this merges.