### PR TITLE
feat(pull): add --exclude-table and --exclude-table-data flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+All agent instructions for this repository live in [CLAUDE.md](CLAUDE.md) —
+read that file in full before making changes. Related authoritative docs:
+[ENGINE_CHECKLIST.md](ENGINE_CHECKLIST.md), [ARCHITECTURE.md](ARCHITECTURE.md),
+[STYLEGUIDE.md](STYLEGUIDE.md), [docs/ENGINE_NOTES.md](docs/ENGINE_NOTES.md).
+
+Cross-repo reminder: when updating spindb, check whether `~/dev/layerbase-cli`
+needs a matching docs update. That CLI forwards non-layerbase commands verbatim
+to spindb and documents spindb's command surface as its own, and its
+`scripts/check-spindb-collisions.ts` validates layerbase verbs against
+`spindb --help`. New spindb flags forward transparently, but new, renamed, or
+removed top-level spindb commands can collide with layerbase verbs or leave its
+docs stale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-08-25
+
 ### Added
 
-- **`spindb pull --exclude-table <name>` and `--exclude-table-data <name>`** (both repeatable): skip tables/collections when pulling a remote database. `--exclude-table` omits the table entirely; `--exclude-table-data` (PostgreSQL only) keeps the table's schema but skips its rows — the right tool for cloning a production database whose analytics/event tables are most of the bytes but useless locally. Supported engines for `--exclude-table`: PostgreSQL (`pg_dump --exclude-table`), MySQL/MariaDB (`--ignore-table`, bare names are auto-qualified with the dumped database), MongoDB/FerretDB (`mongodump --excludeCollection`). Unsupported engines fail fast with a clear error before anything is dumped or dropped. Exclusion applies only to the remote dump — the local pre-pull backup remains complete. Pull results (including `--json`) now report `excludedTables` / `excludedTableData` when used.
+- **`spindb pull --exclude-table <name>` and `--exclude-table-data <name>`** (both repeatable): skip tables/collections when pulling a remote database. `--exclude-table` omits the table entirely; `--exclude-table-data` (PostgreSQL only) keeps the table's schema but skips its rows — the right tool for cloning a production database whose analytics/event tables are most of the bytes but useless locally. Supported engines for `--exclude-table`: PostgreSQL (`pg_dump --exclude-table`), MySQL/MariaDB (`--ignore-table`, bare names are auto-qualified with the dumped database), MongoDB/FerretDB (`mongodump --excludeCollection`). Unsupported engines fail fast with a clear error before anything is dumped or dropped. Exclusion applies only to the remote dump — the local pre-pull backup remains complete. Pull results (including `--json`) now report `excludedTables` / `excludedTableData` when used. Covered by unit tests for the engine allowlist validation and a real-engine PostgreSQL integration round trip proving the excluded table is absent and the schema-only table restores empty.
+
+### Documentation
+
+- **CLAUDE.md/AGENTS.md now record the layerbase-cli cross-repo dependency**: spindb CLI surface changes should trigger a docs review of `~/dev/layerbase-cli`, whose README/help present spindb's commands as their own and whose collision checker validates layerbase verbs against `spindb --help`.
 
 ## [0.63.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`spindb pull --exclude-table <name>` and `--exclude-table-data <name>`** (both repeatable): skip tables/collections when pulling a remote database. `--exclude-table` omits the table entirely; `--exclude-table-data` (PostgreSQL only) keeps the table's schema but skips its rows — the right tool for cloning a production database whose analytics/event tables are most of the bytes but useless locally. Supported engines for `--exclude-table`: PostgreSQL (`pg_dump --exclude-table`), MySQL/MariaDB (`--ignore-table`, bare names are auto-qualified with the dumped database), MongoDB/FerretDB (`mongodump --excludeCollection`). Unsupported engines fail fast with a clear error before anything is dumped or dropped. Exclusion applies only to the remote dump — the local pre-pull backup remains complete. Pull results (including `--json`) now report `excludedTables` / `excludedTableData` when used.
