### PR TITLE
Release 0.64.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,18 @@ on:
     - cron: '17 9 * * *'
   workflow_dispatch:
 
+# Nothing in this workflow uses GITHUB_TOKEN; least-privilege read-only.
+permissions:
+  contents: read
+
 # =============================================================================
 # OS Coverage Strategy (Tiered)
 # =============================================================================
 # Platform-arch combos we test (all 5 supported):
 #   - linux-x64:     ubuntu-22.04 (older glibc) + ubuntu-24.04 (newer glibc)
-#   - linux-arm64:   Docker + QEMU smoke test (download, start, query, stop)
+#   - linux-arm64:   NOT in this workflow - the Docker + QEMU smoke job is
+#                    commented out below (too slow under emulation); run it
+#                    manually/periodically to verify arm64 binaries
 #   - darwin-x64:    macos-15-intel, SMOKE SET ONLY (see below)
 #   - darwin-arm64:  macos-14 (Apple Silicon)
 #   - win32-x64:     windows-latest
@@ -43,7 +49,9 @@ on:
 #   (+ macos-15-intel on the PostgreSQL and Redis smoke jobs only)
 #
 # Exceptions:
-#   - ClickHouse, FerretDB v2, LibSQL: No Windows (no hostdb binaries) → 3 runners
+#   - ClickHouse, LibSQL: No Windows (no hostdb binaries) → 3 runners
+#   - FerretDB v2: No Windows (its postgresql-documentdb BACKEND has no
+#     win32-x64 hostdb binary; the ferretdb binary itself has one) → 3 runners
 #   - FerretDB v1: all 4 matrix runners including Windows (plain PostgreSQL backend)
 #   - Meilisearch on Windows: backup/restore skipped (upstream page size bug)
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   # push:
   #   branches: [dev]
+  schedule:
+    # Nightly full matrix on main. Two jobs: (1) keep the Actions binary caches
+    # warm - they have a 7-day last-access TTL and LRU-evict past the repo's
+    # 10 GB cap, and a cold cache adds 10+ min of re-download to the slowest
+    # Windows jobs on release PRs; (2) surface platform/registry breakage
+    # before release day instead of at the merge button.
+    - cron: '17 9 * * *'
   workflow_dispatch:
 
 # =============================================================================
@@ -13,19 +20,31 @@ on:
 # Platform-arch combos we test (all 5 supported):
 #   - linux-x64:     ubuntu-22.04 (older glibc) + ubuntu-24.04 (newer glibc)
 #   - linux-arm64:   Docker + QEMU smoke test (download, start, query, stop)
-#   - darwin-x64:    macos-15-intel (Intel, available until Aug 2027)
+#   - darwin-x64:    macos-15-intel, SMOKE SET ONLY (see below)
 #   - darwin-arm64:  macos-14 (Apple Silicon)
 #   - win32-x64:     windows-latest
 #
 # Note: macos-14 and macos-15 are BOTH ARM64 runners. To test darwin-x64
 # you must use macos-15-intel (or the deprecated macos-13).
 #
-# All engines (5 runners): ubuntu-22.04, ubuntu-24.04, macos-15-intel, macos-14,
-#   windows-latest
+# darwin-x64 (Intel Mac) is DEMOTED to a two-job smoke set: PostgreSQL (core
+# lifecycle + bundled client tools) and Redis (the canonical dyld-linked engine;
+# Intel Homebrew lives at /usr/local vs /opt/homebrew on ARM, which is the one
+# genuinely arch-specific macOS code path - see core/library-env.ts). Rationale:
+# Apple stopped selling Intel Macs in 2023 and macOS Tahoe is the last Intel
+# release; GitHub's macos-15-intel runners are available only until Aug 2027;
+# and macOS jobs share a 5-concurrent-runner pool, so the full Intel matrix
+# roughly doubled macOS queue time and its ~20 binary caches crowded the repo's
+# 10 GB cache cap. Full sunset when GitHub retires Intel runners or hostdb
+# stops shipping darwin-x64, whichever comes first - coordinate with hostdb
+# builds and layerbase-desktop's Intel build when that happens.
+#
+# All engines (4 runners): ubuntu-22.04, ubuntu-24.04, macos-14, windows-latest
+#   (+ macos-15-intel on the PostgreSQL and Redis smoke jobs only)
 #
 # Exceptions:
