### PR TITLE
chore(ci): run the QuestDB and FerretDB v1 Windows jobs weekly, not per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,19 @@ permissions:
 #   - ClickHouse, LibSQL: No Windows (no hostdb binaries) → 3 runners
 #   - FerretDB v2: No Windows (its postgresql-documentdb BACKEND has no
 #     win32-x64 hostdb binary; the ferretdb binary itself has one) → 3 runners
-#   - FerretDB v1: all 4 matrix runners including Windows (plain PostgreSQL backend)
+#   - FerretDB v1: plain PostgreSQL backend, so it CAN run on Windows - but its
+#     Windows leg runs weekly instead of per-PR (see below) → 3 runners here
+#   - QuestDB: Windows leg runs weekly instead of per-PR (see below) → 3 runners
 #   - Meilisearch on Windows: backup/restore skipped (upstream page size bug)
+#
+# Windows legs that are NOT on the blocking path (decision 2026-08-26): QuestDB
+# and FerretDB v1 only. They were the two slowest jobs in this matrix - a JVM
+# cold start per test and a full PostgreSQL backend behind a proxy, both on the
+# slowest runner class - and neither has ever failed Windows-specifically, so
+# they moved to .github/workflows/weekly-windows-engines.yml (Mondays + manual
+# dispatch). EVERY OTHER Windows engine job stays blocking: DuckDB Win x64
+# caught a real data-correctness bug the day before this split (C-142), which
+# is precisely what the blocking Windows lane is for. Do not widen the split.
 #
 # Unit tests: 3 runners (ubuntu-24.04, macos-14, windows-latest)
 #
@@ -642,6 +653,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # No windows-latest leg: it moved to weekly-windows-engines.yml
+          # (2026-08-26). It and QuestDB's were the two slowest jobs in this
+          # matrix and neither has ever failed Windows-specifically. The
+          # Windows-only log steps below stay for when this job runs there.
           - os: ubuntu-22.04
             icon: 🐧
             label: Linux x64 22.04
@@ -651,9 +666,6 @@ jobs:
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
-          - os: windows-latest
-            icon: 🪟
-            label: Win x64
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1334,6 +1346,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # No windows-latest leg: it moved to weekly-windows-engines.yml
+          # (2026-08-26). QuestDB pays a JVM cold start per test and Windows is
+          # the slowest runner class, which made this the long pole on every PR
+          # to main. The Windows-only log steps below stay for when this job
+          # runs there.
           - os: ubuntu-22.04
             icon: 🐧
             label: Linux x64 22.04
@@ -1343,9 +1360,6 @@ jobs:
           - os: macos-14
             icon: 🍏
             label: macOS ARM64