+
 ## [0.63.0] - 2026-08-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@
 
 ## Ecosystem
 
-SpinDB is the backbone of the Layerbase platform. **hostdb** builds database binaries and publishes them to `registry.layerbase.host` — spindb downloads them. **layerbase-cloud** (`~/dev/layerbase-cloud`) runs spindb inside Docker containers on Hetzner to provide managed databases with connection strings. **layerbase-desktop** (`~/dev/layerbase-desktop`) is an Electron GUI that calls spindb via IPC — it must never contain database logic that isn't in spindb. **layerbase** (`~/dev/layerbase`) is the Next.js web app at layerbase.com for billing, licensing, and the cloud dashboard. Changes to spindb's CLI output or flags are breaking changes for layerbase-desktop.
+SpinDB is the backbone of the Layerbase platform. **hostdb** builds database binaries and publishes them to `registry.layerbase.host` — spindb downloads them. **layerbase-cloud** (`~/dev/layerbase-cloud`) runs spindb inside Docker containers on Hetzner to provide managed databases with connection strings. **layerbase-desktop** (`~/dev/layerbase-desktop`) is an Electron GUI that calls spindb via IPC — it must never contain database logic that isn't in spindb. **layerbase** (`~/dev/layerbase`) is the Next.js web app at layerbase.com for billing, licensing, and the cloud dashboard. **layerbase-cli** (`~/dev/layerbase-cli`) is the branded `layerbase`/`lbase` npm CLI that forwards every non-layerbase command verbatim to the local spindb install. Changes to spindb's CLI output or flags are breaking changes for layerbase-desktop.
+
+**When updating spindb, check whether `~/dev/layerbase-cli` needs a matching docs update.** layerbase-cli's README/help present spindb's command surface as their own (`lbase create / ls / start / backup / branch ...`), and `scripts/check-spindb-collisions.ts` there validates layerbase's registered verbs against `spindb --help`. New spindb flags forward transparently, but a NEW top-level spindb command (or renamed/removed one) can collide with a layerbase verb or make its docs stale — review layerbase-cli's CLAUDE.md/README after any spindb CLI surface change.
 
 ## Overview
 

--- a/TODO.md
+++ b/TODO.md
@@ -268,6 +268,7 @@ SQL seed files are passed via command-line argument (`-e` or `-c`), which could 
 The `spindb pull` command is implemented but needs comprehensive testing across all engines. See `plans/CLONE_FEATURE.md` for detailed status.
 
 - [ ] **End-to-end pull tests** - Test full `spindb pull` workflow for each engine (replace mode, clone mode)
+- [ ] **`--exclude-table` integration tests for MySQL/MariaDB/MongoDB/FerretDB** - Real-engine round trips proving excluded tables/collections are absent. PostgreSQL is covered (`tests/integration/postgresql.test.ts` verifies both `--exclude-table` and `--exclude-table-data`); unit coverage of the allowlist validation exists in `tests/unit/pull-manager.test.ts`
 - [ ] **Post-script integration** - Verify `SPINDB_CONTEXT` JSON and legacy env vars work correctly
 - [ ] **Error handling** - Test network timeouts, invalid credentials, disk space, transaction rollback
 - [ ] **terminateConnections audit** - Verify engines that need connection termination have proper implementations

--- a/cli/commands/pull.ts
+++ b/cli/commands/pull.ts
@@ -19,6 +19,10 @@ import { createSpinner } from '../ui/spinner'
 import { promptConfirm } from '../ui/prompts'
 import { uiError } from '../ui/theme'
 
+function collectRepeatable(value: string, previous: string[]): string[] {
+  return [...previous, value]
+}
+
 export const pullCommand = new Command('pull')
   .description('Pull remote database data into local container')
   .argument('<container>', 'Container name')
@@ -27,6 +31,18 @@ export const pullCommand = new Command('pull')
   .option('-d, --database <name>', 'Target database (default: primary)')
   .option('--as <name>', 'Clone to new database instead of replacing')
   .option('--no-backup', 'Skip backup when replacing (dangerous)')
