### PR TITLE
0.62.9: Weaviate node-identity fix (branches and clones keep their data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.9] - 2026-08-15
+
+### Fixed
+
+- **A branched or cloned Weaviate now serves its parent's data instead of coming up EMPTY.** Weaviate's raft store owns the schema and the shard-to-node assignments, keyed by the node name - and SpinDB derived that name from the port (`node-${port}`) while ALSO wiping `data/raft` whenever the bind:port identity changed between starts. A branch always lands on a new port, so it lost the raft store (the schema) and its objects sat inaccessible on disk. The node identity is now persisted in `.cluster-node-name` at the container-dir level: it rides along with any data-dir copy, so a branch keeps its parent's node name and loads the parent's raft store, while each instance still gossips alone (empty `CLUSTER_JOIN`, per-port gossip/raft binds). The wipe-raft-on-identity-change guard is retired - it silently emptied a database whenever its port moved - and `RAFT_ENABLE_ONE_NODE_RECOVERY=true` handles the advertise-address change instead (always single-node here, so it can never mask a real quorum). Legacy containers migrate on first start: if raft state exists, the old node name is recovered from the retired `.last-cluster-identity` tracker, so an existing database keeps its schema even across a later port change (previously the wipe destroyed it).
+
 ## [0.62.8] - 2026-08-15
 
 ### Changed

--- a/engines/weaviate/index.ts
+++ b/engines/weaviate/index.ts
@@ -1,6 +1,6 @@
 import { spawn, type SpawnOptions } from 'child_process'
 import { existsSync, openSync, closeSync } from 'fs'
-import { chmod, mkdir, writeFile, readFile, unlink, rm } from 'fs/promises'
+import { chmod, mkdir, writeFile, readFile, unlink } from 'fs/promises'
 import { join } from 'path'
 import { BaseEngine } from '../base-engine'
 import { paths } from '../../config/paths'
@@ -48,6 +48,57 @@ import { parseRESTAPIResult } from '../../core/query-parser'
 
 const ENGINE = 'weaviate'
 const engineDef = getEngineDefaults(ENGINE)
