### PR TITLE
release: spindb 0.62.7 - CouchDB branch data-path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.7] - 2026-08-15
+
 ### Fixed
 
 - **A branched CouchDB no longer opens the PARENT's data files.** `generateCouchDBConfig` writes `database_dir` and `view_index_dir` as ABSOLUTE paths, and a branch is a byte copy of the container directory, so a branched container's `local.ini` still named the source's data dir: two CouchDB nodes ran against one set of files. It looked healthy - the branch starts and `/_up` returns 200 - and only surfaced when reading a document through the branch, as `read_beyond_eof` on the parent's `_dbs.couch`. `patchCouchDBConfig` now takes `dataDir` (and optional `logDir`) and re-asserts those keys on every start, which also self-heals a container branched before this fix. Same class as the qdrant `storage_path` fix. Found while validating CouchDB for Layerbase Cloud's branching allowlist (tracker C-109); CouchDB stays off that allowlist until this ships and the validation is re-run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A branched CouchDB no longer opens the PARENT's data files.** `generateCouchDBConfig` writes `database_dir` and `view_index_dir` as ABSOLUTE paths, and a branch is a byte copy of the container directory, so a branched container's `local.ini` still named the source's data dir: two CouchDB nodes ran against one set of files. It looked healthy - the branch starts and `/_up` returns 200 - and only surfaced when reading a document through the branch, as `read_beyond_eof` on the parent's `_dbs.couch`. `patchCouchDBConfig` now takes `dataDir` (and optional `logDir`) and re-asserts those keys on every start, which also self-heals a container branched before this fix. Same class as the qdrant `storage_path` fix. Found while validating CouchDB for Layerbase Cloud's branching allowlist (tracker C-109); CouchDB stays off that allowlist until this ships and the validation is re-run.
+
 ## [0.62.6] - 2026-08-12
 
 ### Changed

--- a/ENGINE_CHECKLIST.md
+++ b/ENGINE_CHECKLIST.md
@@ -4,6 +4,15 @@ This comprehensive document provides both the specification for adding a new dat
 
 **Reference Implementation:** Use [engines/cockroachdb/](engines/cockroachdb/) as a modern example.
 
+> **Before evaluating a new engine, read `~/dev/hostdb/PROSPECTS.md` first.** It is the
+> authoritative record of which engines we plan to add and which we have already
+> evaluated and rejected, with the reasoning and re-open criteria for each. Engines
+> cannot ship in spindb without a hostdb build, so that decision comes first.
+> Already decided against: ArangoDB, Chroma, Dgraph, DuckDB VSS, Kuzu, **Milvus**
+> (Docker-only, needs etcd + MinIO, would force multi-process supervision into
+> spindb), **TimescaleDB** (a PostgreSQL extension rather than a database; TSL
+> licensing blocks layerbase-cloud from serving the build users want).
+
 ---
 
 ## Table of Contents

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.6'
+export const VERSION = '0.62.7'

