### PR TITLE
Release: spindb 0.66.0 - PostgreSQL 18.6.0 + 19.0.0-beta.3 (Aug 2026 CVE wave)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2710,52 +2710,54 @@ jobs:
         timeout-minutes: 30
 
   # ============================================
-  # Docker Linux ARM64 (QEMU) - COMMENTED OUT
+  # Docker Linux ARM64 (QEMU) - MANUAL DISPATCH ONLY
   # ============================================
-  # This job takes ~30-45 min under QEMU emulation (3x longer than all other
-  # tests combined). Uncomment periodically to verify arm64 binaries still
-  # work, or run manually via workflow_dispatch. macOS ARM64 runners validate
-  # ARM code paths in every PR.
-  #
-  # test-docker-linux-arm64:
-  #   name: Docker Linux ARM64 (QEMU)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v6
-  #
-  #     - name: Set up QEMU for ARM64 emulation
-  #       uses: docker/setup-qemu-action@v4
-  #       with:
-  #         platforms: arm64
-  #
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v4
-  #
-  #     - name: Build ARM64 Docker test image
-  #       run: |
-  #         docker buildx build \
-  #           --platform linux/arm64 \
-  #           -t spindb-e2e-arm64 \
-  #           -f tests/docker/Dockerfile \
-  #           --load .
-  #       timeout-minutes: 30
-  #
-  #     - name: Run ARM64 smoke tests
-  #       # QEMU emulation is ~5-10x slower than native; increase timeouts so
-  #       # engines with 30-90s internal waitForReady don't get killed.
-  #       # SurrealDB is skipped: its large Rust binary hangs during --version
-  #       # verification under QEMU user-mode emulation.
-  #       # ClickHouse is skipped: its heavy binary consistently exceeds startup
-  #       # timeouts under QEMU (~120s+ native, far longer emulated). Tested
-  #       # natively on macOS/Linux CI runners instead.
-  #       run: |
-  #         docker run --rm --platform linux/arm64 \
-  #           -e START_TIMEOUT=600 \
-  #           -e STARTUP_TIMEOUT=180 \
-  #           -e "SKIP_ENGINES=surrealdb clickhouse" \
-  #           spindb-e2e-arm64
-  #       timeout-minutes: 90
+  # Gated to workflow_dispatch: ~30-45 min under QEMU emulation, and the
+  # linux-arm64 risk lives in hostdb BINARIES, not spindb code (macOS ARM64
+  # runners validate ARM code paths in every PR). Run this via the Actions
+  # tab when bumping hostdb - that is the moment arm64 binaries change.
+  # Deliberately NOT in ci-success needs and never on PRs or the nightly
+  # cron, so it can never block or noise a release.
+  test-docker-linux-arm64:
+    name: Docker Linux ARM64 (QEMU)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU for ARM64 emulation
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ARM64 Docker test image
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            -t spindb-e2e-arm64 \
+            -f tests/docker/Dockerfile \
+            --load .
+        timeout-minutes: 30
+
+      - name: Run ARM64 smoke tests
+        # QEMU emulation is ~5-10x slower than native; increase timeouts so
+        # engines with 30-90s internal waitForReady don't get killed.
+        # SurrealDB is skipped: its large Rust binary hangs during --version
+        # verification under QEMU user-mode emulation.
+        # ClickHouse is skipped: its heavy binary consistently exceeds startup
+        # timeouts under QEMU (~120s+ native, far longer emulated). Tested
+        # natively on macOS/Linux CI runners instead.
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -e START_TIMEOUT=600 \
+            -e STARTUP_TIMEOUT=180 \
+            -e "SKIP_ENGINES=surrealdb clickhouse" \
+            spindb-e2e-arm64
+        timeout-minutes: 90
 
   # ============================================
   # Docker Export Test - Tests the `spindb export docker` functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ All notable changes to SpinDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.66.0] - 2026-08-25
+
+### Added
+
+- **PostgreSQL 18.6.0 and 19.0.0-beta.3 support** via the hostdb `0.41.0` pin - the upstream 2026-08-13 security release fixing 28 CVEs (~12 at CVSS 8.8 arbitrary-code-execution, including CVE-2026-14664 regexp heap overflow, CVE-2026-16239 cursor type confusion, CVE-2026-19385 pg_dump heap overflow, CVE-2026-15741 EXTRACT deparse SQLi). 18.5 was skipped upstream due to a regression. 18.6.0 ships all 5 platforms; 19.0.0-beta.3 ships 4 (no win32 until EDB publishes RC binaries) and resolves only by exact version token, like beta.1. Note: beta.3 is NOT binary-compatible with beta.1 data dirs (catalog version can change between betas) - beta.1 containers need dump/restore, never a binary swap.
 
 ### Changed
 
