### PR TITLE
fix(couchdb): re-point data paths on start so a branch stops reading the parent's files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A branched CouchDB no longer opens the PARENT's data files.** `generateCouchDBConfig` writes `database_dir` and `view_index_dir` as ABSOLUTE paths, and a branch is a byte copy of the container directory, so a branched container's `local.ini` still named the source's data dir: two CouchDB nodes ran against one set of files. It looked healthy - the branch starts and `/_up` returns 200 - and only surfaced when reading a document through the branch, as `read_beyond_eof` on the parent's `_dbs.couch`. `patchCouchDBConfig` now takes `dataDir` (and optional `logDir`) and re-asserts those keys on every start, which also self-heals a container branched before this fix. Same class as the qdrant `storage_path` fix. Found while validating CouchDB for Layerbase Cloud's branching allowlist (tracker C-109); CouchDB stays off that allowlist until this ships and the validation is re-run.
+
 ## [0.62.6] - 2026-08-12
 
 ### Changed

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -112,6 +112,43 @@ ${adminUsername} = ${adminPassword}
 `
 }
 
+/**
+ * Re-point the absolute paths in an existing local.ini at THIS container.
+ *
+ * Replaces `database_dir` / `view_index_dir` (and the `[log] file`, matched on
+ * the couchdb.log filename so no unrelated `file =` key is touched). Keys that
+ * are missing - a hand-written config - are inserted under `[couchdb]`, adding
+ * the section if it is absent, so the result is always self-consistent.
+ */
+function repointCouchDBPaths(
+  config: string,
+  dataDir: string,
+  logDir?: string,
+): string {
+  let out = config
+  for (const key of ['database_dir', 'view_index_dir']) {
+    const line = `${key} = ${dataDir}`
+    const existing = new RegExp(`^${key} = .*$`, 'm')
+    if (existing.test(out)) {
+      out = out.replace(existing, line)
+    } else if (/^\[couchdb\]/m.test(out)) {
+      out = out.replace(
+        /^\[couchdb\][^\n]*\n?/m,
+        (header) => `${header}${line}\n`,
+      )
+    } else {
+      out = `[couchdb]\n${line}\n\n${out.trimStart()}`
+    }
+  }
+  if (logDir !== undefined) {
+    out = out.replace(
+      /^file = .*couchdb\.log$/m,
+      `file = ${logDir}/couchdb.log`,
+    )
+  }
+  return out
+}
+
 export function patchCouchDBConfig(
   existingConfig: string,
   options: {
@@ -119,10 +156,29 @@ export function patchCouchDBConfig(
     bindAddress?: string
     adminUsername?: string
     adminPassword?: string
+    /**
+     * This container's data directory. When given, `database_dir` and
+     * `view_index_dir` are re-asserted to it.
+     *
+     * REQUIRED for correctness on a BRANCH or a rename: generateCouchDBConfig
+     * writes those keys as ABSOLUTE paths, and a branch is a byte copy of the
+     * container dir - so without this the branch's local.ini still points at the
+     * PARENT's data dir and two CouchDB nodes run against one set of files. That
+     * surfaced as `read_beyond_eof` on the parent's `_dbs.couch` while querying
+     * the branch, with the branch otherwise looking healthy (it starts, and /_up
+     * returns 200). Re-asserting on every start also self-heals a container that
+     * was already branched before this fix.
+     */
+    dataDir?: string
+    /** This container's log directory; `[log] file` is re-pointed into it. */
+    logDir?: string
   },
 ): string {
   let config = existingConfig
   config = config.replace(/^port = \d+/m, `port = ${options.port}`)
+  if (options.dataDir !== undefined) {
+    config = repointCouchDBPaths(config, options.dataDir, options.logDir)
+  }
   if (options.bindAddress !== undefined) {
     config = config.replace(
       /^bind_address = .+/m,
@@ -642,6 +698,11 @@ export class CouchDBEngine extends BaseEngine {
         bindAddress,
         adminUsername: savedAdminAuth?.username,
         adminPassword: savedAdminAuth?.password,
+        // Always re-assert this container's own paths: a branched (or renamed)
+        // container inherits the SOURCE's absolute database_dir and would
+        // otherwise open the parent's files.
+        dataDir,
+        logDir,
       })
       await writeFile(configPath, patchedConfig)
     } else {

--- a/tests/unit/couchdb-config-patch.test.ts
+++ b/tests/unit/couchdb-config-patch.test.ts
@@ -97,3 +97,102 @@ describe('patchCouchDBConfig [admins] handling', () => {
     assert.match(patched, /^port = 11500$/m)
   })
 })
+
+/**
+ * Data-path re-pointing (Layerbase C-109, 2026-08-15).
+ *
+ * generateCouchDBConfig writes `database_dir` / `view_index_dir` as ABSOLUTE
+ * paths, and a branch is a byte copy of the container directory - so before this,
+ * a branched container's local.ini still named the PARENT's data dir and two
+ * CouchDB nodes ran against one set of files. It looked healthy (the branch
+ * starts, /_up returns 200) and only showed up as `read_beyond_eof` on the
+ * parent's `_dbs.couch` when reading a document through the branch.
+ */
+describe('patchCouchDBConfig data-path re-pointing', () => {
+  const parent = [
+    '; SpinDB generated CouchDB configuration',
+    '[couchdb]',
+    'database_dir = /data/containers/couchdb/parent/data',
+    'view_index_dir = /data/containers/couchdb/parent/data',
+    '',
+    '[chttpd]',
+    'port = 5984',
+    'bind_address = 127.0.0.1',
+    '',
+    '[log]',
+    'file = /data/containers/couchdb/parent/logs/couchdb.log',
+    'level = info',
+    '',
+    '[admins]',
+    'admin = -pbkdf2:sha256-deadbeef,salt,10',
+  ].join('\n')
+
+  const BRANCH = '/data/containers/couchdb/branch/data'
+
+  it('re-points both data keys at this container', () => {
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+    })
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, new RegExp(`^view_index_dir = ${BRANCH}$`, 'm'))
+    assert.doesNotMatch(
+      patched,
+      /couchdb\/parent\/data/,
+      'no key may still point at the parent',
+    )
+  })
+
+  it('re-points the log file when a logDir is given', () => {
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+      logDir: '/data/containers/couchdb/branch/logs',
+    })
+    assert.match(
+      patched,
+      /^file = \/data\/containers\/couchdb\/branch\/logs\/couchdb\.log$/m,
+    )
+  })
+
+  it('leaves paths alone when no dataDir is passed (unchanged callers)', () => {
+    const patched = patchCouchDBConfig(parent, { port: 11500 })
+    assert.match(
+      patched,
+      /^database_dir = \/data\/containers\/couchdb\/parent\/data$/m,
+    )
+    assert.match(patched, /^port = 11500$/m)
+  })
+
+  it('inserts the keys into a hand-written config that lacks them', () => {
+    const handWritten = ['[chttpd]', 'port = 5984'].join('\n')
+    const patched = patchCouchDBConfig(handWritten, {
+      port: 11500,
+      dataDir: BRANCH,
+    })
+    assert.match(patched, /^\[couchdb\]$/m)
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, new RegExp(`^view_index_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, /^port = 11500$/m, 'the port patch still applies')
+  })
+
+  it('still preserves the existing admin entry while re-pointing paths', () => {
+    // The two behaviours must not interfere: path re-pointing is new, admin
+    // preservation is the reason this function exists at all.
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+      adminUsername: 'admin',
+      adminPassword: 'a-different-password',
+    })
+    assert.equal(adminLines(patched).length, 1)
+    assert.match(patched, /-pbkdf2:sha256-deadbeef/)
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+  })
+
+  it('is idempotent across repeated starts', () => {
+    const once = patchCouchDBConfig(parent, { port: 11500, dataDir: BRANCH })
+    const twice = patchCouchDBConfig(once, { port: 11500, dataDir: BRANCH })
+    assert.equal(once, twice)
+  })
+})