+  .option(
+    '--exclude-table <table>',
+    'Skip a table/collection entirely (repeatable)',
+    collectRepeatable,
+    [] as string[],
+  )
+  .option(
+    '--exclude-table-data <table>',
+    'Keep table schema but skip its rows (PostgreSQL only, repeatable)',
+    collectRepeatable,
+    [] as string[],
+  )
   .option('--post-script <path>', 'Run script after pull completes')
   .option('--dry-run', 'Preview changes without executing')
   .option('-f, --force', 'Skip confirmation prompts')
@@ -40,6 +56,8 @@ export const pullCommand = new Command('pull')
         database?: string
         as?: string
         backup: boolean // Commander inverts --no-backup to backup: false
+        excludeTable: string[]
+        excludeTableData: string[]
         postScript?: string
         dryRun?: boolean
         force?: boolean
@@ -145,6 +163,8 @@ export const pullCommand = new Command('pull')
           fromUrl: fromUrl,
           asDatabase: options.as,
           noBackup: !options.backup,
+          excludeTables: options.excludeTable,
+          excludeTableData: options.excludeTableData,
           postScript: options.postScript,
           dryRun: options.dryRun,
           force: options.force,
@@ -171,6 +191,16 @@ export const pullCommand = new Command('pull')
           console.log(
             `  ${chalk.dim('Source:')}    ${chalk.gray(result.source)}`,
           )