-          - os: windows-latest
-            icon: 🪟
-            label: Win x64
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/weekly-windows-engines.yml
+++ b/.github/workflows/weekly-windows-engines.yml
@@ -1,0 +1,197 @@
+name: Weekly Windows Engine Tests
+
+# The Windows halves of the two SLOWEST engine jobs, moved off the blocking
+# path (decision 2026-08-26). QuestDB and FerretDB v1 on windows-latest were
+# the long pole on every PR to main: QuestDB pays a JVM cold start per test and
+# FerretDB v1 boots a full PostgreSQL backend behind its proxy, and Windows is
+# the slowest runner class for both. Weekly is enough for them - neither has
+# ever failed Windows-specifically - while the fast-moving Windows coverage
+# stays where it earns its place.
+#
+# DELIBERATELY NARROW: every other Windows engine job stays in ci.yml's
+# blocking matrix. DuckDB Win x64 caught a real data-correctness bug the day
+# before this split (C-142: an open DuckDB file is locked exclusively on
+# Windows, so the branch copy EBUSY'd where POSIX succeeded), which is exactly
+# the kind of platform-specific defect the blocking Windows lane exists to
+# catch. Do not widen this file without a reason of that weight.
+#
+# Scheduled workflows only run from the DEFAULT branch, so this fires from
+# `main` (released code) and never from `dev`. A failure here shows red in the
+# Actions tab like any other run; there is no alerting wiring by design.
+#
+# The steps below are copies of the `test-questdb` and `test-ferretdb-v1` jobs
+# in ci.yml, pinned to windows-latest. KEEP THEM IN SYNC: when you change how
+# either engine is cached, downloaded, or tested in ci.yml, change it here too.
+
+on:
+  schedule:
+    # Mondays 07:23 UTC. Early in the week so a Windows-only regression is
+    # known before the week's release traffic, and off the hour to avoid the
+    # Actions scheduling stampede.
+    - cron: '23 7 * * 1'
+  workflow_dispatch:
+
+# Nothing here uses GITHUB_TOKEN; least-privilege read-only.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  # ============================================
+  # QuestDB Integration Tests (Windows only)
+  # Mirror of ci.yml's `test-questdb`, windows-latest leg.
+  # ============================================
+  test-questdb-windows:
+    name: QuestDB 🪟 Win x64
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cache QuestDB binaries - these are downloaded from hostdb
+      # Cache key v2: bust cache after fixing extraction logic
+      - name: Cache QuestDB binaries
+        uses: actions/cache@v5
+        id: questdb-cache
+        with:
+          path: ~/.spindb/bin
+          key: spindb-questdb-9-${{ runner.os }}-${{ runner.arch }}-v2
+
+      # Use SpinDB to download QuestDB binaries
+      - name: Install QuestDB via SpinDB
+        run: pnpm start engines download questdb 9
+
+      # Download PostgreSQL for psql (used for QuestDB connectivity)
+      - name: Install PostgreSQL via SpinDB (for psql)
+        run: pnpm start engines download postgresql 17
+
+      - name: Show installed engines
+        run: pnpm start engines list
+
+      - name: Run QuestDB integration tests
+        run: pnpm test:engine questdb
+        timeout-minutes: 15
+
+      - name: Show QuestDB logs on failure (Unix)
+        if: failure() && runner.os != 'Windows'
+        run: |
+          echo "=== QuestDB container directories ==="
+          ls -la ~/.spindb/containers/questdb/ 2>/dev/null || echo "No QuestDB containers directory"
+          echo ""
+          echo "=== QuestDB binary directory ==="
+          ls -la ~/.spindb/bin/ 2>/dev/null | grep -i quest || echo "No QuestDB binaries found"
+          echo ""
+          echo "=== QuestDB log files ==="
+          find ~/.spindb/containers/questdb -name "*.log" -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "No log files found"
+
+      - name: Show QuestDB logs on failure (Windows)
+        if: failure() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "=== QuestDB container directories ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\containers\questdb" -ErrorAction SilentlyContinue | Format-Table -AutoSize
+          Write-Host ""
+          Write-Host "=== QuestDB binary directory ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\bin" -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'quest' } | Format-Table -AutoSize
+          Write-Host ""
+          Write-Host "=== QuestDB log files ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\containers\questdb" -Filter "*.log" -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "--- $($_.FullName) ---"
+            Get-Content $_.FullName -ErrorAction SilentlyContinue
+          }
+
+  # ============================================
+  # FerretDB v1 Integration Tests (Windows only)
+  # Mirror of ci.yml's `test-ferretdb-v1`, windows-latest leg.
+  # v1 uses a plain PostgreSQL backend (no DocumentDB), which is why it has a
+  # Windows leg at all - FerretDB v2's postgresql-documentdb backend has no
+  # win32-x64 hostdb binary.
+  # ============================================
+  test-ferretdb-v1-windows:
+    name: FerretDB v1 🪟 Win x64
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Cache FerretDB v1 binaries - ferretdb proxy + plain PostgreSQL
+      - name: Cache FerretDB v1 binaries
+        uses: actions/cache@v5
+        id: ferretdb-v1-cache
+        with:
+          path: ~/.spindb/bin
+          key: spindb-ferretdb-1-pg-17-${{ runner.os }}-${{ runner.arch }}
+
+      # Download FerretDB v1 binaries (proxy only, backend is plain PostgreSQL)
+      - name: Download FerretDB v1 binaries
+        run: pnpm start engines download ferretdb 1
+
+      # FerretDB uses mongosh (MongoDB shell) for connect/run commands
+      # Download MongoDB binaries to get bundled mongosh
+      - name: Download MongoDB binaries (for mongosh)
+        run: pnpm start engines download mongodb 8.0
+
+      - name: Show installed engines
+        run: pnpm start engines list
+
+      - name: Run FerretDB v1 integration tests
+        run: pnpm test:engine ferretdb-v1
+        timeout-minutes: 20
+
+      - name: Show FerretDB v1 logs on failure (Unix)
+        if: failure() && runner.os != 'Windows'
+        run: |
+          echo "=== FerretDB container directories ==="
+          ls -la ~/.spindb/containers/ferretdb/ 2>/dev/null || echo "No FerretDB containers directory"
+          echo ""
+          echo "=== FerretDB binary directory ==="
+          ls -la ~/.spindb/bin/ 2>/dev/null | grep -iE "(ferret|postgresql)" || echo "No FerretDB binaries found"
+          echo ""
+          echo "=== FerretDB log files ==="
+          find ~/.spindb/containers/ferretdb -name "*.log" -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "No log files found"
+          echo ""
+          echo "=== PostgreSQL backend log files ==="
+          find ~/.spindb/containers/ferretdb -name "postgresql*.log" -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "No PostgreSQL log files found"
+
+      - name: Show FerretDB v1 logs on failure (Windows)
+        if: failure() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "=== FerretDB container directories ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\containers\ferretdb" -Recurse -ErrorAction SilentlyContinue | Select-Object FullName
+          Write-Host ""
+          Write-Host "=== FerretDB binary directory ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\bin" -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*ferret*" -or $_.Name -like "*postgresql*" } | Select-Object FullName
+          Write-Host ""
+          Write-Host "=== FerretDB log files ==="
+          Get-ChildItem -Path "$env:USERPROFILE\.spindb\containers\ferretdb" -Filter "*.log" -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "--- $($_.FullName) ---"
+            Get-Content $_.FullName -ErrorAction SilentlyContinue
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to SpinDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.3] - 2026-08-26
+
+### Changed
+
+- **CI: the QuestDB and FerretDB v1 Windows jobs moved off the blocking matrix to a weekly schedule.** They were the two slowest jobs on every PR to main - QuestDB pays a JVM cold start per test, FerretDB v1 boots a full PostgreSQL backend behind its proxy, and Windows is the slowest runner class for both - and neither has ever failed Windows-specifically. They now run from `.github/workflows/weekly-windows-engines.yml` on Mondays at 07:23 UTC plus manual dispatch, and a failure shows red in the Actions tab. Their Linux and macOS legs are untouched and still blocking, so the `CI Success` gate still waits on both jobs; it just no longer waits on their Windows halves. **Deliberately narrow:** every other Windows engine job stays blocking. The DuckDB Windows job caught a real data-correctness bug the day before this split (0.68.2, C-142), which is exactly what that lane is for. No product code changed.
+
 ## [0.68.2] - 2026-08-26
 
 ### Fixed

