### PR TITLE
feat: PostgreSQL 17.11.0 + 16.15.0 + 15.19.0 via hostdb 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to SpinDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.0] - 2026-08-26
+
+### Added
+
+- **PostgreSQL 17.11.0, 16.15.0, and 15.19.0 support** via the hostdb `0.42.0` pin - the old-major half of the upstream 2026-08-13 security release, the same 28-CVE batch 18.6.0 carried in spindb 0.66.0 (CVE-2026-14664 regexp heap overflow, CVE-2026-16239 cursor type confusion, CVE-2026-19385 pg_dump heap overflow, CVE-2026-15741 EXTRACT deparse SQLi, among others). The 15/16/17 lines were deferred out of that wave and were still resolving to the pre-CVE May 2026 patches. All three ship on all 5 platforms.
+
+### Changed
+
+- **PostgreSQL's `15`, `16`, and `17` lines now resolve to `15.19.0`, `16.15.0`, and `17.11.0`** (were 15.18.0, 16.14.0, 17.10.0): `spindb create -e postgresql --db-version 17` and explicit prefixes like `17.11` get the patched build. The `18` line is unchanged at 18.6.0. 15.15.0, 15.18.0, 16.11.0, 16.14.0, 17.7.0, and 17.10.0 remain resolvable; existing containers self-pin their stored full version, so nothing running is disturbed. Minor bump because the resolved defaults changed.
+- **Pin `hostdb` to `0.42.0`** (was 0.41.0).
+
 ## [0.67.0] - 2026-08-26
 
 ### Fixed

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.67.0'
+export const VERSION = '0.68.0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",
@@ -93,7 +93,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hostdb": "0.41.0",
+    "hostdb": "0.42.0",
     "inquirer": "^9.3.7",
     "inquirer-autocomplete-prompt": "^3.0.1",
     "ora": "^8.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       hostdb:
-        specifier: 0.41.0
-        version: 0.41.0
+        specifier: 0.42.0
+        version: 0.42.0
       inquirer:
         specifier: ^9.3.7
         version: 9.3.8(@types/node@20.19.41)
@@ -876,8 +876,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hostdb@0.41.0:
-    resolution: {integrity: sha512-IeFVgaG1Mzjj9+sqAI9QBe4RrvDWsHaruPCoVtfr8e20OwEIt0rFfhNeYz9mgDzzLhKFCSYQr1fMBsmDCd9rAw==}
+  hostdb@0.42.0:
+    resolution: {integrity: sha512-gjDuhytqoMZvle+r6m/TCcVzZA0sR9KmYoCbrebu0wrJfE6czAtu/9DXiQnpiepSXJVsCDZ3xv6qQfgaHnjvcg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2533,7 +2533,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hostdb@0.41.0: {}
+  hostdb@0.42.0: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
Pins hostdb 0.42.0, completing the Aug 2026 CVE wave for the old major lines: the 17/16/15 defaults move to 17.11.0 / 16.15.0 / 15.19.0 (upstream 2026-08-13 coordinated security release). Existing containers self-pin their stored full version, so nothing running is disturbed. hostdb tarball delta audited: only postgresql changed (3 GA versions added, nothing removed or modified). Real-binary verified from source on darwin-arm64: 17.11 / 16.15 / 15.19 prefix forms each resolve to the .0 patch, boot, and report the right SELECT version(); 18 still resolves 18.6.0. Unit 1756/1756 and hostdb-sync 23/23 green. Per the bump-hostdb workflow, the Docker Linux ARM64 (QEMU) smoke is being dispatched alongside CI since all three source linux-arm64 from Percona.