-#   - ClickHouse, FerretDB v2, LibSQL: No Windows (no hostdb binaries) → 4 runners
-#   - FerretDB v1: All platforms including Windows (plain PostgreSQL backend)
+#   - ClickHouse, FerretDB v2, LibSQL: No Windows (no hostdb binaries) → 3 runners
+#   - FerretDB v1: all 4 matrix runners including Windows (plain PostgreSQL backend)
 #   - Meilisearch on Windows: backup/restore skipped (upstream page size bug)
 #
 # Unit tests: 3 runners (ubuntu-24.04, macos-14, windows-latest)
@@ -212,9 +231,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -274,9 +290,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -354,9 +367,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -415,9 +425,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -476,9 +483,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -539,9 +543,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -639,9 +640,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -798,9 +796,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -861,9 +856,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -937,9 +929,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1016,9 +1005,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1092,9 +1078,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1262,9 +1245,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1352,9 +1332,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1447,9 +1424,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1536,9 +1510,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1624,9 +1595,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1712,9 +1680,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1805,9 +1770,6 @@ jobs:
           - os: ubuntu-24.04
             icon: 🐧
             label: Linux x64 24.04
-          - os: macos-15-intel
-            icon: 🍏
-            label: macOS x64
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
@@ -1969,7 +1931,9 @@ jobs:
         id: pg-cache
         with:
           path: ~/.spindb/bin
-          key: spindb-pg-18-v2-${{ runner.os }}-${{ runner.arch }}
+          # Same content as test-postgresql's cache (~/.spindb/bin with only
+          # pg 18 downloaded) - share one key instead of storing 285 MB twice
+          key: spindb-pg-18-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install PostgreSQL via SpinDB
         run: pnpm start engines download postgresql 18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: darwin-x64 (Intel Mac) demoted to a two-job smoke set** (PostgreSQL + Redis; Redis is the canonical dyld-linked engine covering the `/usr/local` Intel Homebrew path). Binaries remain fully built and supported — only the per-release test matrix shrank. Rationale and sunset plan in `TESTING_STRATEGY.md` and the `ci.yml` header.
+- **CI: nightly scheduled full-matrix run** keeps Actions binary caches warm (7-day TTL, 10 GB LRU cap) so release PRs stop re-downloading engines on the slowest Windows jobs, and surfaces platform/registry breakage before release day.
+- **CI: `test-rename-clone` shares `test-postgresql`'s binary cache** instead of storing a duplicate 285 MB PostgreSQL cache per platform.
+
 ## [0.64.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.1] - 2026-08-25
+
+No runtime changes — identical package code to 0.64.0. This release exists to activate the CI overhaul below (release-PR workflows and the nightly cron only take effect from `main`).
+
 ### Changed
 
 - **CI: darwin-x64 (Intel Mac) demoted to a two-job smoke set** (PostgreSQL + Redis; Redis is the canonical dyld-linked engine covering the `/usr/local` Intel Homebrew path). Binaries remain fully built and supported — only the per-release test matrix shrank. Rationale and sunset plan in `TESTING_STRATEGY.md` and the `ci.yml` header.

--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -8,24 +8,42 @@ SpinDB tests every engine on every supported platform-arch combo in CI.
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | PR to main, manual dispatch | Lint, unit tests, and full integration tests on all platforms |
+| `ci.yml` | PR to main, nightly cron, manual dispatch | Lint, unit tests, and full integration tests on all platforms. The nightly run keeps Actions binary caches warm (7-day last-access TTL, 10 GB LRU cap) so release PRs restore hot caches instead of re-downloading, and surfaces platform/registry breakage before release day |
 | `publish.yml` | Push to main (merge) | Version check + publish to npm with OIDC |
 | `upstream-version-check.yml` | PR to main | Informational: flags newer PostgreSQL major versions |
 
 ## Platform Coverage (ci.yml)
 
-Every engine runs on **6 runners** covering all **5 platform-arch combos**:
+Every engine runs on **5 runners**, with darwin-x64 reduced to a smoke set:
 
 | Platform-Arch | Runner | Notes |
 |---------------|--------|-------|
 | linux-x64 | ubuntu-22.04 | Older glibc (2.35) — catches binary compatibility issues |
 | linux-x64 | ubuntu-24.04 | Newer glibc (2.39) — catches library renames (e.g., libaio) |
 | linux-arm64 | Docker + QEMU | Smoke test: download, start, one query, stop per engine |
-| darwin-x64 | macos-15-intel | Intel macOS (available until Aug 2027) |
+| darwin-x64 | macos-15-intel | **Smoke set only**: PostgreSQL + Redis (see below) |
 | darwin-arm64 | macos-14 | Apple Silicon |
 | win32-x64 | windows-latest | |
 
 **Important:** `macos-14` and `macos-15` are both ARM64 runners. Use `macos-15-intel` for darwin-x64 testing.
