### PR TITLE
feat(pull): add --jobs for parallel dump/restore (PostgreSQL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`spindb pull --jobs <n>`** (PostgreSQL only, 1-8): parallel dump and restore. `--jobs 2+` switches the remote dump to `pg_dump -Fd -j N` (directory format, one connection per worker, tables split across workers) and the local load to `pg_restore -j N`. On latency-bound remotes (e.g. Neon cross-region) where a single connection is the bottleneck, aggregate throughput scales with workers. Requires a direct endpoint: parallel dump coordinates workers with synchronized snapshots, which connection poolers reject — pooler hostnames (Neon `-pooler`, pgbouncer) are detected up front with an actionable error. Composes with `--exclude-table` / `--exclude-table-data` (the combination is the fast path for large databases with excludable bulk tables). Non-PostgreSQL engines reject the flag with a clear error. PostgreSQL restore now also auto-detects directory-format (`-Fd`) dumps by their `toc.dat`.
+
 ## [0.64.1] - 2026-08-25
 
 No runtime changes — identical package code to 0.64.0. This release exists to activate the CI overhaul below (release-PR workflows and the nightly cron only take effect from `main`).

--- a/cli/commands/pull.ts
+++ b/cli/commands/pull.ts
@@ -43,6 +43,11 @@ export const pullCommand = new Command('pull')
     collectRepeatable,
     [] as string[],
   )
+  .option(
+    '--jobs <n>',
+    'Parallel dump/restore workers (PostgreSQL only, 1-8; requires a direct non-pooler endpoint)',
+    (value: string) => parseInt(value, 10),
+  )
   .option('--post-script <path>', 'Run script after pull completes')
   .option('--dry-run', 'Preview changes without executing')
   .option('-f, --force', 'Skip confirmation prompts')
@@ -58,6 +63,7 @@ export const pullCommand = new Command('pull')
         backup: boolean // Commander inverts --no-backup to backup: false
         excludeTable: string[]
         excludeTableData: string[]
+        jobs?: number
         postScript?: string
         dryRun?: boolean
         force?: boolean
@@ -165,6 +171,7 @@ export const pullCommand = new Command('pull')
           noBackup: !options.backup,
           excludeTables: options.excludeTable,
           excludeTableData: options.excludeTableData,
+          jobs: options.jobs,
           postScript: options.postScript,
           dryRun: options.dryRun,
           force: options.force,

--- a/core/pull-manager.ts
+++ b/core/pull-manager.ts
@@ -9,7 +9,7 @@
 
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { unlink, writeFile } from 'fs/promises'
+import { rm, unlink, writeFile } from 'fs/promises'
 import { spawn } from 'child_process'
 import { withTransaction } from './transaction-manager'
 import { containerManager } from './container-manager'