--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -54,6 +54,22 @@ The linux-arm64 QEMU job reuses the Docker E2E image (`tests/docker/Dockerfile`)
 | ClickHouse | 3 (no Windows) | No hostdb binary for Windows |
 | FerretDB | 3 (no Windows) | postgresql-documentdb has startup issues on Windows |
 | Meilisearch | 4 (backup/restore skipped on Windows) | Upstream page size alignment bug |
+| QuestDB | 3 blocking + Windows weekly | Slowest job in the matrix (JVM cold start per test on the slowest runner class) |
+| FerretDB v1 | 3 blocking + Windows weekly | Second slowest (full PostgreSQL backend behind the proxy) |
+
+QuestDB and FerretDB v1 are the **only** two engines whose Windows leg is off
+the blocking path. It runs weekly instead, from
+`.github/workflows/weekly-windows-engines.yml` (Mondays 07:23 UTC plus manual
+dispatch), because those two dominated PR wall-clock time and neither has ever
+failed Windows-specifically. Every other Windows engine job stays blocking, and
+that is not a formality: the DuckDB Windows job caught a real data-correctness
+bug the day before the split (C-142 - an open DuckDB file is locked exclusively
+on Windows, so the branch copy failed with EBUSY where POSIX succeeded). Widen
+the split only for a job that is both slow and has never found anything.
+
+Because scheduled workflows run only from the default branch, the weekly run
+tests `main`, not `dev`. A failure shows red in the Actions tab; there is no
+alerting wiring.
 
 **Unit tests** run on 3 runners in ci.yml (ubuntu-24.04, macos-14, windows-latest).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.68.2",