+- **PostgreSQL's `18` line now resolves to `18.6.0`** (was 18.4.0): `spindb create --engine postgresql` and explicit `18`/`18.6` requests get the patched build. 18.1.0 and 18.4.0 remain resolvable; existing containers self-pin their stored full version, so nothing running is disturbed. Minor bump because the resolved default changed.
+- **Pin `hostdb` to `0.41.0`** (was 0.40.0).
 - **CI: the linux-arm64 QEMU smoke job is enabled, gated to manual dispatch only.** It was fully written but commented out, leaving linux-arm64 with zero automated coverage. It now runs when CI is triggered from the Actions tab — the intended cadence is per hostdb bump (the moment arm64 binaries actually change; spindb's own code paths are arch-validated by macOS ARM64 in every PR). Never runs on PRs or the nightly cron, and is not part of the `CI Success` gate, so it can neither slow nor block a release.
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **CHEATSHEET.md's Pull section now covers the 0.64/0.65 flags**: `--exclude-table`, `--exclude-table-data` (with wildcard patterns), `--jobs` (with the direct-endpoint/pooler requirement), the combined fast path for large production databases, per-engine support notes, and the `excludedTables`/`excludedTableData` JSON fields. CLAUDE.md's "After Adding Any Feature" checklist now names CHEATSHEET.md so CLI surface changes can't silently skip it again.
+
 ## [0.65.0] - 2026-08-25
 
 ### Added
 
 - **`spindb pull --jobs <n>`** (PostgreSQL only, 1-8): parallel dump and restore. `--jobs 2+` switches the remote dump to `pg_dump -Fd -j N` (directory format, one connection per worker, tables split across workers) and the local load to `pg_restore -j N`. On latency-bound remotes (e.g. Neon cross-region) where a single connection is the bottleneck, aggregate throughput scales with workers. Requires a direct endpoint: parallel dump coordinates workers with synchronized snapshots, which connection poolers reject — pooler hostnames (Neon `-pooler`, pgbouncer) are detected up front with an actionable error. Composes with `--exclude-table` / `--exclude-table-data` (the combination is the fast path for large databases with excludable bulk tables). Non-PostgreSQL engines reject the flag with a clear error. PostgreSQL restore now also auto-detects directory-format (`-Fd`) dumps by their `toc.dat`.
+
+### Fixed
+
+- **`spindb pull` no longer reports success when the restore actually failed.** PostgreSQL's restore layer signals failure by resolving with a non-zero exit code (pg_restore can exit non-zero on partial success), and pull discarded that result — a completely failed pg_restore produced "Pull complete!" over an empty database, and a failed backup-side restore produced an empty "backup". All three pull restore steps (remote data into the target in both modes, and the original into the backup database) now check the exit code and abort with pg_restore's stderr, triggering the existing transaction rollback that preserves the original data. Real-engine integration confirms pg_restore exits 0 on normal pulls, so the happy path is unaffected. This bug predated the new pull flags.
+- **Malformed `--jobs` values are rejected instead of silently truncated.** The CLI parsed `--jobs` with `parseInt`, so `2.5` became 2 and `4abc` became 4 before validation could refuse them; the parser now uses `Number()` and hands invalid input to validation as-is.
 
 ## [0.64.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: the linux-arm64 QEMU smoke job is enabled, gated to manual dispatch only.** It was fully written but commented out, leaving linux-arm64 with zero automated coverage. It now runs when CI is triggered from the Actions tab — the intended cadence is per hostdb bump (the moment arm64 binaries actually change; spindb's own code paths are arch-validated by macOS ARM64 in every PR). Never runs on PRs or the nightly cron, and is not part of the `CI Success` gate, so it can neither slow nor block a release.
+
 ### Documentation
 
 - **CHEATSHEET.md's Pull section now covers the 0.64/0.65 flags**: `--exclude-table`, `--exclude-table-data` (with wildcard patterns), `--jobs` (with the direct-endpoint/pooler requirement), the combined fast path for large production databases, per-engine support notes, and the `excludedTables`/`excludedTableData` JSON fields. CLAUDE.md's "After Adding Any Feature" checklist now names CHEATSHEET.md so CLI surface changes can't silently skip it again.

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -297,9 +297,25 @@ spindb pull mydb --from-env PROD_DB_URL --dry-run
 # Run script after pull (e.g., sync credentials)
 spindb pull mydb --from-env PROD_DB_URL --post-script ./sync-creds.ts
 
+# Skip tables/collections (repeatable). --exclude-table omits the table
+# entirely; --exclude-table-data keeps its schema but skips the rows
+# (PostgreSQL only) — ideal for analytics/event tables that dominate the bytes
+spindb pull mydb --from-env PROD_DB_URL --exclude-table debug_log
+spindb pull mydb --from-env PROD_DB_URL --exclude-table-data 'traffic_*'
+
+# Parallel dump/restore (PostgreSQL only, 1-8 workers). Splits tables across
+# N connections — big speedup on latency-bound remotes. Requires the DIRECT
+# endpoint: connection poolers (Neon -pooler hosts, pgbouncer) are refused
+spindb pull mydb --from-env PROD_DB_URL --jobs 4
+
+# The fast path for large production databases: exclude the bulk, parallelize the rest
+spindb pull mydb --from-env PROD_DB_URL --exclude-table-data 'traffic_*' --jobs 4
+
 # JSON output for scripting (includes connection URLs)
 spindb pull mydb --from-env PROD_DB_URL --json
 ```
+
+**Table exclusion engine support:** `--exclude-table` works on PostgreSQL, MySQL, MariaDB (bare names auto-qualified as `db.table`), MongoDB, and FerretDB (collections). `--exclude-table-data` and `--jobs` are PostgreSQL only. Unsupported engines fail with a clear error before anything is dumped or dropped. Exclusions apply only to the remote dump — the local pre-pull backup stays complete. `--jobs` parallelizes across tables (one large table still rides a single connection), so it pairs best with exclusions.
 
 **JSON output includes connection URLs for scripting:**
 ```json
@@ -315,6 +331,8 @@ spindb pull mydb --from-env PROD_DB_URL --json
   "source": "postgresql://user:***@prod.example.com/db"
 }
 ```
+
+When exclusions are used, the JSON also carries `excludedTables` / `excludedTableData` arrays (omitted otherwise).
 
 > **vs restore --from-url:** `restore` directly overwrites without backup. `pull` automatically creates a timestamped backup (e.g., `mydb_20260129_143052`) before replacing, so you can always revert.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ If modifying an engine, also run `pnpm test:engine <engine>`.
 
 ### After Adding Any Feature
 
-Update: CLAUDE.md, README.md, TODO.md, CHANGELOG.md, and add tests.
+Update: CLAUDE.md, README.md, TODO.md, CHANGELOG.md, and add tests. If the CLI surface changed (new command, flag, or output field), also update CHEATSHEET.md — it is the complete command reference the README defers to, and it silently goes stale otherwise.
 
 ## Development Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ The factory reads `databases.json` (via `core/hostdb-metadata.ts`) as the author
 5. `pnpm test:unit` passes (version maps auto-rebuild from new snapshot).
 6. Commit: `chore(deps): bump hostdb 0.31.0 → 0.32.0` describing new versions / deprecations.
 7. Standard feature → dev → main PR flow.
+8. Trigger the CI workflow manually (Actions tab → CI → Run workflow) on the bump branch: the `Docker Linux ARM64 (QEMU)` smoke job runs ONLY on manual dispatch and is the sole automated linux-arm64 coverage. hostdb bumps are exactly when arm64 binaries change, so this is the moment to run it.
 
 ### Container version pinning (eager resolution + auto-migrate)
 

--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -20,7 +20,7 @@ Every engine runs on **5 runners**, with darwin-x64 reduced to a smoke set:
 |---------------|--------|-------|
 | linux-x64 | ubuntu-22.04 | Older glibc (2.35) — catches binary compatibility issues |
 | linux-x64 | ubuntu-24.04 | Newer glibc (2.39) — catches library renames (e.g., libaio) |
-| linux-arm64 | Docker + QEMU | **Manual/periodic only** — the QEMU smoke job is commented out in ci.yml (too slow under emulation); no PR or nightly run covers linux-arm64 |
+| linux-arm64 | Docker + QEMU | **Manual dispatch only** — the QEMU smoke job runs only via workflow_dispatch (too slow under emulation for PRs/nightly). Run it when bumping hostdb: that's when arm64 binaries change. Not in `CI Success`, so it can never block a release |
 | darwin-x64 | macos-15-intel | **Smoke set only**: PostgreSQL + Redis (see below) |
 | darwin-arm64 | macos-14 | Apple Silicon |
 | win32-x64 | windows-latest | |
@@ -45,7 +45,7 @@ runtime. Full sunset (hostdb builds, spindb support table, desktop Intel
 build) is a coordinated ecosystem decision for when GitHub retires Intel
 runners — see the OS Coverage Strategy header in `ci.yml`.
 
-The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`) and `run-e2e.sh` in smoke test mode. It's slow (~30-45 min under emulation), so it is **commented out in ci.yml** — uncomment or run it manually to periodically verify arm64 binaries.
+The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`) and `run-e2e.sh` in smoke test mode. It's slow (~30-45 min under emulation), so it is **gated to `workflow_dispatch`** — trigger CI manually from the Actions tab to run it. The intended cadence is per hostdb bump (step 8 of the bump workflow in CLAUDE.md), since linux-arm64 risk lives in hostdb binaries, not spindb code.
 
 ### Exceptions
 

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.65.0'
+export const VERSION = '0.66.0'

--- a/engines/cockroachdb/version-maps.ts
+++ b/engines/cockroachdb/version-maps.ts
@@ -13,7 +13,8 @@ import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'cockroachdb'
 
-export const COCKROACHDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const COCKROACHDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/couchdb/version-maps.ts
+++ b/engines/couchdb/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'couchdb'
 
-export const COUCHDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const COUCHDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/duckdb/version-maps.ts
+++ b/engines/duckdb/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'duckdb'
 
-export const DUCKDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const DUCKDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/influxdb/version-maps.ts
+++ b/engines/influxdb/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'influxdb'
 
-export const INFLUXDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const INFLUXDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/libsql/version-maps.ts
+++ b/engines/libsql/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'libsql'
 
-export const LIBSQL_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const LIBSQL_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/mariadb/version-maps.ts
+++ b/engines/mariadb/version-maps.ts
@@ -10,16 +10,14 @@
  * '10' and '11' are still resolvable via the MAP (LTS-pick).
  */
 
-import {
-  resolveVersion as hostdbResolveVersion,
-  listVersions,
-} from 'hostdb'
+import { resolveVersion as hostdbResolveVersion, listVersions } from 'hostdb'
 import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'mariadb'
 
-export const MARIADB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const MARIADB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/meilisearch/version-maps.ts
+++ b/engines/meilisearch/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'meilisearch'
 
-export const MEILISEARCH_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const MEILISEARCH_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/mongodb/version-maps.ts
+++ b/engines/mongodb/version-maps.ts
@@ -9,16 +9,14 @@
  * keys '7' and '8' still resolve via the MAP (LTS-pick: '8' → 8.0.23, not 8.2.9).
  */
 
-import {
-  resolveVersion as hostdbResolveVersion,
-  listVersions,
-} from 'hostdb'
+import { resolveVersion as hostdbResolveVersion, listVersions } from 'hostdb'
 import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'mongodb'
 
-export const MONGODB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const MONGODB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/mysql/version-maps.ts
+++ b/engines/mysql/version-maps.ts
@@ -13,10 +13,7 @@
  * the available-versions list; only `enabled: false` removes a version entirely.
  */
 
-import {
-  resolveVersion as hostdbResolveVersion,
-  listVersions,
-} from 'hostdb'
+import { resolveVersion as hostdbResolveVersion, listVersions } from 'hostdb'
 import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 

--- a/engines/postgresql/version-maps.ts
+++ b/engines/postgresql/version-maps.ts
@@ -13,7 +13,8 @@ import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'postgresql'
 
-export const POSTGRESQL_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const POSTGRESQL_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/qdrant/version-maps.ts
+++ b/engines/qdrant/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'qdrant'
 
-export const QDRANT_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const QDRANT_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/questdb/version-maps.ts
+++ b/engines/questdb/version-maps.ts
@@ -13,7 +13,8 @@ import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'questdb'
 
-export const QUESTDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const QUESTDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/sqlite/version-maps.ts
+++ b/engines/sqlite/version-maps.ts
@@ -19,7 +19,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'sqlite'
 
-export const SQLITE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const SQLITE_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/surrealdb/version-maps.ts
+++ b/engines/surrealdb/version-maps.ts
@@ -13,7 +13,8 @@ import { buildVersionMap } from '../version-map-builder'
 
 const ENGINE = 'surrealdb'
 
-export const SURREALDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const SURREALDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/tigerbeetle/version-maps.ts
+++ b/engines/tigerbeetle/version-maps.ts
@@ -8,16 +8,14 @@
  * spindb convention. The 1-part key '0' still resolves via the MAP.
  */
 
-import {
-  resolveVersion as hostdbResolveVersion,
-  listVersions,
-} from 'hostdb'
+import { resolveVersion as hostdbResolveVersion, listVersions } from 'hostdb'
 import { buildVersionMap } from '../version-map-builder'
 import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'tigerbeetle'
 
-export const TIGERBEETLE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const TIGERBEETLE_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = listVersions(ENGINE, {
   format: 'major-minor',

--- a/engines/typedb/version-maps.ts
+++ b/engines/typedb/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'typedb'
 
-export const TYPEDB_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const TYPEDB_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/valkey/version-maps.ts
+++ b/engines/valkey/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'valkey'
 
-export const VALKEY_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const VALKEY_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/engines/weaviate/version-maps.ts
+++ b/engines/weaviate/version-maps.ts
@@ -14,7 +14,8 @@ import { logDebug } from '../../core/error-handler'
 
 const ENGINE = 'weaviate'
 
-export const WEAVIATE_VERSION_MAP: Record<string, string> = buildVersionMap(ENGINE)
+export const WEAVIATE_VERSION_MAP: Record<string, string> =
+  buildVersionMap(ENGINE)
 
 export const SUPPORTED_MAJOR_VERSIONS = getSupportedMajorVersions(ENGINE)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.40.0",
+    "hostdb": "0.41.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.40.0
-        version: 0.40.0
+        specifier: 0.41.0
+        version: 0.41.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.40.0:
-    resolution: {integrity: sha512-e3mLb2CBzHa52iEc1t464Y962rC37UPnnypxO430y5veTYpYuNTK8wRAcJ+9uIhWaXzpQlTRq/lhp0i2w6FfdA==}
+  hostdb@0.41.0:
+    resolution: {integrity: sha512-IeFVgaG1Mzjj9+sqAI9QBe4RrvDWsHaruPCoVtfr8e20OwEIt0rFfhNeYz9mgDzzLhKFCSYQr1fMBsmDCd9rAw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.40.0: {}
+  hostdb@0.41.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/tests/unit/version-utils.test.ts
+++ b/tests/unit/version-utils.test.ts
@@ -113,8 +113,14 @@ describe('parsePrereleaseVersion', () => {
 
   it('returns null for GA versions', () => {
     assert(parsePrereleaseVersion('18.4.0') === null, 'GA is not a prerelease')
-    assert(parsePrereleaseVersion('19') === null, 'bare major is not prerelease')
-    assert(parsePrereleaseVersion('') === null, 'empty string is not prerelease')
+    assert(
+      parsePrereleaseVersion('19') === null,
+      'bare major is not prerelease',
+    )
+    assert(
+      parsePrereleaseVersion('') === null,
+      'empty string is not prerelease',
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

- **Pins hostdb `0.41.0`** (was 0.40.0), adding PostgreSQL **18.6.0** and **19.0.0-beta.3** - the upstream 2026-08-13 security release fixing 28 CVEs (~12 at CVSS 8.8 ACE: regexp heap overflow, cursor type confusion, pg_dump heap overflow, EXTRACT deparse SQLi). 18.5 was skipped upstream.
- **The `18` line now resolves to 18.6.0** (was 18.4.0) - minor bump per policy. 18.1.0/18.4.0 remain resolvable; existing containers self-pin their stored full version, so nothing running is disturbed.
- 19.0.0-beta.3 resolves only by exact token (no `19` prefix match, verified) and is **NOT binary-compatible with beta.1 data dirs**.
- Also carries the two unreleased dev commits (arm64 QEMU smoke job enablement, CHEATSHEET pull-flags docs).

## Verification

- `pnpm test:hostdb-sync` 23/23 (live R2 drift gate), `test:unit` 1735/1735, `test:cli` 54/54, lint + typecheck clean.
- Resolver spot-check: `18 -> 18.6.0`, `18.6 -> 18.6.0`, `19.0.0-beta.3` exact-only, `19 -> null`.
- Version maps rebuilt from the bundled hostdb snapshot - no manual MAP edits.
- The linux-arm64 QEMU smoke job has been dispatched on dev (per-hostdb-bump cadence).

Merging publishes **spindb 0.66.0** to npm, which gates the cloud `SPINDB_VERSION` image bump (next leg of the PG CVE cascade).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.66.0 with support for PostgreSQL 18.6.0 and 19.0.0-beta.3.
  * Added PostgreSQL parallel dump and restore guidance using `--jobs`.
  * Added repeatable table and collection exclusions, including JSON output details and validation rules.
* **Bug Fixes**
  * Improved restore failure reporting and strict `--jobs` validation.
* **Documentation**
  * Expanded large-database examples, supported-engine details, pooler restrictions, and ARM64 testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->