+          if (result.excludedTables?.length) {
+            console.log(
+              `  ${chalk.dim('Excluded:')}  ${result.excludedTables.join(', ')}`,
+            )
+          }
+          if (result.excludedTableData?.length) {
+            console.log(
+              `  ${chalk.dim('Schema-only:')} ${result.excludedTableData.join(', ')}`,
+            )
+          }
           console.log('')
 
           if (result.mode === 'replace') {
@@ -207,6 +237,16 @@ export const pullCommand = new Command('pull')
           console.log(
             `  ${chalk.dim('Source:')}    ${chalk.gray(result.source)}`,
           )
+          if (result.excludedTables?.length) {
+            console.log(
+              `  ${chalk.dim('Excluded:')}  ${result.excludedTables.join(', ')}`,
+            )
+          }
+          if (result.excludedTableData?.length) {
+            console.log(
+              `  ${chalk.dim('Schema-only:')} ${result.excludedTableData.join(', ')}`,
+            )
+          }
           console.log('')
         }
       } catch (error) {

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.63.0'
+export const VERSION = '0.64.0'

--- a/core/pull-manager.ts
+++ b/core/pull-manager.ts
@@ -15,9 +15,63 @@ import { withTransaction } from './transaction-manager'
 import { containerManager } from './container-manager'
 import { getEngine } from '../engines'
 import { logDebug } from './error-handler'
-import type { ContainerConfig, PullOptions, PullResult, Engine } from '../types'
+import { Engine } from '../types'
+import type {
+  ContainerConfig,
+  PullOptions,
+  PullResult,
+  RemoteDumpOptions,
+} from '../types'
 import type { BaseEngine } from '../engines/base-engine'
 import { getDefaultFormat } from '../config/backup-formats'
+
+/**
+ * Engines whose remote dump tool can exclude tables/collections entirely
+ * (--exclude-table). pg_dump: --exclude-table, mysqldump/mariadb-dump:
+ * --ignore-table, mongodump: --excludeCollection.
+ */
+export const EXCLUDE_TABLES_ENGINES: Engine[] = [
+  Engine.PostgreSQL,
+  Engine.MySQL,
+  Engine.MariaDB,
+  Engine.MongoDB,
+  Engine.FerretDB,
+]
+
+/**
+ * Engines whose remote dump tool can keep a table's schema while skipping its
+ * rows (--exclude-table-data). Only pg_dump supports this natively.
+ */
+export const EXCLUDE_TABLE_DATA_ENGINES: Engine[] = [Engine.PostgreSQL]
+
+/**
+ * Validate --exclude-table / --exclude-table-data against the engine's
+ * capabilities. Throws with an actionable message on unsupported combinations.
+ */
+export function validateExcludeOptions(
+  engine: Engine,
+  options: Pick<PullOptions, 'excludeTables' | 'excludeTableData'>,
+): void {
+  if (
+    options.excludeTables?.length &&
+    !EXCLUDE_TABLES_ENGINES.includes(engine)
+  ) {
+    throw new Error(
+      `--exclude-table is not supported for ${engine}.\n` +
+        `  Supported engines: ${EXCLUDE_TABLES_ENGINES.join(', ')}`,
+    )
+  }
+  if (
+    options.excludeTableData?.length &&
+    !EXCLUDE_TABLE_DATA_ENGINES.includes(engine)
+  ) {
+    throw new Error(
+      `--exclude-table-data is not supported for ${engine}.\n` +
+        `  Supported engines: ${EXCLUDE_TABLE_DATA_ENGINES.join(', ')}\n` +
+        '  To skip a table entirely (schema and data), use --exclude-table.',
+    )
+  }
+}
 
 /**
  * Context passed to post-pull scripts via SPINDB_CONTEXT env var.
@@ -56,6 +110,9 @@ export class PullManager {
 
     const engine = getEngine(config.engine)
     const timestamp = this.generateTimestamp()
+
+    // Fail fast if table exclusion was requested on an engine that can't do it
+    validateExcludeOptions(config.engine, options)
 
     // 2. Determine mode and target database
     const isCloneMode = !!options.asDatabase
@@ -169,7 +226,11 @@ export class PullManager {
 
       // Step 4: Dump remote to temp file
       logDebug(`Dumping remote database to: ${tempRemoteDump}`)
-      await engine.dumpFromConnectionString(options.fromUrl, tempRemoteDump)
+      await engine.dumpFromConnectionString(
+        options.fromUrl,
+        tempRemoteDump,
+        this.remoteDumpOptions(options),
+      )
       tx.addRollback({
         description: 'Delete remote dump temp file',
         execute: async () => {
@@ -268,6 +329,12 @@ export class PullManager {
           ? engine.getConnectionString(config, backupDatabase)
           : undefined,
         source: this.redactUrl(options.fromUrl),
+        excludedTables: options.excludeTables?.length
+          ? options.excludeTables
+          : undefined,
+        excludedTableData: options.excludeTableData?.length
+          ? options.excludeTableData
+          : undefined,
         message: keepBackup
           ? `Pulled remote data into "${targetDatabase}", backup at "${backupDatabase}"`
           : `Pulled remote data into "${targetDatabase}"`,
@@ -324,7 +391,11 @@ export class PullManager {
 
       // Step 3: Dump remote to temp file
       logDebug(`Dumping remote database to: ${tempRemoteDump}`)
-      await engine.dumpFromConnectionString(options.fromUrl, tempRemoteDump)
+      await engine.dumpFromConnectionString(
+        options.fromUrl,
+        tempRemoteDump,
+        this.remoteDumpOptions(options),
+      )
       tx.addRollback({
         description: 'Delete remote dump temp file',
         execute: async () => {
@@ -383,6 +454,12 @@ export class PullManager {
         database: targetDatabase,
         databaseUrl: engine.getConnectionString(config, targetDatabase),
         source: this.redactUrl(options.fromUrl),
+        excludedTables: options.excludeTables?.length
+          ? options.excludeTables
+          : undefined,
+        excludedTableData: options.excludeTableData?.length
+          ? options.excludeTableData
+          : undefined,
         message: `Cloned remote data into new database "${targetDatabase}"`,
       }
     })
@@ -435,6 +512,18 @@ export class PullManager {
       } catch {
         // Ignore errors
       }
+    }
+  }
+
+  private remoteDumpOptions(
+    options: PullOptions,
+  ): RemoteDumpOptions | undefined {
+    if (!options.excludeTables?.length && !options.excludeTableData?.length) {
+      return undefined
+    }
+    return {
+      excludeTables: options.excludeTables,
+      excludeTableData: options.excludeTableData,
     }
   }
 
@@ -503,6 +592,12 @@ export class PullManager {
         ? engine.getConnectionString(config, backupDatabase!)
         : undefined,
       source: this.redactUrl(options.fromUrl),
+      excludedTables: options.excludeTables?.length
+        ? options.excludeTables
+        : undefined,
+      excludedTableData: options.excludeTableData?.length
+        ? options.excludeTableData
+        : undefined,
       message: '[DRY RUN] No changes made',
     }
   }

--- a/engines/base-engine.ts
+++ b/engines/base-engine.ts
@@ -6,6 +6,7 @@ import type {
   BackupResult,
   RestoreResult,
   DumpResult,
+  RemoteDumpOptions,
   StatusResult,
   QueryResult,
   QueryOptions,
@@ -276,10 +277,14 @@ export abstract class BaseEngine {
     return new Map()
   }
 
-  // Create a dump from a remote database using a connection string
+  // Create a dump from a remote database using a connection string.
+  // Engines that support table exclusion honor options.excludeTables /
+  // options.excludeTableData; support is gated by the allowlists in
+  // core/pull-manager.ts, so unsupported engines never receive them.
   abstract dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult>
 
   /**

--- a/engines/ferretdb/index.ts
+++ b/engines/ferretdb/index.ts
@@ -79,6 +79,7 @@ import {
   type BackupResult,
   type RestoreResult,
   type DumpResult,
+  type RemoteDumpOptions,
   type StatusResult,
   type QueryResult,
   type QueryOptions,
@@ -1580,6 +1581,7 @@ export class FerretDBEngine extends BaseEngine {
   async dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult> {
     // Use mongodump if available
     const mongodump = await configManager.getBinaryPath('mongodump')
@@ -1596,6 +1598,26 @@ export class FerretDBEngine extends BaseEngine {
       '--archive=' + outputPath,
       '--gzip',
     ]
+
+    if (options?.excludeTables?.length) {
+      // mongodump only accepts --excludeCollection together with --db
+      let database = ''
+      try {
+        database = new URL(connectionString).pathname.replace(/^\//, '')
+      } catch {
+        // Fall through to the error below
+      }
+      if (!database) {
+        throw new Error(
+          'Excluding collections requires a database in the connection string.\n' +
+            '  Example: mongodb://user:pass@host:27017/mydb',
+        )
+      }
+      args.push('--db', database)
+      for (const collection of options.excludeTables) {
+        args.push(`--excludeCollection=${collection}`)
+      }
+    }
 
     const spawnOptions: SpawnOptions = {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/engines/mariadb/index.ts
+++ b/engines/mariadb/index.ts
@@ -47,6 +47,7 @@ import {
   type BackupResult,
   type RestoreResult,
   type DumpResult,
+  type RemoteDumpOptions,
   type StatusResult,
   type QueryResult,
   type QueryOptions,
@@ -966,6 +967,7 @@ export class MariaDBEngine extends BaseEngine {
   async dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult> {
     const dumpPath = await this.getDumpPath()
 
@@ -981,6 +983,12 @@ export class MariaDBEngine extends BaseEngine {
       user,
       '--result-file',
       outputPath,
+      // mariadb-dump requires db-qualified names; qualify bare names with the
+      // database being dumped
+      ...(options?.excludeTables ?? []).map(
+        (table) =>
+          `--ignore-table=${table.includes('.') ? table : `${database}.${table}`}`,
+      ),
       database,
     ]
 

--- a/engines/mongodb/index.ts
+++ b/engines/mongodb/index.ts
@@ -50,6 +50,7 @@ import {
   type BackupResult,
   type RestoreResult,
   type DumpResult,
+  type RemoteDumpOptions,
   type StatusResult,
   type QueryResult,
   type QueryOptions,
@@ -879,6 +880,7 @@ export class MongoDBEngine extends BaseEngine {
   async dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult> {
     const mongodump = await getMongodumpPath()
     if (!mongodump) {
@@ -897,6 +899,9 @@ export class MongoDBEngine extends BaseEngine {
       parsed.database,
       '--archive=' + outputPath,
       '--gzip',
+      ...(options?.excludeTables ?? []).map(
+        (collection) => `--excludeCollection=${collection}`,
+      ),
     ]
 
     // Note: Don't use shell mode - spawn handles paths with spaces correctly

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -55,6 +55,7 @@ import {
   type BackupResult,
   type RestoreResult,
   type DumpResult,
+  type RemoteDumpOptions,
   type StatusResult,
   type QueryResult,
   type QueryOptions,
@@ -1050,6 +1051,7 @@ export class MySQLEngine extends BaseEngine {
   async dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult> {
     const dumpPath = await this.getDumpPath()
 
@@ -1065,6 +1067,12 @@ export class MySQLEngine extends BaseEngine {
       user,
       '--result-file',
       outputPath,
+      // mysqldump requires db-qualified names; qualify bare names with the
+      // database being dumped
+      ...(options?.excludeTables ?? []).map(
+        (table) =>
+          `--ignore-table=${table.includes('.') ? table : `${database}.${table}`}`,
+      ),
       database,
     ]
 

--- a/engines/postgresql/index.ts
+++ b/engines/postgresql/index.ts
@@ -49,6 +49,7 @@ import type {
   BackupResult,
   RestoreResult,
   DumpResult,
+  RemoteDumpOptions,
   StatusResult,
   QueryResult,
   QueryOptions,
@@ -860,6 +861,7 @@ export class PostgreSQLEngine extends BaseEngine {
   async dumpFromConnectionString(
     connectionString: string,
     outputPath: string,
+    options?: RemoteDumpOptions,
   ): Promise<DumpResult> {
     // Get compatible pg_dump path (may switch versions or use direct path)
     const { path: pgDumpPath, warnings } =
@@ -872,6 +874,13 @@ export class PostgreSQLEngine extends BaseEngine {
 
     return new Promise((resolve, reject) => {
       const args = [connectionString, '-Fc', '-f', outputPath]
+
+      for (const table of options?.excludeTables ?? []) {
+        args.push(`--exclude-table=${table}`)
+      }
+      for (const table of options?.excludeTableData ?? []) {
+        args.push(`--exclude-table-data=${table}`)
+      }
 
       const proc = spawn(pgDumpPath, args, spawnOptions)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/integration/postgresql.test.ts
+++ b/tests/integration/postgresql.test.ts
@@ -26,6 +26,7 @@ import {
 import { assert, assertEqual, assertDeepEqual } from '../utils/assertions'
 import { containerManager } from '../../core/container-manager'
 import { processManager } from '../../core/process-manager'
+import { pullManager } from '../../core/pull-manager'
 import { getEngine } from '../../engines'
 import { Engine } from '../../types'
 import { paths } from '../../config/paths'
@@ -703,6 +704,99 @@ describe('PostgreSQL Integration Tests', () => {
     console.log(
       `   ✓ Row deleted using engine.runScript, now have ${rowCount} rows`,
     )
+  })
+
+  it('pull --exclude-table skips the table, --exclude-table-data keeps schema but drops rows', async () => {
+    console.log(`\n📥 Testing pull with table exclusions...`)
+
+    const pulledDatabase = 'pull_excl_target'
+
+    // Seed two extra tables in the source database: one to exclude entirely,
+    // one to pull schema-only
+    await runScriptSQL(
+      containerName,
+      `CREATE TABLE excluded_entirely (id serial primary key, payload text);
+       INSERT INTO excluded_entirely (payload) SELECT 'event ' || g FROM generate_series(1, 20) g;
+       CREATE TABLE schema_only (id serial primary key, blob text);
+       INSERT INTO schema_only (blob) SELECT 'data ' || g FROM generate_series(1, 10) g;`,
+      DATABASE,
+    )
+
+    try {
+      const result = await pullManager.pull(containerName, {
+        fromUrl: getConnectionString(ENGINE, testPorts[0], DATABASE),
+        asDatabase: pulledDatabase,
+        excludeTables: ['excluded_entirely'],
+        excludeTableData: ['schema_only'],
+      })
+
+      assert(result.success, 'Pull should succeed')
+      assertDeepEqual(
+        result.excludedTables,
+        ['excluded_entirely'],
+        'Result should report the fully excluded table',
+      )
+      assertDeepEqual(
+        result.excludedTableData,
+        ['schema_only'],
+        'Result should report the schema-only table',
+      )
+
+      // Regular table came through with its data
+      const kept = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM test_user',
+        pulledDatabase,
+      )
+      assertEqual(
+        Number(kept.rows[0].n),
+        EXPECTED_ROW_COUNT - 1,
+        'Non-excluded table should keep all its rows',
+      )
+
+      // --exclude-table: the table must not exist at all
+      const excludedExists = await executeQuery(
+        containerName,
+        "SELECT to_regclass('public.excluded_entirely') IS NOT NULL AS present",
+        pulledDatabase,
+      )
+      assertEqual(
+        String(excludedExists.rows[0].present),
+        'false',
+        'Excluded table should not exist in the pulled database',
+      )
+
+      // --exclude-table-data: schema present, zero rows
+      const schemaOnly = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM schema_only',
+        pulledDatabase,
+      )
+      assertEqual(
+        Number(schemaOnly.rows[0].n),
+        0,
+        'Schema-only table should exist but have no rows',
+      )
+
+      console.log(`   ✓ Exclusions verified in "${pulledDatabase}"`)
+    } finally {
+      // Clean up so later tests (rename, persistence checks) see the
+      // container in its expected state
+      const config = await containerManager.getConfig(containerName)
+      if (config) {
+        const engine = getEngine(config.engine)
+        try {
+          await engine.dropDatabase(config, pulledDatabase)
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+      await runScriptSQL(
+        containerName,
+        'DROP TABLE IF EXISTS excluded_entirely; DROP TABLE IF EXISTS schema_only;',
+        DATABASE,
+      )
+    }
   })
 
   it('should create a user and update password on re-create', async () => {

--- a/tests/unit/pull-manager.test.ts
+++ b/tests/unit/pull-manager.test.ts
@@ -10,8 +10,61 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
+import {
+  validateExcludeOptions,
+  EXCLUDE_TABLES_ENGINES,
+  EXCLUDE_TABLE_DATA_ENGINES,
+} from '../../core/pull-manager'
+import { Engine } from '../../types'
 
 describe('PullManager', () => {
+  describe('validateExcludeOptions', () => {
+    it('allows --exclude-table for every allowlisted engine', () => {
+      for (const engine of EXCLUDE_TABLES_ENGINES) {
+        assert.doesNotThrow(() =>
+          validateExcludeOptions(engine, { excludeTables: ['traffic_event'] }),
+        )
+      }
+    })
+
+    it('allows --exclude-table-data for PostgreSQL', () => {
+      assert.doesNotThrow(() =>
+        validateExcludeOptions(Engine.PostgreSQL, {
+          excludeTableData: ['traffic_event'],
+        }),
+      )
+      assert.deepStrictEqual(EXCLUDE_TABLE_DATA_ENGINES, [Engine.PostgreSQL])
+    })
+
+    it('rejects --exclude-table for unsupported engines', () => {
+      for (const engine of [Engine.Redis, Engine.SQLite, Engine.ClickHouse]) {
+        assert.throws(
+          () => validateExcludeOptions(engine, { excludeTables: ['t'] }),
+          /--exclude-table is not supported/,
+        )
+      }
+    })
+
+    it('rejects --exclude-table-data for non-PostgreSQL engines', () => {
+      for (const engine of [Engine.MySQL, Engine.MongoDB, Engine.MariaDB]) {
+        assert.throws(
+          () => validateExcludeOptions(engine, { excludeTableData: ['t'] }),
+          /--exclude-table-data is not supported/,
+        )
+      }
+    })
+
+    it('accepts empty or missing exclusion lists for any engine', () => {
+      assert.doesNotThrow(() => validateExcludeOptions(Engine.Redis, {}))
+      assert.doesNotThrow(() =>
+        validateExcludeOptions(Engine.Redis, {
+          excludeTables: [],
+          excludeTableData: [],
+        }),
+      )
+    })
+  })
+
   describe('generateTimestamp', () => {
     it('should generate timestamp in YYYYMMDD_HHMMSS format', () => {
       // Access private method via prototype manipulation for testing

--- a/types/index.ts
+++ b/types/index.ts
@@ -339,9 +339,17 @@ export type PullOptions = {
   asDatabase?: string // Clone mode: create new database with this name
   noBackup?: boolean // Skip backup (requires force)
   postScript?: string // Path to post-pull script
+  excludeTables?: string[] // Skip these tables/collections entirely (schema + data)
+  excludeTableData?: string[] // Keep schema but skip rows (PostgreSQL only)
   dryRun?: boolean
   force?: boolean
   json?: boolean
+}
+
+// Options for dumping a remote database (spindb pull / remote backup)
+export type RemoteDumpOptions = {
+  excludeTables?: string[] // Skip these tables/collections entirely (schema + data)
+  excludeTableData?: string[] // Keep schema but skip rows (PostgreSQL only)
 }
 
 export type PullResult = {
@@ -354,6 +362,8 @@ export type PullResult = {
   backupDatabase?: string // Backup database (replace mode only)
   backupUrl?: string // Connection URL for backup database (replace mode only)
   source: string // Redacted remote URL
+  excludedTables?: string[] // Tables/collections excluded entirely from the pull
+  excludedTableData?: string[] // Tables whose rows were excluded (schema kept)
   message: string
 }
 


### PR DESCRIPTION
## Summary

Adds table/collection exclusion to `spindb pull`, so a large remote database can be cloned without its analytics/event tables dominating the transfer.

- `--exclude-table <name>` (repeatable): skip a table/collection entirely. Supported: PostgreSQL (`pg_dump --exclude-table`), MySQL/MariaDB (`--ignore-table`, bare names auto-qualified with the dumped database), MongoDB/FerretDB (`mongodump --excludeCollection`).
- `--exclude-table-data <name>` (repeatable, PostgreSQL only): keep the table's schema but skip its rows via `pg_dump --exclude-table-data` — migrations and queries keep working locally, the bytes stay on the server.
- Unsupported engines fail fast with an actionable error via allowlists in `core/pull-manager.ts` (`EXCLUDE_TABLES_ENGINES` / `EXCLUDE_TABLE_DATA_ENGINES`), before anything is dumped or dropped — same pattern as `INTO_EXISTING_ENGINES`.
- Exclusion applies only to the remote dump; the local pre-pull safety backup stays complete, so rollback restores full original data.
- Pull results (including `--json`) additively report `excludedTables` / `excludedTableData`.
- FerretDB edge case: `--excludeCollection` requires `--db`, so the URI must include a database — errors with an example if missing.

Also documents the layerbase-cli cross-repo docs dependency in CLAUDE.md and adds AGENTS.md, and bumps to 0.64.0.

## Testing

- New unit tests for the allowlist validation (accept/reject per engine, empty lists) — full unit suite 1721/1721.
- New real-engine PostgreSQL integration test: seeds extra tables, pulls in clone mode with both flags, and asserts the excluded table is absent, the schema-only table restores with zero rows, and the normal table keeps its data. pg suite 24/24.
- Integration suites re-run for all five touched engines: postgres 23→24, mysql 22, mariadb 22, mongodb 21, ferretdb 19 — all green.
- Manual E2E on a scratch pg 18 container verified the CLI end to end.
- Follow-up tracked in TODO.md: exclusion integration tests for MySQL/MariaDB/MongoDB/FerretDB.