--- a/engines/couchdb/index.ts
+++ b/engines/couchdb/index.ts
@@ -112,6 +112,43 @@ ${adminUsername} = ${adminPassword}
 `
 }
 
+/**
+ * Re-point the absolute paths in an existing local.ini at THIS container.
+ *
+ * Replaces `database_dir` / `view_index_dir` (and the `[log] file`, matched on
+ * the couchdb.log filename so no unrelated `file =` key is touched). Keys that
+ * are missing - a hand-written config - are inserted under `[couchdb]`, adding
+ * the section if it is absent, so the result is always self-consistent.
+ */
+function repointCouchDBPaths(
+  config: string,
+  dataDir: string,
+  logDir?: string,
+): string {
+  let out = config
+  for (const key of ['database_dir', 'view_index_dir']) {
+    const line = `${key} = ${dataDir}`
+    const existing = new RegExp(`^${key} = .*$`, 'm')
+    if (existing.test(out)) {
+      out = out.replace(existing, line)
+    } else if (/^\[couchdb\]/m.test(out)) {
+      out = out.replace(
+        /^\[couchdb\][^\n]*\n?/m,
+        (header) => `${header}${line}\n`,
+      )
+    } else {
+      out = `[couchdb]\n${line}\n\n${out.trimStart()}`
+    }
+  }
+  if (logDir !== undefined) {
+    out = out.replace(
+      /^file = .*couchdb\.log$/m,
+      `file = ${logDir}/couchdb.log`,
+    )
+  }
+  return out
+}
+
 export function patchCouchDBConfig(
   existingConfig: string,
   options: {
@@ -119,10 +156,29 @@ export function patchCouchDBConfig(
     bindAddress?: string
     adminUsername?: string
     adminPassword?: string
+    /**
+     * This container's data directory. When given, `database_dir` and
+     * `view_index_dir` are re-asserted to it.
+     *
+     * REQUIRED for correctness on a BRANCH or a rename: generateCouchDBConfig
+     * writes those keys as ABSOLUTE paths, and a branch is a byte copy of the
+     * container dir - so without this the branch's local.ini still points at the
+     * PARENT's data dir and two CouchDB nodes run against one set of files. That
+     * surfaced as `read_beyond_eof` on the parent's `_dbs.couch` while querying
+     * the branch, with the branch otherwise looking healthy (it starts, and /_up
+     * returns 200). Re-asserting on every start also self-heals a container that
+     * was already branched before this fix.
+     */
+    dataDir?: string
+    /** This container's log directory; `[log] file` is re-pointed into it. */
+    logDir?: string
   },
 ): string {
   let config = existingConfig
   config = config.replace(/^port = \d+/m, `port = ${options.port}`)
+  if (options.dataDir !== undefined) {
+    config = repointCouchDBPaths(config, options.dataDir, options.logDir)
+  }
   if (options.bindAddress !== undefined) {
     config = config.replace(
       /^bind_address = .+/m,
@@ -642,6 +698,11 @@ export class CouchDBEngine extends BaseEngine {
         bindAddress,
         adminUsername: savedAdminAuth?.username,
         adminPassword: savedAdminAuth?.password,
+        // Always re-assert this container's own paths: a branched (or renamed)
+        // container inherits the SOURCE's absolute database_dir and would
+        // otherwise open the parent's files.
+        dataDir,
+        logDir,
       })
       await writeFile(configPath, patchedConfig)
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.6",
+  "version": "0.62.7",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/couchdb-config-patch.test.ts
+++ b/tests/unit/couchdb-config-patch.test.ts
@@ -97,3 +97,102 @@ describe('patchCouchDBConfig [admins] handling', () => {
     assert.match(patched, /^port = 11500$/m)
   })
 })
+
+/**
+ * Data-path re-pointing (Layerbase C-109, 2026-08-15).
+ *
+ * generateCouchDBConfig writes `database_dir` / `view_index_dir` as ABSOLUTE
+ * paths, and a branch is a byte copy of the container directory - so before this,
+ * a branched container's local.ini still named the PARENT's data dir and two
+ * CouchDB nodes ran against one set of files. It looked healthy (the branch
+ * starts, /_up returns 200) and only showed up as `read_beyond_eof` on the
+ * parent's `_dbs.couch` when reading a document through the branch.
+ */
+describe('patchCouchDBConfig data-path re-pointing', () => {
+  const parent = [
+    '; SpinDB generated CouchDB configuration',
+    '[couchdb]',
+    'database_dir = /data/containers/couchdb/parent/data',
+    'view_index_dir = /data/containers/couchdb/parent/data',
+    '',
+    '[chttpd]',
+    'port = 5984',
+    'bind_address = 127.0.0.1',
+    '',
+    '[log]',
+    'file = /data/containers/couchdb/parent/logs/couchdb.log',
+    'level = info',
+    '',
+    '[admins]',
+    'admin = -pbkdf2:sha256-deadbeef,salt,10',
+  ].join('\n')
+
+  const BRANCH = '/data/containers/couchdb/branch/data'
+
+  it('re-points both data keys at this container', () => {
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+    })
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, new RegExp(`^view_index_dir = ${BRANCH}$`, 'm'))
+    assert.doesNotMatch(
+      patched,
+      /couchdb\/parent\/data/,
+      'no key may still point at the parent',
+    )
+  })
+
+  it('re-points the log file when a logDir is given', () => {
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+      logDir: '/data/containers/couchdb/branch/logs',
+    })
+    assert.match(
+      patched,
+      /^file = \/data\/containers\/couchdb\/branch\/logs\/couchdb\.log$/m,
+    )
+  })
+
+  it('leaves paths alone when no dataDir is passed (unchanged callers)', () => {
+    const patched = patchCouchDBConfig(parent, { port: 11500 })
+    assert.match(
+      patched,
+      /^database_dir = \/data\/containers\/couchdb\/parent\/data$/m,
+    )
+    assert.match(patched, /^port = 11500$/m)
+  })
+
+  it('inserts the keys into a hand-written config that lacks them', () => {
+    const handWritten = ['[chttpd]', 'port = 5984'].join('\n')
+    const patched = patchCouchDBConfig(handWritten, {
+      port: 11500,
+      dataDir: BRANCH,
+    })
+    assert.match(patched, /^\[couchdb\]$/m)
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, new RegExp(`^view_index_dir = ${BRANCH}$`, 'm'))
+    assert.match(patched, /^port = 11500$/m, 'the port patch still applies')
+  })
+
+  it('still preserves the existing admin entry while re-pointing paths', () => {
+    // The two behaviours must not interfere: path re-pointing is new, admin
+    // preservation is the reason this function exists at all.
+    const patched = patchCouchDBConfig(parent, {
+      port: 11500,
+      dataDir: BRANCH,
+      adminUsername: 'admin',
+      adminPassword: 'a-different-password',
+    })
+    assert.equal(adminLines(patched).length, 1)
+    assert.match(patched, /-pbkdf2:sha256-deadbeef/)
+    assert.match(patched, new RegExp(`^database_dir = ${BRANCH}$`, 'm'))
+  })
+
+  it('is idempotent across repeated starts', () => {
+    const once = patchCouchDBConfig(parent, { port: 11500, dataDir: BRANCH })
+    const twice = patchCouchDBConfig(once, { port: 11500, dataDir: BRANCH })
+    assert.equal(once, twice)
+  })
+})


### PR DESCRIPTION
**Merging this publishes 0.62.7 to npm** (main-push OIDC publish). `version-check` compares against the published 0.62.6, so it should pass.

## What ships

One fix, plus a docs commit already on `dev`.

**A branched CouchDB no longer opens the PARENT's data files.** `generateCouchDBConfig` writes `database_dir` and `view_index_dir` as **absolute** paths, and a branch is a byte copy of the container directory — so a branched container's `local.ini` still named the source's data dir and two CouchDB nodes ran against one set of files.

It presented as healthy, which is what makes it dangerous: `spindb branch` reports success, the branch starts, `/_up` returns 200, and the Erlang node name is already unique per port. It only showed up when reading a document *through* the branch:

```
{"error":"badmatch","reason":"{'EXIT',{error,{read_beyond_eof,
  ".../containers/couchdb/cdrace/data/_dbs.couch" ...
```

— the **parent's** path, while the process is the branch.

`patchCouchDBConfig` now takes `dataDir` (and optional `logDir`) and re-asserts those keys **on every start**, so a branch, rename or move all converge, and a container branched before this fix heals on its next start instead of needing manual repair. Keys missing from a hand-written config are inserted under `[couchdb]`; the `[log] file` key is matched on the `couchdb.log` filename so no unrelated `file =` is touched; admin preservation is unchanged; callers passing no `dataDir` behave exactly as before.

Same class as the qdrant `storage_path` fix. Found validating CouchDB for Layerbase Cloud's branching allowlist (cloud tracker C-109).

## Contents

- `f060f8d` fix(couchdb): re-point data paths on start (PR #273)
- `e7adf80` docs: point the engine checklist at hostdb PROSPECTS
- `e5f21a5` chore(release): 0.62.7 — package.json, the tracked `config/version.ts`, and the changelog entry promoted out of `[Unreleased]`

## Verification

Unit suite **1702 pass / 0 fail**; `pnpm lint` (eslint + tsc) clean; prettier clean. 6 unit cases cover the new behaviour: both data keys re-pointed, log re-pointed, no-`dataDir` back-compat, insertion into a config lacking the keys, admin preservation alongside re-pointing, and idempotency across repeated starts.

## After this merges

1. **layerbase-cloud**: bump `images/Dockerfile.base` `ARG SPINDB_VERSION` 0.62.6 → 0.62.7 and both `deploy/setup.sh` occurrences, rebuild the universal image, deploy. Existing containers pick it up on recreation.
2. **layerbase-desktop**: bump its spindb dependency (the half that gets forgotten).
3. **Re-validate CouchDB branching** end to end — create → branch → read a document *through* the branch → confirm it opens its **own** `_dbs.couch` — and only then remove CouchDB from `BRANCH_FORBIDDEN_ENGINES` and add it to the allowlist. Until then it stays hard-blocked in the cloud API for everyone including admins (verified on prod: `400 branching_unsafe_engine`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CouchDB startup behavior for branched containers by ensuring database, view index, and optional log paths point to the correct container-specific locations.
  - Added recovery for older branches and configurations with missing path settings.
  - Preserved existing credentials and configuration during updates.

- **Documentation**
  - Added guidance for evaluating and shipping database engines, including current engine decisions.

- **Chores**
  - Updated the application version to 0.62.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->