+
+/**
+ * Resolve the container's stable cluster node identity (CLUSTER_HOSTNAME /
+ * RAFT_JOIN), persisting it in `.cluster-node-name` at the container-dir level
+ * on first resolution.
+ *
+ * Why persisted instead of derived: Weaviate's raft store (which owns the
+ * schema and the shard-to-node assignments) is keyed by the node name. The old
+ * `node-${port}` derivation changed the name whenever the port changed, so any
+ * data-dir copy that lands on a new port - `spindb branch`, `spindb clone` -
+ * could not load the copied raft store and came up with an EMPTY schema, while
+ * the objects sat inaccessible on disk. The identity file rides along with the
+ * copied container dir, so a branch keeps its parent's node name, loads the
+ * parent's raft store, and serves the parent's data (each instance still
+ * gossips alone: CLUSTER_JOIN is empty and the gossip/raft bind ports derive
+ * from each instance's own HTTP port).
+ *
+ * Backward compatibility, first resolution on an existing container:
+ * - If raft state exists and `.last-cluster-identity` (the retired wipe
+ *   tracker) recorded the port the raft store was written under, persist
+ *   `node-<thatPort>` so the existing schema keeps loading even if the port
+ *   has since changed.
+ * - Otherwise persist `node-${port}` - identical to the old derivation.
+ */
+export async function resolveWeaviateNodeIdentity(options: {
+  containerDir: string
+  dataDir: string
+  port: number
+}): Promise<string> {
+  const { containerDir, dataDir, port } = options
+  const nodeNameFile = join(containerDir, '.cluster-node-name')
+  if (existsSync(nodeNameFile)) {
+    const persisted = (await readFile(nodeNameFile, 'utf-8')).trim()
+    if (persisted) return persisted
+  }
+
+  let nodeName = `node-${port}`
+  const legacyIdentityFile = join(containerDir, '.last-cluster-identity')
+  if (existsSync(join(dataDir, 'raft')) && existsSync(legacyIdentityFile)) {
+    try {
+      const lastIdentity = (await readFile(legacyIdentityFile, 'utf-8')).trim()
+      const match = lastIdentity.match(/:(\d+)$/)
+      if (match) nodeName = `node-${match[1]}`
+    } catch {
+      // Unreadable tracker: fall through to the port-derived name.
+    }
+  }
+
+  await writeFile(nodeNameFile, nodeName)
+  return nodeName
+}
 
 /**
  * Parse a Weaviate connection string
@@ -454,30 +505,15 @@ export class WeaviateEngine extends BaseEngine {
       return null
     }
 
-    // Clean up RAFT state if the cluster identity changed since last start.
-    // RAFT persists the cluster advertise address and node name; stale state
-    // causes Weaviate to hang trying to rejoin the old node on restart.
-    // Track both bind address and port since RAFT ports derive from the HTTP port.
-    const bindFile = join(containerDir, '.last-cluster-identity')
+    // Node identity is persisted (.cluster-node-name), so a port change no
+    // longer changes the raft identity and the old wipe-raft-on-identity-change
+    // guard is retired. The raft store holds the SCHEMA, so that wipe silently
+    // emptied a database whenever its port moved - and it is what broke
+    // `spindb branch` for Weaviate (a branch always lands on a new port).
+    // Address changes are handled by RAFT_ENABLE_ONE_NODE_RECOVERY below.
+    // `.last-cluster-identity` is no longer written; it is read once by
+    // resolveWeaviateNodeIdentity to migrate legacy containers.
     const currentBind = container.bindAddress ?? '127.0.0.1'
-    const currentIdentity = `${currentBind}:${port}`
-    try {
-      const lastIdentity = existsSync(bindFile)
-        ? (await readFile(bindFile, 'utf-8')).trim()
-        : null
-      if (lastIdentity && lastIdentity !== currentIdentity) {
-        const raftDir = join(dataDir, 'raft')
-        if (existsSync(raftDir)) {
-          logDebug(
-            `Cluster identity changed (${lastIdentity} → ${currentIdentity}), wiping RAFT state`,
-          )
-          await rm(raftDir, { recursive: true, force: true })
-        }
-      }
-      await writeFile(bindFile, currentIdentity)
-    } catch (error) {
-      logDebug(`RAFT identity check failed: ${error}`)
-    }
 
     // Weaviate uses environment variables for configuration
     const args = [
@@ -517,9 +553,13 @@ export class WeaviateEngine extends BaseEngine {
       }
     }
 
-    // Node identity must be consistent across all starts AND restores.
-    // Use port-based naming for uniqueness when multiple containers run.
-    const nodeHostname = `node-${port}`
+    // Node identity must be consistent across all starts, restores, AND
+    // data-dir copies (branch/clone) - see resolveWeaviateNodeIdentity.
+    const nodeHostname = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port,
+    })
 
     // Weaviate's RAFT layer rejects wildcard bind addresses (0.0.0.0, ::)
     // as cluster advertise addresses — "local bind address is not advertisable"
@@ -542,6 +582,11 @@ export class WeaviateEngine extends BaseEngine {
       CLUSTER_JOIN: '',
       RAFT_JOIN: nodeHostname,
       RAFT_BOOTSTRAP_EXPECT: '1',
+      // Single-node recovery: lets a raft store written under a different
+      // advertise address (a branched/cloned data dir, or a moved container)
+      // load instead of hanging on the old peer address. Always single-node
+      // here (CLUSTER_JOIN is empty), so this can never mask a real quorum.
+      RAFT_ENABLE_ONE_NODE_RECOVERY: 'true',
       GRPC_PORT: String(grpcPort),
       CLUSTER_GOSSIP_BIND_PORT: String(gossipPort),
       CLUSTER_DATA_BIND_PORT: String(dataPort),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.8",
+  "version": "0.62.9",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/data-dir-copy-guard.test.ts
+++ b/tests/unit/data-dir-copy-guard.test.ts
@@ -92,6 +92,9 @@ describe('assertDataDirCopyable', () => {
       Engine.TypeDB,
       Engine.ClickHouse,
       Engine.Meilisearch,
+      Engine.Qdrant,
+      Engine.QuestDB,
+      Engine.InfluxDB,
     ]) {
       assert.doesNotThrow(() => assertDataDirCopyable(engine, 'Branching'))
     }

--- a/tests/unit/weaviate-node-identity.test.ts
+++ b/tests/unit/weaviate-node-identity.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for resolveWeaviateNodeIdentity.
+ *
+ * Weaviate's raft store (schema + shard-to-node assignments) is keyed by the
+ * node name. Deriving the name from the port (`node-${port}`) meant any
+ * data-dir copy landing on a new port - `spindb branch`, `spindb clone` -
+ * could not load the copied raft store and came up with an EMPTY schema. The
+ * identity is now persisted in `.cluster-node-name` at the container-dir
+ * level, so it rides along with copies and stays stable across port changes.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { resolveWeaviateNodeIdentity } from '../../engines/weaviate'
+
+let containerDir: string
+let dataDir: string
+
+beforeEach(async () => {
+  containerDir = await mkdtemp(join(tmpdir(), 'wv-identity-'))
+  dataDir = join(containerDir, 'data')
+  await mkdir(dataDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(containerDir, { recursive: true, force: true })
+})
+
+describe('resolveWeaviateNodeIdentity', () => {
+  it('derives node-<port> on a fresh container and persists it', async () => {
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 8080,
+    })
+    assert.equal(name, 'node-8080')
+    const persisted = await readFile(
+      join(containerDir, '.cluster-node-name'),
+      'utf-8',
+    )
+    assert.equal(persisted, 'node-8080')
+  })
+
+  it('returns the persisted name even when the port has changed', async () => {
+    await resolveWeaviateNodeIdentity({ containerDir, dataDir, port: 8080 })
+    // The container moves to a new port (branch, clone, or an edit) - the
+    // identity must NOT follow the port, or the raft store stops loading.
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 9151,
+    })
+    assert.equal(name, 'node-8080')
+  })
+
+  it('a copied container dir inherits the source identity (the branch case)', async () => {
+    await resolveWeaviateNodeIdentity({ containerDir, dataDir, port: 8080 })
+    // Simulate `spindb branch`: the whole container dir is copied, then the
+    // branch starts on its own port.
+    const branchDir = await mkdtemp(join(tmpdir(), 'wv-identity-branch-'))
+    try {
+      const branchData = join(branchDir, 'data')
+      await mkdir(branchData, { recursive: true })
+      await writeFile(
+        join(branchDir, '.cluster-node-name'),
+        await readFile(join(containerDir, '.cluster-node-name'), 'utf-8'),
+      )
+      const branchName = await resolveWeaviateNodeIdentity({
+        containerDir: branchDir,
+        dataDir: branchData,
+        port: 9151,
+      })
+      assert.equal(branchName, 'node-8080', 'branch must keep the parent name')
+    } finally {
+      await rm(branchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('legacy container with raft state: derives the name from the retired identity tracker', async () => {
+    // A pre-fix container that ran on port 8080, has raft state owned by
+    // node-8080, and whose port has since changed to 9151. The retired
+    // `.last-cluster-identity` recorded bind:port; the raft store must keep
+    // loading, so the OLD port wins.
+    await mkdir(join(dataDir, 'raft'), { recursive: true })
+    await writeFile(
+      join(containerDir, '.last-cluster-identity'),
+      '0.0.0.0:8080',
+    )
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 9151,
+    })
+    assert.equal(name, 'node-8080')
+    // And it is now persisted, so later starts stop consulting the tracker.
+    assert.equal(
+      (
+        await readFile(join(containerDir, '.cluster-node-name'), 'utf-8')
+      ).trim(),
+      'node-8080',
+    )
+  })
+
+  it('legacy tracker without raft state is ignored (nothing to preserve)', async () => {
+    await writeFile(
+      join(containerDir, '.last-cluster-identity'),
+      '0.0.0.0:8080',
+    )
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 9151,
+    })
+    assert.equal(name, 'node-9151')
+  })
+
+  it('malformed tracker falls back to the port-derived name', async () => {
+    await mkdir(join(dataDir, 'raft'), { recursive: true })
+    await writeFile(join(containerDir, '.last-cluster-identity'), 'garbage')
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 9151,
+    })
+    assert.equal(name, 'node-9151')
+  })
+
+  it('an empty persisted file is treated as absent', async () => {
+    await writeFile(join(containerDir, '.cluster-node-name'), '')
+    const name = await resolveWeaviateNodeIdentity({
+      containerDir,
+      dataDir,
+      port: 8080,
+    })
+    assert.equal(name, 'node-8080')
+  })
+})


### PR DESCRIPTION
Publishes 0.62.9 to npm.

- d8d73ac fix(weaviate): persist node identity so branches and clones keep their data (#278)

The one change: Weaviate's node identity is persisted (.cluster-node-name) instead of derived from the port, the raft wipe-on-identity-change guard is retired, and RAFT_ENABLE_ONE_NODE_RECOVERY handles address changes. A branched/cloned Weaviate now serves its parent's data instead of coming up empty, and an existing database survives a port change that previously destroyed its schema. Full validation table in #278.

After npm publish: cloud image bump to 0.62.9, then the Weaviate branching allowlist pass in layerbase-cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Branched and cloned Weaviate instances now retain and serve their parent’s data reliably.
  * Improved recovery when instances are moved, copied, or have changed network ports.
  * Preserved isolated cluster communication for each instance.

* **Tests**
  * Added coverage for identity persistence, cloning, port changes, and legacy data recovery.

* **Chores**
  * Updated the release version to 0.62.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->