### PR TITLE
fix(couchdb): refuse branch/reset/clone instead of returning a non-isolated copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`spindb branch`, `spindb branch reset` and `spindb clone` now REFUSE CouchDB** instead of producing a copy that silently writes to the original. CouchDB 3.x is a cluster even as a single node and keeps its identity inside the data (`_nodes.couch` plus the `_dbs` shard map, which records the owning Erlang node per shard range), so a duplicated data directory duplicates the cluster: the two instances find each other over epmd, form one cluster, and the copy - owning no shards - proxies every read and write to the source. A document written to the copy reads back on the original. It fails silently, because the copy starts, `/_up` returns 200, and reads look correct precisely because they are the parent's data. Unlike the port and `database_dir` (re-asserted on start since 0.62.7), this cannot be repaired by editing a config file: CouchDB has no supported in-place node rename. The isolated path is to create a fresh container and replicate into it (`POST /_replicate`), which is the direction tracked in #275. The refusal is raised before a running source is stopped, so an attempted branch no longer takes the database down on its way to failing.
+
 ## [0.62.7] - 2026-08-15
 
 ### Fixed

--- a/core/branch-manager.ts
+++ b/core/branch-manager.ts
@@ -23,7 +23,7 @@ import { existsSync } from 'fs'
 import { mkdir, rm } from 'fs/promises'
 import { join, extname, dirname } from 'path'
 import { paths } from '../config/paths'
-import { containerManager } from './container-manager'
+import { containerManager, assertDataDirCopyable } from './container-manager'
 import { processManager } from './process-manager'
 import { startContainerWithRetry } from './start-with-retry'
 import { cloneDirectory, type CopyMethod } from './cow-copy'
@@ -114,6 +114,11 @@ class BranchManager {
     }
 
     const { engine } = sourceConfig
+    // Refuse here, not deeper in the copy: a live source is STOPPED before the
+    // data directory is duplicated, so a late failure would take the user's
+    // database down for nothing.
+    assertDataDirCopyable(engine, 'Branching')
+
     if (await containerManager.exists(name, { engine })) {
       throw new Error(`Container "${name}" already exists`)
     }
@@ -382,6 +387,8 @@ class BranchManager {
     }
 
     // Stop a running server branch before removing it.
