### PR TITLE
test: the cloud-branchable pin gains Weaviate (allowlist closed at 16)

### DIFF
--- a/tests/unit/data-dir-copy-guard.test.ts
+++ b/tests/unit/data-dir-copy-guard.test.ts
@@ -95,6 +95,7 @@ describe('assertDataDirCopyable', () => {
       Engine.Qdrant,
       Engine.QuestDB,
       Engine.InfluxDB,
+      Engine.Weaviate,
     ]) {
       assert.doesNotThrow(() => assertDataDirCopyable(engine, 'Branching'))
     }


### PR DESCRIPTION
Deferred from the 0.62.9 release: Weaviate was allowlisted cloud-side only after 0.62.9 shipped, so the `data-dir-copy-guard` pin of "engines the cloud actually branches today" stopped one short. The cloud allowlist is now closed by decision at 16 (CouchDB + TigerBeetle permanently excluded), so this list is final. Test-only; rides the next release.