### PR TITLE
Release spindb 0.62.6: hostdb 0.39.0 (TypeDB 3.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.6] - 2026-08-12
+
+### Changed
+
+- Bump `hostdb` to 0.39.0: adds TypeDB 3.12.2 (all platforms) and moves the TypeDB 3.x default to 3.12.2. Also picks up hostdb 0.38.4's release-pipeline hardening (no artifact changes) and the Redis 7.4.10 deprecation flag.
+
 ## [0.62.5] - 2026-08-10
 
 ### Fixed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.4'
+export const VERSION = '0.62.6'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.5",
+  "version": "0.62.6",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.38.3",
+    "hostdb": "0.39.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.38.3
-        version: 0.38.3
+        specifier: 0.39.0
+        version: 0.39.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.38.3:
-    resolution: {integrity: sha512-CrAKGUbHS48ealZ7QDwPvUIDzyW8WrJzweoKTGGxV8pwjUoUsFJH2b7odsyVL94CUAe1uzWaouFZO976gK5Zhg==}
+  hostdb@0.39.0:
+    resolution: {integrity: sha512-wwTtsjnOcXgLwJvBS83kzcQNTBdLlM5oFXmBsQpWQWGeIcwgx7ZXUZKxCOmaoo35Inw5P6WVMjpJHqR2v7p9Qw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.38.3: {}
+  hostdb@0.39.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
Bumps the exact hostdb pin 0.38.3 -> 0.39.0: TypeDB 3.12.2 on all 5 platforms, TypeDB 3.x default now 3.12.2. Also picks up hostdb 0.38.4 (release-pipeline hardening, no artifact changes; Redis 7.4.10 deprecation flag).

- Local gates green: test:hostdb-sync (23), test:unit (1696), test:cli (54), lint/tsc.
- This PR's CI is the full Linux matrix gate required before any downstream (cloud/desktop) pin bump.
- Merging publishes 0.62.6 to npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TypeDB 3.12.2 across supported platforms.
  * Updated the default TypeDB 3.x version to 3.12.2.
* **Deprecations**
  * Marked Redis 7.4.10 for deprecation.
* **Release Updates**
  * Released version 0.62.6 with updated database compatibility and improved release-pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->