@@ -45,6 +45,35 @@ export const EXCLUDE_TABLES_ENGINES: Engine[] = [
 export const EXCLUDE_TABLE_DATA_ENGINES: Engine[] = [Engine.PostgreSQL]
 
 /**
+ * Engines whose remote dump supports parallel workers (--jobs).
+ * pg_dump -Fd -j N; the dump becomes a directory instead of a single file.
+ */
+export const PARALLEL_PULL_ENGINES: Engine[] = [Engine.PostgreSQL]
+
+/** Parallel dump opens jobs+1 connections; keep a sane ceiling. */
+export const MAX_PULL_JOBS = 8
+
+/**
+ * Validate --jobs against the engine and range. Throws with an actionable
+ * message on unsupported combinations.
+ */
+export function validateJobsOption(engine: Engine, jobs?: number): void {
+  if (jobs === undefined) return
+  if (!Number.isInteger(jobs) || jobs < 1 || jobs > MAX_PULL_JOBS) {
+    throw new Error(
+      `--jobs must be an integer between 1 and ${MAX_PULL_JOBS} (got ${jobs}).\n` +
+        '  Parallel dump opens jobs+1 connections to the remote server.',
+    )
+  }
+  if (jobs > 1 && !PARALLEL_PULL_ENGINES.includes(engine)) {
+    throw new Error(
+      `--jobs is not supported for ${engine}.\n` +
+        `  Supported engines: ${PARALLEL_PULL_ENGINES.join(', ')}`,
+    )
+  }
+}
+
+/**
  * Validate --exclude-table / --exclude-table-data against the engine's
  * capabilities. Throws with an actionable message on unsupported combinations.
  */
@@ -70,6 +99,29 @@ export function validateExcludeOptions(
         `  Supported engines: ${EXCLUDE_TABLE_DATA_ENGINES.join(', ')}\n` +
         '  To skip a table entirely (schema and data), use --exclude-table.',
     )
+  }
+}
+
+/**
+ * Package the pull options that the engine's remote dump understands.
+ * Exported so tests can prove every option actually reaches the dump tool
+ * (a private version of this once silently dropped `jobs`).
+ */
+export function buildRemoteDumpOptions(
+  options: PullOptions,
+): RemoteDumpOptions | undefined {
+  const parallel = options.jobs !== undefined && options.jobs > 1
+  if (
+    !options.excludeTables?.length &&
+    !options.excludeTableData?.length &&
+    !parallel
+  ) {
+    return undefined
+  }
+  return {
+    excludeTables: options.excludeTables,
+    excludeTableData: options.excludeTableData,
+    jobs: parallel ? options.jobs : undefined,
   }
 }
 