+
+### darwin-x64 (Intel Mac) is a smoke set, not a full matrix
+
+Since the 0.64.x cycle, Intel macOS runs only two jobs: **PostgreSQL** (core
+lifecycle + bundled client tools) and **Redis** (the canonical dyld-linked
+engine — Intel Homebrew lives at `/usr/local` vs `/opt/homebrew` on ARM, the
+one genuinely arch-specific macOS code path; see `core/library-env.ts`).
+
+Why: Apple stopped selling Intel Macs in 2023 and macOS Tahoe is the last
+Intel release; GitHub's Intel runners exist only until Aug 2027; macOS jobs
+share a 5-concurrent-runner pool so the full Intel matrix roughly doubled
+macOS queue time; and its ~20 binary caches crowded the repo's 10 GB Actions
+cache cap, evicting the Windows caches that protect the slowest jobs.
+
+Binaries for darwin-x64 are still built by hostdb and fully supported at
+runtime. Full sunset (hostdb builds, spindb support table, desktop Intel
+build) is a coordinated ecosystem decision for when GitHub retires Intel
+runners — see the OS Coverage Strategy header in `ci.yml`.
 
 The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`) and `run-e2e.sh` in smoke test mode. It's slow (~30-45 min under emulation) but runs in parallel with all other jobs.
 
@@ -33,9 +51,9 @@ The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`)
 
 | Engine | Runners | Reason |
 |--------|---------|--------|
-| ClickHouse | 4 (no Windows) | No hostdb binary for Windows |
-| FerretDB | 4 (no Windows) | postgresql-documentdb has startup issues on Windows |
-| Meilisearch | 5 (backup/restore skipped on Windows) | Upstream page size alignment bug |
+| ClickHouse | 3 (no Windows) | No hostdb binary for Windows |
+| FerretDB | 3 (no Windows) | postgresql-documentdb has startup issues on Windows |
+| Meilisearch | 4 (backup/restore skipped on Windows) | Upstream page size alignment bug |
 
 **Unit tests** run on 3 runners in ci.yml (ubuntu-24.04, macos-14, windows-latest).
 

--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -20,7 +20,7 @@ Every engine runs on **5 runners**, with darwin-x64 reduced to a smoke set:
 |---------------|--------|-------|
 | linux-x64 | ubuntu-22.04 | Older glibc (2.35) — catches binary compatibility issues |
 | linux-x64 | ubuntu-24.04 | Newer glibc (2.39) — catches library renames (e.g., libaio) |
-| linux-arm64 | Docker + QEMU | Smoke test: download, start, one query, stop per engine |
+| linux-arm64 | Docker + QEMU | **Manual/periodic only** — the QEMU smoke job is commented out in ci.yml (too slow under emulation); no PR or nightly run covers linux-arm64 |
 | darwin-x64 | macos-15-intel | **Smoke set only**: PostgreSQL + Redis (see below) |
 | darwin-arm64 | macos-14 | Apple Silicon |
 | win32-x64 | windows-latest | |
@@ -45,7 +45,7 @@ runtime. Full sunset (hostdb builds, spindb support table, desktop Intel
 build) is a coordinated ecosystem decision for when GitHub retires Intel
 runners — see the OS Coverage Strategy header in `ci.yml`.
 
-The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`) and `run-e2e.sh` in smoke test mode. It's slow (~30-45 min under emulation) but runs in parallel with all other jobs.
+The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`) and `run-e2e.sh` in smoke test mode. It's slow (~30-45 min under emulation), so it is **commented out in ci.yml** — uncomment or run it manually to periodically verify arm64 binaries.
 
 ### Exceptions
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.64.0'
+export const VERSION = '0.64.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
## 0.64.1

No runtime changes — identical package code to 0.64.0. This release activates the CI overhaul (#289): darwin-x64 demoted to a PostgreSQL + Redis smoke set, nightly scheduled cache-warm matrix run, and pg binary-cache dedupe. Details in CHANGELOG.md and TESTING_STRATEGY.md.

This PR is also the validation run for the new matrix — it should show markedly fewer jobs (~110 vs 132) and much lower wall-clock on warm caches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 0.64.1.

* **CI Improvements**
  * Added nightly full-matrix testing with cache warming.
  * Streamlined Intel macOS checks to PostgreSQL and Redis smoke tests.
  * Improved PostgreSQL cache sharing for rename and clone tests.

* **Documentation**
  * Updated testing and release documentation to reflect the revised platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->