### PR TITLE
release: spindb 0.63.0 (QuestDB 10.0.1, default line 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-08-25
+
+### Added
+
+- **QuestDB 10.0.1 support** via the hostdb `0.40.0` pin (upstream patch of the 10.0 line, published 2026-08-24). All 5 platforms; the JRE-bundled platforms (darwin-arm64, darwin-x64, linux-arm64) carry Temurin JRE 25, and 10.0.1's launcher flags are the same set as 9.4.x, verified against that JRE. Real-binary integration tests now run QuestDB on the `10` line.
+
+### Changed
+
+- **QuestDB's default line is now `10`** (was `9`): `spindb create --engine questdb` without an explicit version resolves to 10.0.1. The 9 line (9.2.3, 9.4.3) remains fully supported and resolvable; existing 9.x containers are untouched. Minor bump because the recommended default changed.
+- **Pin `hostdb` to `0.40.0`** (was 0.39.0).
+
 ## [0.62.10] - 2026-08-18
 
 ### Fixed

--- a/config/engine-defaults.ts
+++ b/config/engine-defaults.ts
@@ -252,7 +252,7 @@ export const engineDefaults: Record<Engine, EngineDefaults> = {
     maxConnections: 0, // Not applicable - managed internally
   },
   [Engine.QuestDB]: {
-    defaultVersion: '9',
+    defaultVersion: '10',
     defaultPort: 8812, // QuestDB PostgreSQL wire protocol port
     portRange: { start: 8812, end: 8912 },
     superuser: 'admin', // Default user with password 'quest'

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.62.10'
+export const VERSION = '0.63.0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.62.10",
+  "version": "0.63.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.39.0",
+    "hostdb": "0.40.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.39.0
-        version: 0.39.0
+        specifier: 0.40.0
+        version: 0.40.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.39.0:
-    resolution: {integrity: sha512-wwTtsjnOcXgLwJvBS83kzcQNTBdLlM5oFXmBsQpWQWGeIcwgx7ZXUZKxCOmaoo35Inw5P6WVMjpJHqR2v7p9Qw==}
+  hostdb@0.40.0:
+    resolution: {integrity: sha512-e3mLb2CBzHa52iEc1t464Y962rC37UPnnypxO430y5veTYpYuNTK8wRAcJ+9uIhWaXzpQlTRq/lhp0i2w6FfdA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.39.0: {}
+  hostdb@0.40.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -85,7 +85,7 @@ export const TEST_PORTS = {
 export const TEST_VERSIONS = {
   cockroachdb: '25',
   surrealdb: '2',
-  questdb: '9',
+  questdb: '10',
   typedb: '3',
 }
 


### PR DESCRIPTION
Publishes spindb 0.63.0:

- hostdb pin 0.39.0 -> 0.40.0 (QuestDB 10.0.1, all 5 platforms; Temurin 25 JRE bundles on the three no-rt platforms)
- QuestDB defaultVersion '9' -> '10' (create without a version resolves 10.0.1); 9.2.3/9.4.3 remain supported, existing 9.x containers untouched
- Integration tests boot the 10 line with real binaries

Local gates were green (hostdb-sync 23/23, unit 1716/1716, questdb real-binary 15/15 booting 10.0.1-darwin-arm64, cli 54/54). This PR runs the full 5-platform engine matrix; per the engine-version runbook, no downstream pin (cloud/desktop) moves until this matrix is fully green and 0.63.0 is on npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for QuestDB 10.0.1.
  - Added bundled Temurin JRE 25 coverage across supported platforms.
  - Verified launcher compatibility and real-binary integration testing.

- **Bug Fixes**
  - Updated the default QuestDB version to 10.

- **Chores**
  - Released version 0.63.0 with updated platform support tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->