### PR DESCRIPTION
Found while validating CouchDB for Layerbase Cloud's branching allowlist. It is the same class as the qdrant `storage_path` fix.

## The bug

`generateCouchDBConfig` writes `database_dir` and `view_index_dir` as **absolute** paths, and a branch is a byte copy of the container directory. The start-time `patchCouchDBConfig` re-asserts only `port`, `bind_address` and the admin line — never the data paths. So a branched container's `local.ini` still named the **source's** data dir, and two CouchDB nodes ran against one set of files.

It presents as healthy, which is the dangerous part: `spindb branch` reports success, the branch starts, `/_up` returns 200, and the Erlang node name is already unique per port. It only shows up when you read a document through the branch:

```
{"error":"badmatch","reason":"{'EXIT',{error,{read_beyond_eof,
  ".../containers/couchdb/cdrace/data/_dbs.couch" ...
```

Note the path names the **parent** (`cdrace`) while the process is the branch (`cdrace-branch`) — the branch reading a file the parent is actively writing.

## The fix

`patchCouchDBConfig` takes `dataDir` (and an optional `logDir`) and re-asserts those keys **on every start**, so a branch, a rename, or a move all converge — and a container branched before this fix heals on its next start rather than needing manual repair.

- Keys absent from a hand-written config are inserted under `[couchdb]`, adding the section if it is missing, so the result is always self-consistent.
- The `[log] file` key is matched on the `couchdb.log` filename, so no unrelated `file =` key in another section is touched.
- Admin preservation is untouched; a test pins that the two behaviours do not interfere.
- Callers that pass no `dataDir` keep their old behaviour exactly (covered by a test), so nothing outside the start path changes.

## Verification

6 new unit cases in `tests/unit/couchdb-config-patch.test.ts` (both data keys re-pointed, log re-pointed, no-`dataDir` back-compat, insertion into a config lacking the keys, admin preservation alongside re-pointing, idempotency across repeated starts). Full unit suite **1702 pass / 0 fail**, `pnpm lint` (eslint + tsc) clean.

## Release path

Not published from here. Once this is released, Layerbase Cloud needs the universal-image `SPINDB_VERSION` bump, then CouchDB's branch validation should be re-run end to end (create → branch → read a document through the branch → confirm the branch's own `_dbs.couch` is what it opens) before CouchDB is added to the branching allowlist. Until then CouchDB is hard-blocked in the cloud API for everyone including admins (layerbase-cloud tracker C-109).