+  "version": "0.68.3",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",


### PR DESCRIPTION
Bob's decision: the two slowest Windows jobs come off the blocking path.

## What moved

Only the **`windows-latest` matrix leg** of `test-questdb` and `test-ferretdb-v1`. They were the long pole on every PR to main: QuestDB pays a JVM cold start per test, FerretDB v1 boots a full PostgreSQL backend behind its proxy, and Windows is the slowest runner class for both. Neither has ever failed Windows-specifically.

They now live in `.github/workflows/weekly-windows-engines.yml`, on **Mondays 07:23 UTC** plus `workflow_dispatch` (off the hour to dodge the Actions scheduling stampede). A failure shows red in the Actions tab like any other run; no alerting wiring, as asked.

## What did NOT move

Everything else. Verified mechanically rather than by eye - parsing both versions of `ci.yml` and diffing every job's runner set shows **exactly two jobs changed**:

```
test-ferretdb-v1  [macos-14, ubuntu-22.04, ubuntu-24.04, windows-latest] -> [macos-14, ubuntu-22.04, ubuntu-24.04]
test-questdb      [macos-14, ubuntu-22.04, ubuntu-24.04, windows-latest] -> [macos-14, ubuntu-22.04, ubuntu-24.04]
jobs changed: 2
```

DuckDB, SQLite and every other Windows engine job keep their blocking leg. That is not a formality: **the DuckDB Windows job caught a real data-correctness bug the day before this split** (0.68.2 / C-142 - an open DuckDB file is locked exclusively on Windows, so the branch copy failed with EBUSY where POSIX succeeded). Widen this split only for a job that is both slow *and* has never found anything.

## The aggregate gate

`ci-success` still `needs:` both `test-questdb` and `test-ferretdb-v1` - their Linux and macOS legs are untouched and still blocking. It simply no longer waits on the Windows halves, because those legs no longer exist in that workflow. **No change to the gate itself was required**, and none was made. Confirmed programmatically:

```
aggregate job: ci-success
gate needs questdb: True
gate needs ferretdb-v1: True
```

Existing check names are unchanged for every remaining leg, so nothing referenced by branch protection is renamed.

## Drift

The two weekly jobs' steps are **byte-identical copies** of the ci.yml originals - asserted by parsing both files and comparing the step lists (`steps identical: True`, 11 steps each), not by reading the diff. Both files carry a cross-reference telling the next person to change them together, and the ci.yml matrices carry an inline note saying where the Windows leg went and why.

The Windows-only log-dump steps stay in the ci.yml jobs. They are inert (`if: failure() && runner.os == 'Windows'`) and keeping them means re-adding a Windows leg later is a one-line change.

## Versioning

`0.68.2 -> 0.68.3`, CHANGELOG entry under `### Changed` prefixed `CI:`. **Why a bump for a CI-only change:** the repo has direct precedent - 0.64.1 was the darwin-x64 demotion and 0.65.0 carried the arm64-QEMU gating, both CI-only, both versioned entries in the same shape. And it is load-bearing here, not ceremonial: `version-check.yml` blocks any PR to main whose version is not greater than npm's, and 0.68.2 published this afternoon, so the next `dev -> main` needs 0.68.3 regardless of who bumps it.

`TESTING_STRATEGY.md`'s exceptions table and the OS Coverage Strategy header in `ci.yml` both record the split, since that is where the 0.64.1 entry says this class of rationale belongs.

## Checks

`actionlint` clean on the new workflow; the warnings it reports on `ci.yml` (SC2010, SC2034) are all pre-existing and untouched by this change. Prettier clean. Both files parse as valid YAML with the expected jobs, runners and cron. No product code changed, so there is nothing to test beyond CI itself.