+    assertDataDirCopyable(config.engine, 'Resetting a branch')
+
     if (!isFileBasedEngine(config.engine) && !isRemoteContainer(config)) {
       const running = await processManager.isRunning(name, {
         engine: config.engine,

--- a/core/container-manager.ts
+++ b/core/container-manager.ts
@@ -54,6 +54,53 @@ export type DeleteOptions = {
   force?: boolean
 }
 
+/**
+ * Engines whose data directory cannot be duplicated into a second LIVE instance,
+ * with the reason surfaced to the user.
+ *
+ * CouchDB 3.x is a cluster even when it is a single node, and its identity lives
+ * INSIDE the data - `_nodes.couch` holds the node list and `_dbs.couch` holds the
+ * shard map, which records the owning Erlang node name per shard range. A copy
+ * therefore inherits the ORIGINAL's cluster: the two instances discover each
+ * other over epmd (they run on one host), form one cluster, and the copy owns no
+ * shards, so it proxies every read and write to the source. Observed directly:
+ * a document written to the copy reads back on the original.
+ *
+ * That is silent - the copy starts, `/_up` returns 200, and reads look correct
+ * because they are the parent's data - so refusing is safer than warning. Unlike
+ * the port and `database_dir` (which patchCouchDBConfig rewrites on start), this
+ * cannot be repaired by editing a config file: CouchDB has no supported in-place
+ * node rename. The isolated path is to create a fresh node and REPLICATE into it.
+ *
+ * See https://github.com/robertjbass/spindb/issues/275.
+ */
+const DATA_DIR_COPY_UNSAFE: Partial<Record<Engine, string>> = {
+  [Engine.CouchDB]:
+    'CouchDB stores its cluster identity inside the data directory (_nodes and ' +
+    'the _dbs shard map), so a copied instance joins the original cluster and ' +
+    'forwards its reads and writes to the source - the copy is NOT isolated, ' +
+    'and writing to it modifies the original. Create a new CouchDB container ' +
+    'and replicate into it instead (POST /_replicate). ' +
+    'Details: https://github.com/robertjbass/spindb/issues/275',
+}
+
+/**
+ * Throw when an engine's data directory must not be duplicated. Exported so the
+ * refusal is unit-testable without standing up a container.
+ */
+export function assertDataDirCopyable(engine: Engine, operation: string): void {
+  const reason = DATA_DIR_COPY_UNSAFE[engine]
+  if (!reason) return
+  // Compose the prefix explicitly: passing a custom message to
+  // UnsupportedOperationError REPLACES its default "<operation> is not supported
+  // for <engine>" line, and the user needs to see which operation was refused.
+  throw new UnsupportedOperationError(
+    operation,
+    engine,
+    `${operation} is not supported for ${engine}. ${reason}`,
+  )
+}
+
 export class ContainerManager {
   async create(name: string, options: CreateOptions): Promise<ContainerConfig> {
     const { engine, version, port, database, binaryPath, memoryBudgetMb } =
@@ -481,6 +528,9 @@ export class ContainerManager {
     }
 
     const { engine } = sourceConfig
+    // Both branch and clone land here, and both produce a second live instance
+    // off one data directory - which is exactly what CouchDB cannot survive.
+    assertDataDirCopyable(engine, 'Copying a data directory')
 
     // Check target doesn't exist (for this engine)
     if (await this.exists(targetName, { engine })) {

--- a/tests/unit/data-dir-copy-guard.test.ts
+++ b/tests/unit/data-dir-copy-guard.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the data-directory copy guard (issue #275).
+ *
+ * CouchDB 3.x is a cluster even as a single node, and its identity lives inside
+ * the DATA: `_nodes.couch` is the node list and `_dbs.couch` is the shard map,
+ * which records the owning Erlang node name per shard range. Duplicating the data
+ * directory therefore duplicates the cluster: the two instances find each other
+ * over epmd, form one cluster, and the copy - owning no shards - proxies every
+ * read and write to the source. A document written to the copy reads back on the
+ * original.
+ *
+ * It fails silently (the copy starts, `/_up` returns 200, reads look right
+ * because they ARE the parent's data), and unlike the port or `database_dir` it
+ * cannot be repaired by rewriting a config file, because CouchDB has no supported
+ * in-place node rename. So branch, branch-reset and clone all refuse.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { assertDataDirCopyable } from '../../core/container-manager'
+import { Engine } from '../../types'
+
+describe('assertDataDirCopyable', () => {
+  it('refuses CouchDB and says why, and how to get an isolated copy', () => {
+    assert.throws(
+      () => assertDataDirCopyable(Engine.CouchDB, 'Branching'),
+      (error: Error) => {
+        assert.equal(error.name, 'UnsupportedOperationError')
+        // The operation the user actually attempted, so the message reads right
+        // from `branch`, `branch reset` and `clone` alike.
+        assert.match(error.message, /^Branching is not supported for couchdb/)
+        // The mechanism, not just a refusal.
+        assert.match(error.message, /_nodes and the _dbs shard map/)
+        assert.match(
+          error.message,
+          /forwards its reads and writes to the source/,
+        )
+        // The way out.
+        assert.match(error.message, /replicate into it instead/i)
+        assert.match(error.message, /issues\/275/)
+        return true
+      },
+    )
+  })
+
+  it('carries the attempted operation through', () => {
+    for (const op of [
+      'Branching',
+      'Resetting a branch',
+      'Copying a data directory',
+    ]) {
+      // Assert on error.message, not the regexp form of assert.throws: that
+      // matches error.toString(), which starts with the error NAME, so a `^`
+      // anchor on the message can never match.
+      assert.throws(
+        () => assertDataDirCopyable(Engine.CouchDB, op),
+        (error: Error) => {
+          assert.match(
+            error.message,
+            new RegExp(`^${op} is not supported for couchdb`),
+          )
+          return true
+        },
+      )
+    }
+  })
+
+  it('allows every other engine', () => {
+    // A deny-list, so a new engine is copyable until proven otherwise - the same
+    // posture the rest of the branching code takes.
+    for (const engine of Object.values(Engine)) {
+      if (engine === Engine.CouchDB) continue
+      assert.doesNotThrow(
+        () => assertDataDirCopyable(engine, 'Branching'),
+        `${engine} must remain copyable`,
+      )
+    }
+  })
+
+  it('allows the engines the cloud actually branches today', () => {
+    // Pinned explicitly: a careless edit to the deny-list that caught one of
+    // these would break branching for real users of that engine.
+    for (const engine of [
+      Engine.PostgreSQL,
+      Engine.MySQL,
+      Engine.MariaDB,
+      Engine.Redis,
+      Engine.Valkey,
+      Engine.FerretDB,
+      Engine.LibSQL,
+      Engine.SQLite,
+      Engine.DuckDB,
+      Engine.TypeDB,
+      Engine.ClickHouse,
+      Engine.Meilisearch,
+    ]) {
+      assert.doesNotThrow(() => assertDataDirCopyable(engine, 'Branching'))
+    }
+  })
+})


### PR DESCRIPTION
Closes the silent half of #275. **Refuses the operation** rather than handing back a copy that writes to the original.

## Why CouchDB cannot be copied this way

CouchDB 3.x is a cluster even as a single node, and its identity lives **inside the data**, not in a config file:

- `_nodes.couch` — the cluster's node list
- `_dbs.couch` — the shard map, which records the **owning Erlang node name** per shard range
- `shards/…` — the actual documents

Duplicating the data directory duplicates the cluster. The copy boots under a different node name (spindb derives it from the port), but its `_nodes` still lists the original, so the two find each other over epmd on the same host and form **one** cluster — and its `_dbs` still says every shard belongs to the **source** node. The copy owns no shards, so it proxies every read and write to its parent.

Verified on 0.62.7:

- `/_membership` on **both** returns `[couchdb_15330@127.0.0.1, couchdb_15332@127.0.0.1]`
- `by_node` in the shard map still names only `couchdb_15330@127.0.0.1`
- a document written to the **copy** reads back **200 on the original**

It fails *silently* — the copy starts, `/_up` returns 200, and reads look correct because they are the parent's data. That is why refusing beats warning.

Unlike the port and `database_dir` (re-asserted on every start since #273 / 0.62.7), this cannot be repaired by rewriting config: CouchDB has no supported in-place node rename. An isolated copy needs a fresh node plus replication, which is the design work #275 still tracks.

## The change

- `assertDataDirCopyable(engine, operation)` in `core/container-manager.ts`, called from the shared `copyContainerData` — so **branch, branch reset and clone** are all covered by one guard.
- Also called at the top of `createBranch` / `resetBranch`, because a live source is **stopped before** the copy: a late failure would take the user's database down on its way to erroring.
- A **deny-list**, so a new engine stays copyable until proven otherwise — same posture as the rest of the branching code.
- The thrown message carries the attempted operation ("Branching is not supported for couchdb. …"), the mechanism, and the way out. Note `UnsupportedOperationError` *replaces* its default prefix when given a custom message, so the guard composes the prefix itself.

## Verification

4 unit cases in `tests/unit/data-dir-copy-guard.test.ts`: the refusal and its content, the operation prefix for each call site, every other engine still allowed, and an explicit pin on the twelve engines Layerbase Cloud branches today so a careless deny-list edit cannot break a real user. Unit suite **1706 pass / 0 fail**; `pnpm lint` (eslint + tsc) clean.

## Note for the cloud/desktop side

Layerbase Cloud already hard-blocks CouchDB branching for all callers including admins. Desktop had no such gate, which is what made this worth doing in spindb: with this merged, a local `lbase branch` of a CouchDB database fails loudly instead of quietly writing to the parent.