@@ -111,8 +163,10 @@ export class PullManager {
     const engine = getEngine(config.engine)
     const timestamp = this.generateTimestamp()
 
-    // Fail fast if table exclusion was requested on an engine that can't do it
+    // Fail fast if table exclusion or parallel dump was requested on an
+    // engine that can't do it
     validateExcludeOptions(config.engine, options)
+    validateJobsOption(config.engine, options.jobs)
 
     // 2. Determine mode and target database
     const isCloneMode = !!options.asDatabase
@@ -229,13 +283,13 @@ export class PullManager {
       await engine.dumpFromConnectionString(
         options.fromUrl,
         tempRemoteDump,
-        this.remoteDumpOptions(options),
+        buildRemoteDumpOptions(options),
       )
       tx.addRollback({
         description: 'Delete remote dump temp file',
         execute: async () => {
           try {
-            await unlink(tempRemoteDump)
+            await rm(tempRemoteDump, { recursive: true, force: true })
           } catch {
             // Ignore errors
           }
@@ -276,6 +330,7 @@ export class PullManager {
       await engine.restore(config, tempRemoteDump, {
         database: targetDatabase,
         createDatabase: false,
+        jobs: options.jobs,
       })
 
       // Step 9: Cleanup temp files
@@ -285,7 +340,7 @@ export class PullManager {
         // Ignore errors
       }
       try {
-        await unlink(tempRemoteDump)
+        await rm(tempRemoteDump, { recursive: true, force: true })
       } catch {
         // Ignore errors
       }
@@ -394,13 +449,13 @@ export class PullManager {
       await engine.dumpFromConnectionString(
         options.fromUrl,
         tempRemoteDump,
-        this.remoteDumpOptions(options),
+        buildRemoteDumpOptions(options),
       )
       tx.addRollback({
         description: 'Delete remote dump temp file',
         execute: async () => {
           try {
-            await unlink(tempRemoteDump)
+            await rm(tempRemoteDump, { recursive: true, force: true })
           } catch {
             // Ignore errors
           }
@@ -412,11 +467,12 @@ export class PullManager {
       await engine.restore(config, tempRemoteDump, {
         database: targetDatabase,
         createDatabase: false,
+        jobs: options.jobs,
       })
 
       // Step 5: Cleanup
       try {
-        await unlink(tempRemoteDump)
+        await rm(tempRemoteDump, { recursive: true, force: true })
       } catch {
         // Ignore errors
       }
@@ -512,18 +568,6 @@ export class PullManager {
       } catch {
         // Ignore errors
       }
-    }
-  }
-
-  private remoteDumpOptions(
-    options: PullOptions,
-  ): RemoteDumpOptions | undefined {
-    if (!options.excludeTables?.length && !options.excludeTableData?.length) {
-      return undefined
-    }
-    return {
-      excludeTables: options.excludeTables,
-      excludeTableData: options.excludeTableData,
     }
   }
 

--- a/engines/postgresql/index.ts
+++ b/engines/postgresql/index.ts
@@ -60,6 +60,16 @@ import type {
 const execAsync = promisify(exec)
 
 /**
+ * Detect connection-pooler hostnames (e.g. Neon's `ep-xxx-pooler.<region>...`).
+ * Parallel dump coordinates workers with synchronized snapshots
+ * (SET TRANSACTION SNAPSHOT), which transaction-pooling proxies like PgBouncer
+ * reject - so --jobs > 1 needs the direct endpoint. Exported for unit testing.
+ */
+export function isPoolerHost(hostname: string): boolean {
+  return /-pooler\./i.test(hostname) || /^pgbouncer\./i.test(hostname)
+}
+
+/**
  * Build a Windows-safe psql command string for either a file or inline SQL.
  * This is exported for unit testing.
  */
@@ -872,8 +882,33 @@ export class PostgreSQLEngine extends BaseEngine {
       ...getWindowsSpawnOptions(),
     }
 
+    const jobs = options?.jobs ?? 1
+    if (jobs > 1) {
+      // Parallel dump requires real server sessions for synchronized
+      // snapshots; transaction poolers (Neon -pooler endpoints, PgBouncer)
+      // break it. Fail with guidance instead of a cryptic pg_dump error.
+      let hostname = ''
+      try {
+        hostname = new URL(connectionString).hostname
+      } catch {
+        // Unparseable strings get pg_dump's own error below
+      }
+      if (isPoolerHost(hostname)) {
+        throw new Error(
+          `--jobs requires a direct (non-pooler) connection: "${hostname}" looks like a connection pooler.\n` +
+            '  Parallel pg_dump uses synchronized snapshots, which poolers reject.\n' +
+            '  Use the direct endpoint (for Neon, remove "-pooler" from the host).',
+        )
+      }
+    }
+
     return new Promise((resolve, reject) => {
-      const args = [connectionString, '-Fc', '-f', outputPath]
+      // jobs > 1 needs directory format (-Fd): pg_dump creates outputPath as a
+      // directory and splits tables across `jobs` connections
+      const args =
+        jobs > 1
+          ? [connectionString, '-Fd', '-j', String(jobs), '-f', outputPath]
+          : [connectionString, '-Fc', '-f', outputPath]
 
       for (const table of options?.excludeTables ?? []) {
         args.push(`--exclude-table=${table}`)

--- a/engines/postgresql/restore.ts
+++ b/engines/postgresql/restore.ts
@@ -1,4 +1,4 @@
-import { open } from 'fs/promises'
+import { open, stat } from 'fs/promises'
 import { existsSync } from 'fs'
 import { exec } from 'child_process'
 import { promisify } from 'util'
@@ -23,6 +23,26 @@ const execAsync = promisify(exec)
 export async function detectBackupFormat(
   filePath: string,
 ): Promise<BackupFormat> {
+  // Directory-format dump (pg_dump -Fd): a directory containing toc.dat
+  try {
+    const st = await stat(filePath)
+    if (st.isDirectory()) {
+      if (existsSync(join(filePath, 'toc.dat'))) {
+        return {
+          format: 'directory',
+          description: 'PostgreSQL directory format (pg_dump -Fd)',
+          restoreCommand: 'pg_restore',
+        }
+      }
+      throw new Error(
+        `"${filePath}" is a directory but not a PostgreSQL directory-format dump (no toc.dat)`,
+      )
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    // Fall through: missing paths get the normal open() error below
+  }
+
   // Read only the bytes needed for format detection (up to offset 262 for tar magic)
   const HEADER_SIZE = 263
   const buffer = Buffer.alloc(HEADER_SIZE)
@@ -141,12 +161,14 @@ export type RestoreOptions = {
    * as-is.
    */
   clean?: boolean
+  /** Parallel restore workers (pg_restore -j). Only for custom/tar/directory formats. */
+  jobs?: number
 }
 
 /**
- * Build the `pg_restore` command for a custom/tar dump. Pure (no I/O) so the
- * argument construction - especially the `--clean --if-exists` that makes
- * `--into-existing` a faithful replace - is unit-testable.
+ * Build the `pg_restore` command for a custom/tar/directory dump. Pure (no
+ * I/O) so the argument construction - especially the `--clean --if-exists`
+ * that makes `--into-existing` a faithful replace - is unit-testable.
  */
 export function buildPgRestoreCommand(args: {
   restorePath: string
@@ -156,9 +178,11 @@ export function buildPgRestoreCommand(args: {
   formatFlag: string
   backupPath: string
   clean?: boolean
+  jobs?: number
 }): string {
   const cleanFlags = args.clean ? ' --clean --if-exists' : ''
-  return `"${args.restorePath}" -h 127.0.0.1 -p ${args.port} -U ${args.user} -d ${args.database} --no-owner --no-privileges${cleanFlags} ${args.formatFlag} "${args.backupPath}"`
+  const jobsFlag = args.jobs && args.jobs > 1 ? ` -j ${args.jobs}` : ''
+  return `"${args.restorePath}" -h 127.0.0.1 -p ${args.port} -U ${args.user} -d ${args.database} --no-owner --no-privileges${cleanFlags}${jobsFlag} ${args.formatFlag} "${args.backupPath}"`
 }
 
 /**
@@ -304,6 +328,7 @@ export async function restoreBackup(
     pgRestorePath,
     containerVersion,
     clean,
+    jobs,
   } = options
   const execOptions = {
     maxBuffer: 50 * 1024 * 1024,
@@ -352,7 +377,9 @@ export async function restoreBackup(
           ? '-Fc'
           : detectedFormat === 'tar'
             ? '-Ft'
-            : ''
+            : detectedFormat === 'directory'
+              ? '-Fd'
+              : ''
       const result = await execAsync(
         buildPgRestoreCommand({
           restorePath,
@@ -362,6 +389,7 @@ export async function restoreBackup(
           formatFlag,
           backupPath,
           clean,
+          jobs,
         }),
         execOptions,
       )

--- a/tests/integration/postgresql.test.ts
+++ b/tests/integration/postgresql.test.ts
@@ -6,6 +6,9 @@
 
 import { describe, it, before, after } from 'node:test'
 import { join, dirname } from 'path'
+import { tmpdir } from 'os'
+import { existsSync } from 'fs'
+import { stat, rm as rmAsync } from 'fs/promises'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -815,6 +818,95 @@ describe('PostgreSQL Integration Tests', () => {
       await runScriptSQL(
         containerName,
         'DROP TABLE IF EXISTS schema_only',
+        DATABASE,
+      )
+    }
+  })
+
+  it('pull --jobs runs a parallel dump/restore round trip (with exclusions)', async () => {
+    console.log(`\n📥 Testing parallel pull (--jobs 2)...`)
+
+    const pulledDatabase = 'pull_jobs_target'
+
+    await runScriptSQL(
+      containerName,
+      'CREATE TABLE jobs_skip_rows (id serial primary key, blob text)',
+      DATABASE,
+    )
+    await runScriptSQL(
+      containerName,
+      "INSERT INTO jobs_skip_rows (blob) SELECT 'data ' || g FROM generate_series(1, 10) g",
+      DATABASE,
+    )
+
+    try {
+      // First prove jobs > 1 actually engages parallel directory-format dump
+      // at the engine level (pg_dump -Fd creates a directory with toc.dat)
+      const engineForDump = getEngine(ENGINE)
+      const fdDumpPath = join(tmpdir(), `spindb-test-fd-${Date.now()}`)
+      try {
+        await engineForDump.dumpFromConnectionString(
+          getConnectionString(ENGINE, testPorts[0], DATABASE),
+          fdDumpPath,
+          { jobs: 2 },
+        )
+        const st = await stat(fdDumpPath)
+        assert(st.isDirectory(), '--jobs dump should produce a directory (-Fd)')
+        assert(
+          existsSync(join(fdDumpPath, 'toc.dat')),
+          'directory dump should contain toc.dat',
+        )
+      } finally {
+        await rmAsync(fdDumpPath, { recursive: true, force: true })
+      }
+
+      const result = await pullManager.pull(containerName, {
+        fromUrl: getConnectionString(ENGINE, testPorts[0], DATABASE),
+        asDatabase: pulledDatabase,
+        jobs: 2,
+        excludeTableData: ['jobs_skip_rows'],
+      })
+
+      assert(result.success, 'Parallel pull should succeed')
+
+      // Data came through the -Fd directory dump intact
+      const kept = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM test_user',
+        pulledDatabase,
+      )
+      assertEqual(
+        Number(kept.rows[0].n),
+        EXPECTED_ROW_COUNT - 1,
+        'Parallel pull should carry table data',
+      )
+
+      // --exclude-table-data still works alongside --jobs
+      const schemaOnly = await executeQuery(
+        containerName,
+        'SELECT count(*)::int AS n FROM jobs_skip_rows',
+        pulledDatabase,
+      )
+      assertEqual(
+        Number(schemaOnly.rows[0].n),
+        0,
+        'Excluded-data table should exist but be empty in parallel mode',
+      )
+
+      console.log(`   ✓ Parallel dump/restore verified in "${pulledDatabase}"`)
+    } finally {
+      const config = await containerManager.getConfig(containerName)
+      if (config) {
+        const engine = getEngine(config.engine)
+        try {
+          await engine.dropDatabase(config, pulledDatabase)
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+      await runScriptSQL(
+        containerName,
+        'DROP TABLE IF EXISTS jobs_skip_rows',
         DATABASE,
       )
     }

--- a/tests/unit/postgresql-restore.test.ts
+++ b/tests/unit/postgresql-restore.test.ts
@@ -3,8 +3,15 @@
  */
 
 import { describe, it } from 'node:test'
+import { mkdtemp, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import { assert } from '../utils/assertions'
-import { buildPgRestoreCommand } from '../../engines/postgresql/restore'
+import {
+  buildPgRestoreCommand,
+  detectBackupFormat,
+} from '../../engines/postgresql/restore'
+import { isPoolerHost } from '../../engines/postgresql'
 
 describe('PostgreSQL Restore Module', () => {
   describe('buildPgRestoreCommand', () => {
@@ -48,6 +55,73 @@ describe('PostgreSQL Restore Module', () => {
         cmd.indexOf('--clean --if-exists') < cmd.indexOf('-Fc'),
         'clean flags precede the format flag',
       )
+    })
+
+    it('adds -j N for parallel restore only when jobs > 1', () => {
+      const parallel = buildPgRestoreCommand({
+        ...base,
+        formatFlag: '-Fd',
+        jobs: 4,
+      })
+      assert(parallel.includes(' -j 4 '), 'includes -j 4')
+      assert(parallel.includes('-Fd'), 'keeps the directory format flag')
+      const single = buildPgRestoreCommand({ ...base, jobs: 1 })
+      assert(!single.includes(' -j '), 'jobs: 1 stays single-stream')
+      const unset = buildPgRestoreCommand(base)
+      assert(!unset.includes(' -j '), 'no jobs stays single-stream')
+    })
+  })
+
+  describe('detectBackupFormat (directory dumps)', () => {
+    it('detects a pg_dump -Fd directory via toc.dat', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'spindb-fd-test-'))
+      try {
+        await writeFile(join(dir, 'toc.dat'), 'PGDMP-toc-placeholder')
+        const format = await detectBackupFormat(dir)
+        assert(format.format === 'directory', 'detects directory format')
+        assert(
+          format.restoreCommand === 'pg_restore',
+          'restores with pg_restore',
+        )
+      } finally {
+        await rm(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects a directory without toc.dat', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'spindb-notdump-test-'))
+      try {
+        let threw = false
+        try {
+          await detectBackupFormat(dir)
+        } catch {
+          threw = true
+        }
+        assert(threw, 'throws on a non-dump directory')
+      } finally {
+        await rm(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('isPoolerHost', () => {
+    it('flags Neon pooler endpoints and pgbouncer hosts', () => {
+      assert(
+        isPoolerHost(
+          'ep-damp-frost-a5b3oyxr-pooler.c-2.us-east-2.aws.neon.tech',
+        ),
+        'Neon -pooler host',
+      )
+      assert(isPoolerHost('pgbouncer.internal.example.com'), 'pgbouncer host')
+    })
+
+    it('passes direct endpoints and local hosts', () => {
+      assert(
+        !isPoolerHost('ep-damp-frost-a5b3oyxr.c-2.us-east-2.aws.neon.tech'),
+        'Neon direct host',
+      )
+      assert(!isPoolerHost('127.0.0.1'), 'localhost IP')
+      assert(!isPoolerHost('db.example.com'), 'plain host')
     })
   })
 })

--- a/tests/unit/pull-manager.test.ts
+++ b/tests/unit/pull-manager.test.ts
@@ -12,8 +12,12 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert'
 import {
   validateExcludeOptions,
+  validateJobsOption,
+  buildRemoteDumpOptions,
   EXCLUDE_TABLES_ENGINES,
   EXCLUDE_TABLE_DATA_ENGINES,
+  PARALLEL_PULL_ENGINES,
+  MAX_PULL_JOBS,
 } from '../../core/pull-manager'
 import { Engine } from '../../types'
 
@@ -61,6 +65,76 @@ describe('PullManager', () => {
           excludeTables: [],
           excludeTableData: [],
         }),
+      )
+    })
+  })
+
+  describe('validateJobsOption', () => {
+    it('allows jobs within range for PostgreSQL', () => {
+      assert.deepStrictEqual(PARALLEL_PULL_ENGINES, [Engine.PostgreSQL])
+      for (const jobs of [1, 2, 4, MAX_PULL_JOBS]) {
+        assert.doesNotThrow(() => validateJobsOption(Engine.PostgreSQL, jobs))
+      }
+    })
+
+    it('allows undefined jobs for any engine', () => {
+      assert.doesNotThrow(() => validateJobsOption(Engine.Redis, undefined))
+      assert.doesNotThrow(() => validateJobsOption(Engine.MySQL, undefined))
+    })
+
+    it('allows jobs: 1 (single-stream) on any engine', () => {
+      assert.doesNotThrow(() => validateJobsOption(Engine.MySQL, 1))
+    })
+
+    it('rejects jobs > 1 for non-PostgreSQL engines', () => {
+      for (const engine of [Engine.MySQL, Engine.MongoDB, Engine.Redis]) {
+        assert.throws(
+          () => validateJobsOption(engine, 2),
+          /--jobs is not supported/,
+        )
+      }
+    })
+
+    it('rejects out-of-range and non-integer values', () => {
+      for (const jobs of [0, -1, MAX_PULL_JOBS + 1, 2.5, NaN]) {
+        assert.throws(
+          () => validateJobsOption(Engine.PostgreSQL, jobs),
+          /--jobs must be an integer between/,
+        )
+      }
+    })
+  })
+
+  describe('buildRemoteDumpOptions', () => {
+    const fromUrl = 'postgresql://localhost/db'
+
+    it('forwards jobs to the engine dump (regression: jobs was once dropped)', () => {
+      const opts = buildRemoteDumpOptions({ fromUrl, jobs: 4 })
+      assert.strictEqual(opts?.jobs, 4)
+    })
+
+    it('forwards jobs alongside exclusions', () => {
+      const opts = buildRemoteDumpOptions({
+        fromUrl,
+        jobs: 2,
+        excludeTableData: ['big_table'],
+      })
+      assert.strictEqual(opts?.jobs, 2)
+      assert.deepStrictEqual(opts?.excludeTableData, ['big_table'])
+    })
+
+    it('treats jobs: 1 as default single-stream (no options object needed)', () => {
+      assert.strictEqual(
+        buildRemoteDumpOptions({ fromUrl, jobs: 1 }),
+        undefined,
+      )
+    })
+
+    it('returns undefined when nothing needs forwarding', () => {
+      assert.strictEqual(buildRemoteDumpOptions({ fromUrl }), undefined)
+      assert.strictEqual(
+        buildRemoteDumpOptions({ fromUrl, excludeTables: [] }),
+        undefined,
       )
     })
   })

--- a/types/index.ts
+++ b/types/index.ts
@@ -341,6 +341,7 @@ export type PullOptions = {
   postScript?: string // Path to post-pull script
   excludeTables?: string[] // Skip these tables/collections entirely (schema + data)
   excludeTableData?: string[] // Keep schema but skip rows (PostgreSQL only)
+  jobs?: number // Parallel dump/restore workers (PostgreSQL only, 1-8)
   dryRun?: boolean
   force?: boolean
   json?: boolean
@@ -350,6 +351,7 @@ export type PullOptions = {
 export type RemoteDumpOptions = {
   excludeTables?: string[] // Skip these tables/collections entirely (schema + data)
   excludeTableData?: string[] // Keep schema but skip rows (PostgreSQL only)
+  jobs?: number // Parallel dump workers; >1 switches pg_dump to directory format (-Fd)
 }
 
 export type PullResult = {


### PR DESCRIPTION
## Summary

Implements the parallel-dump feature request from the efficient-app clone investigation: on a latency-bound remote (Neon cross-region), `pg_dump -Fc`'s single connection sustained ~1 MB/s with pg_dump >99% idle; parallel COPY streams measured 2.5x aggregate.

- `--jobs <n>` (1-8) on `spindb pull`, PostgreSQL only. `jobs > 1` switches the remote dump to `pg_dump -Fd -j N` (directory format, tables split across N connections) and the local load to `pg_restore -j N`.
- **Pooler guard**: parallel dump coordinates workers via synchronized snapshots, which transaction poolers reject — hostnames matching Neon `-pooler` / `pgbouncer` are refused up front with "use the direct endpoint" guidance.
- **Allowlist**: `PARALLEL_PULL_ENGINES` in `core/pull-manager.ts`, same pattern as the exclusion flags — non-pg engines error before anything is dumped or dropped; `--jobs 1` is a no-op everywhere.
- **Cap of 8**: parallel dump opens jobs+1 connections; small computes have low ceilings.
- Composes with `--exclude-table` / `--exclude-table-data` — the combination is the intended fast path (exclusion cuts bytes, parallelism multiplies throughput on the many-small-tables remainder).
- PostgreSQL restore auto-detects `-Fd` directory dumps via `toc.dat` (additive branch; file-format detection untouched); pull temp cleanup handles directories.

## Notable: a bug the edge-case audit caught

The private helper packaging dump options predated the flag and silently dropped `jobs` — validation passed, restore parallelized, but the dump stayed single-stream. It's now the exported `buildRemoteDumpOptions` with a named regression test, and the integration test asserts the `-Fd` directory dump actually engages (checks `toc.dat` on disk), not just that data round-trips.

## Testing

- Unit: full suite green; new tests for jobs validation (engine allowlist, range, non-integer), `isPoolerHost`, `-j`/`-Fd` command building, directory-format detection, and the `buildRemoteDumpOptions` regression.
- Integration (real pg): 25/25 — engine-level `-Fd -j 2` dump verified on disk, then a full parallel pull round trip with `--exclude-table-data` composed, proving data lands and the excluded table restores empty.
- Windows/Linux validation lands on the 0.65.0 release PR (full matrix), same model as the exclusion feature.

## Known limits (documented, not bugs)

- Parallelism splits across tables — a single giant table still rides one connection.
- Parallel dump is more sensitive to concurrent DDL on the source (worker lock acquisition); fails loudly and is retryable.