### PR TITLE
fix: prepend to library search paths instead of replacing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.5] - 2026-08-10
+
+### Fixed
+
+- **Spawning an engine no longer discards your own `LD_LIBRARY_PATH` /
+  `DYLD_FALLBACK_LIBRARY_PATH`.** `getLibraryEnv()` returned a bare
+  `{ LD_LIBRARY_PATH: <binPath>/lib }`, and every call site spreads it over
+  `process.env` (`{ ...process.env, ...getLibraryEnv(binPath) }`), so the
+  caller's existing value was replaced rather than extended for MariaDB, Redis
+  and Valkey child processes. Anyone relying on that variable to resolve their
+  own libraries lost it for the spawned engine. The bundled `lib` directory is
+  now PREPENDED, so it still wins while the caller's search path survives
+  behind it.
+- **`getWindowsDllEnv()` now prepends to `PATH` instead of appending.** It
+  exists to make a bundled DLL resolve (InfluxDB's `python/python313.dll`),
+  but appending loses to any same-named DLL already reachable on `PATH`. A
+  stray `python313.dll` from another install would win, turning a clear
+  missing-DLL failure into a harder-to-read version-mismatch one.
+
+Both paths are covered by `tests/unit/library-env.test.ts`, including the
+Windows separator (exercised directly through the extracted `prependPath`
+helper, since `getWindowsDllEnv` early-returns off Windows and that branch
+would otherwise never run in CI). The prepend assertion was verified to fail
+against the previous implementation.
+
 ## [0.62.4] - 2026-08-06
 
 ### Changed

--- a/core/library-env.ts
+++ b/core/library-env.ts
@@ -22,6 +22,14 @@ import { join } from 'path'
  * On Linux: LD_LIBRARY_PATH
  * On Windows: returns undefined (not applicable).
  *
+ * {binPath}/lib is PREPENDED to any value the caller already has, never
+ * substituted for it. Callers spread the result over process.env
+ * (`{ ...process.env, ...getLibraryEnv(binPath) }`), so returning a bare
+ * value silently dropped a user's own LD_LIBRARY_PATH / DYLD_FALLBACK_LIBRARY_PATH
+ * for the spawned engine - which breaks anyone who relies on it to resolve
+ * their own libraries. Prepending keeps our bundled copy winning while
+ * leaving their search path intact behind it.
+ *
  * Usage: spread into spawn env: `{ ...process.env, ...getLibraryEnv(binPath) }`
  */
 export function getLibraryEnv(
@@ -31,22 +39,52 @@ export function getLibraryEnv(
   const libDir = join(binPath, 'lib')
 
   if (plat === 'darwin') {
-    return { DYLD_FALLBACK_LIBRARY_PATH: libDir }
+    return {
+      DYLD_FALLBACK_LIBRARY_PATH: prependPath(
+        libDir,
+        process.env.DYLD_FALLBACK_LIBRARY_PATH,
+        ':',
+      ),
+    }
   }
   if (plat === 'linux') {
-    return { LD_LIBRARY_PATH: libDir }
+    return {
+      LD_LIBRARY_PATH: prependPath(libDir, process.env.LD_LIBRARY_PATH, ':'),
+    }
   }
   return undefined
 }
 
 /**
+ * Puts `dir` at the front of an existing search path, preserving whatever was
+ * already there. An absent or empty existing value yields just `dir`, so no
+ * caller ever gets a stray leading or trailing separator.
+ *
+ * Exported for tests: it is the whole of the prepend-not-replace behavior, and
+ * testing it directly is the only way to cover the Windows separator on a
+ * non-Windows CI runner.
+ */
+export function prependPath(
+  dir: string,
+  existing: string | undefined,
+  separator: string,
+): string {
+  return existing ? `${dir}${separator}${existing}` : dir
+}
+
+/**
  * Returns env vars that add a directory to the Windows DLL search path.
- * Appends the directory to the existing PATH environment variable.
+ * PREPENDS the directory to the existing PATH environment variable.
  * Returns undefined on non-Windows platforms (not needed).
  *
  * Use for engines that bundle DLLs in subdirectories that aren't on the
  * default search path (e.g., InfluxDB's python/ directory containing
  * python313.dll needed at load time).
+ *
+ * Prepend rather than append: this exists to make OUR bundled DLL resolve,
+ * and appending loses to any same-named DLL already reachable on PATH. A
+ * stray python313.dll of a different build then wins, which produces a
+ * second, harder-to-read failure than the missing-DLL one this fixes.
  *
  * Usage: spread into spawn env: `{ ...process.env, ...getWindowsDllEnv(dllDir) }`
  */
@@ -54,8 +92,7 @@ export function getWindowsDllEnv(
   dllDir: string,
 ): Record<string, string> | undefined {
   if (osPlatform() !== 'win32') return undefined
-  const currentPath = process.env.PATH || ''
-  return { PATH: `${currentPath};${dllDir}` }
+  return { PATH: prependPath(dllDir, process.env.PATH, ';') }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.4",
+  "version": "0.62.5",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/library-env.test.ts
+++ b/tests/unit/library-env.test.ts
@@ -1,48 +1,166 @@
 import { describe, it } from 'node:test'
 import { platform as osPlatform } from 'os'
 import { join } from 'path'
-import { getLibraryEnv, detectLibraryError } from '../../core/library-env'
+import {
+  getLibraryEnv,
+  getWindowsDllEnv,
+  prependPath,
+  detectLibraryError,
+} from '../../core/library-env'
 import { assert, assertEqual } from '../utils/assertions'
+
+// The unit suite runs with --experimental-test-isolation=none, so every test
+// shares one process: any process.env write has to be restored or it leaks
+// into unrelated tests.
+function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+  const had = Object.hasOwn(process.env, key)
+  const previous = process.env[key]
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+  try {
+    return fn()
+  } finally {
+    if (had) process.env[key] = previous
+    else delete process.env[key]
+  }
+}
+
+const LIBRARY_PATH_VAR: Record<string, string> = {
+  darwin: 'DYLD_FALLBACK_LIBRARY_PATH',
+  linux: 'LD_LIBRARY_PATH',
+}
 
 describe('library-env', () => {
   describe('getLibraryEnv', () => {
     const binPath = '/home/user/.spindb/bin/redis-8.4.0-linux-arm64'
+    const plat = osPlatform()
+    const envVar = LIBRARY_PATH_VAR[plat]
 
     it('should return an object with the correct library path', () => {
-      const result = getLibraryEnv(binPath)
-      const plat = osPlatform()
-
-      if (plat === 'darwin') {
-        assert(result !== undefined, 'Should return env on macOS')
+      if (!envVar) {
         assertEqual(
-          result!.DYLD_FALLBACK_LIBRARY_PATH,
-          join(binPath, 'lib'),
-          'Should set DYLD_FALLBACK_LIBRARY_PATH',
+          getLibraryEnv(binPath),
+          undefined,
+          'Should return undefined on Windows',
         )
-      } else if (plat === 'linux') {
-        assert(result !== undefined, 'Should return env on Linux')
-        assertEqual(
-          result!.LD_LIBRARY_PATH,
-          join(binPath, 'lib'),
-          'Should set LD_LIBRARY_PATH',
-        )
-      } else if (plat === 'win32') {
-        assertEqual(result, undefined, 'Should return undefined on Windows')
+        return
       }
+
+      withEnv(envVar, undefined, () => {
+        const result = getLibraryEnv(binPath)
+        assert(result !== undefined, `Should return env on ${plat}`)
+        assertEqual(
+          result![envVar],
+          join(binPath, 'lib'),
+          `Should set ${envVar}`,
+        )
+      })
     })
 
     it('should point to the lib subdirectory of binPath', () => {
-      const result = getLibraryEnv(binPath)
-      const plat = osPlatform()
+      if (!envVar) return
 
-      if (plat === 'win32') return
+      withEnv(envVar, undefined, () => {
+        const result = getLibraryEnv(binPath)
+        assert(result !== undefined, 'Should return env on Unix')
+        const values = Object.values(result!)
+        assert(values.length === 1, 'Should have exactly one env var')
+        assert(
+          values[0].endsWith('/lib'),
+          `Path should end with /lib, got: ${values[0]}`,
+        )
+      })
+    })
 
-      assert(result !== undefined, 'Should return env on Unix')
-      const values = Object.values(result!)
-      assert(values.length === 1, 'Should have exactly one env var')
-      assert(
-        values[0].endsWith('/lib'),
-        `Path should end with /lib, got: ${values[0]}`,
+    it("should PREPEND to the caller's existing library path, not replace it", () => {
+      if (!envVar) return
+
+      withEnv(envVar, '/opt/mylibs:/usr/local/custom/lib', () => {
+        const result = getLibraryEnv(binPath)
+        assert(result !== undefined, 'Should return env on Unix')
+        assertEqual(
+          result![envVar],
+          `${join(binPath, 'lib')}:/opt/mylibs:/usr/local/custom/lib`,
+          'Bundled lib dir should win, existing entries should survive behind it',
+        )
+      })
+    })
+
+    it('should not emit a trailing separator when the existing value is empty', () => {
+      if (!envVar) return
+
+      withEnv(envVar, '', () => {
+        const result = getLibraryEnv(binPath)
+        assertEqual(
+          result![envVar],
+          join(binPath, 'lib'),
+          'Empty existing value should yield just the lib dir',
+        )
+      })
+    })
+  })
+
+  describe('getWindowsDllEnv', () => {
+    it('should return undefined off Windows', () => {
+      if (osPlatform() === 'win32') return
+      assertEqual(
+        getWindowsDllEnv('C:\\bin\\influxdb\\python'),
+        undefined,
+        'Only Windows needs the PATH treatment',
+      )
+    })
+
+    it('should prepend the DLL dir to PATH on Windows', () => {
+      if (osPlatform() !== 'win32') return
+
+      withEnv('PATH', 'C:\\Windows\\System32', () => {
+        assertEqual(
+          getWindowsDllEnv('C:\\bin\\influxdb\\python')!.PATH,
+          'C:\\bin\\influxdb\\python;C:\\Windows\\System32',
+          'Bundled DLL dir must come first so a stray same-named DLL cannot win',
+        )
+      })
+    })
+  })
+
+  // Covers the Windows separator on non-Windows runners: getWindowsDllEnv
+  // itself early-returns off win32, so without this the ';' branch would
+  // never execute in CI.
+  describe('prependPath', () => {
+    it('should place the new directory first', () => {
+      assertEqual(
+        prependPath('/new', '/old', ':'),
+        '/new:/old',
+        'New directory should come first',
+      )
+    })
+
+    it('should preserve every existing entry in order', () => {
+      assertEqual(
+        prependPath('/new', '/a:/b:/c', ':'),
+        '/new:/a:/b:/c',
+        'Existing entries should survive in their original order',
+      )
+    })
+
+    it('should use the Windows separator when asked', () => {
+      assertEqual(
+        prependPath('C:\\new', 'C:\\Windows\\System32', ';'),
+        'C:\\new;C:\\Windows\\System32',
+        'Windows paths join with a semicolon',
+      )
+    })
+
+    it('should return just the directory when nothing exists', () => {
+      assertEqual(
+        prependPath('/new', undefined, ':'),
+        '/new',
+        'Absent existing value should not add a separator',
+      )
+      assertEqual(
+        prependPath('/new', '', ':'),
+        '/new',
+        'Empty existing value should not add a separator',
       )
     })
   })


### PR DESCRIPTION
## The bug

`core/library-env.ts` had mirror-image bugs on the Unix and Windows paths.

**`getLibraryEnv()` replaced the caller's library path.** It returned a bare `{ LD_LIBRARY_PATH: <binPath>/lib }`, and every call site spreads it over `process.env`:

```ts
env: { ...process.env, ...getLibraryEnv(binPath) }
```

so a user's own `LD_LIBRARY_PATH` / `DYLD_FALLBACK_LIBRARY_PATH` was **dropped** for MariaDB, Redis and Valkey child processes. Anyone relying on it to resolve their own libraries lost it for the spawned engine.

**`getWindowsDllEnv()` appended to `PATH`.** It preserved the existing value but put the bundled directory last, so any same-named DLL already reachable on `PATH` beat the one it exists to make resolvable. A stray `python313.dll` from another install wins, turning a clear missing-DLL failure into the harder-to-read version-mismatch class.

Both now prepend: our bundled copy wins, the caller's search path survives behind it.

## Tests

`tests/unit/library-env.test.ts` gains coverage for prepending, for preserving existing entries in order, and for not emitting a stray separator when the existing value is absent or empty. The existing tests read ambient `process.env`, so they now control it explicitly and restore it (the unit suite runs `--experimental-test-isolation=none`, one shared process).

`prependPath` is exported and tested directly. That is the only way to cover the Windows `;` separator on a non-Windows runner: `getWindowsDllEnv` early-returns off win32, so that branch would otherwise never execute in CI.

**The prepend assertion was verified to fail against the previous implementation** (reverted the fix, watched the test go red, restored it) rather than only observed passing.

## CI will be red, and it is red on `dev` already

`pnpm test:unit` reports **8 failures, all pre-existing and unrelated to this change**:

- With this branch: 1696 tests, 1688 pass, 8 fail
- With these changes stashed on clean `dev`: 1688 tests, 1680 pass, **the same 8 fail**

All 8 are SQLite version-map assertions expecting `3.53.4`. This repo pins `hostdb@0.38.3`, which ships SQLite **3.53.1**; `3.53.4` only exists in **hostdb 0.38.4**. The tests are ahead of the pin.

Fixing that means bumping the `hostdb` pin to `0.38.4`, which changes engine versions and deserves its own PR rather than riding along with a library-path fix.

## Version

`0.62.5` (npm is at `0.62.4`), so `version-check` passes. CHANGELOG updated.

`pnpm check` (tsc) and `pnpm lint` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine launches now preserve existing library search paths while prioritizing bundled libraries.
  * Improved Windows DLL resolution by prioritizing bundled libraries in the system path.
  * Added support for platform-specific path separators and empty existing paths.

* **Chores**
  * Updated the release version to 0.62.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->