### PR TITLE
release: 0.68.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to SpinDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.68.4] - 2026-09-01
+
+### Fixed
+
+- **A remote MySQL dump from a GTID-enabled source now restores as a normal user instead of failing on `SET @@GLOBAL.GTID_PURGED`.** `spindb pull` and the remote-URL backup paths built their `mysqldump` invocation without `--set-gtid-purged=OFF`, so a dump taken from a managed MySQL that runs with GTIDs on (Aiven documents requiring this flag, and it is the norm across managed MySQL) embedded a `SET @@GLOBAL.GTID_PURGED` statement in the output. Replaying that statement takes privileges a normal application user does not have, so the restore into a spindb container failed on a dump that had itself succeeded, with an error that named GTIDs rather than the flag that caused it. The local backup path in `engines/mysql/backup.ts` has always passed the flag; the remote path simply never got it.
+- **A remote MySQL dump no longer locks the source tables while it reads them.** The same invocation was missing `--single-transaction`, so a dump from a live database held read locks for its whole duration instead of reading from one consistent InnoDB snapshot. Both flags are MySQL-only: `mariadb-dump` rejects `--set-gtid-purged`, and MariaDB builds its own arguments, so nothing changed for that engine.
+- **A Heroku Redis URL with the legacy `h` username now authenticates.** Heroku's classic Redis add-on minted URLs shaped like `rediss://h:<password>@host:port`, where `h` is a placeholder rather than an ACL user. The RESP client treated any username other than `default` as real and sent `AUTH h <password>`, which those servers reject with `WRONGPASS` even though the password is correct. A lone `h` is now handled the same way an absent username already was, with a one-argument `AUTH`. Modern Heroku Key-Value URLs leave the username empty and were never affected, and every other username, including a real ACL user whose name merely starts with `h`, is unchanged.
+
 ## [0.68.3] - 2026-08-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,8 @@ The focused March 28, 2026 auth sweep passed sequentially for all of the engines
 - remote connection-string query path (`dumpFromConnectionString`)
 - local/linked query execution path (`executeQuery`)
 
+**Heroku's legacy `h` username is not an ACL user:** the classic Redis add-on minted URLs shaped like `rediss://h:<password>@host:port`, where `h` is a dummy placeholder (modern Heroku Key-Value URLs leave the username empty). `AUTH h <password>` fails with `WRONGPASS` on those servers, so `buildRespAuthArgs()` in `engines/redis/resp-client.ts` treats a lone `h` like an absent username and sends the one-argument `AUTH`. The redis-cli paths (`shouldPassRedisCliUsername()`) still only special-case `default`; if a Heroku URL ever fails auth through `redis-cli` rather than the RESP client, that helper is the place to look.
+
 **When debugging Redis/Valkey query auth, test both paths:** a change can fix remote URL queries and still break local container queries, or vice versa. The cloud incident on March 26-27, 2026 only became clear after checking both the cloud-managed local container path and the remote URL path.
 
 **Spawning background server processes:** MUST use `stdio: ['ignore', 'ignore', 'ignore']` for detached processes. Using `'pipe'` keeps file descriptors open, preventing Node.js exit even after `proc.unref()`. Causes `spindb start` to hang in Docker/CI. All 19 server engines now follow this rule (FerretDB was the last to be fixed in 0.43.0).

--- a/config/version.ts
+++ b/config/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated — do not edit manually
-export const VERSION = '0.68.0'
+export const VERSION = '0.68.4'

--- a/engines/mysql/index.ts
+++ b/engines/mysql/index.ts
@@ -140,6 +140,55 @@ export function buildMysqlInlineCommand(
   }
 }
 
+/**
+ * Build the mysqldump argument list for a dump taken from a remote connection
+ * string. Exported for unit testing: the flags are the whole contract here, so
+ * the test asserts the built array rather than running mysqldump.
+ *
+ * Two flags matter beyond the connection details, and both match what the
+ * local backup path in `backup.ts` already passes:
+ * - `--set-gtid-purged=OFF` keeps `SET @@GLOBAL.GTID_PURGED` out of the dump.
+ *   A GTID-enabled source (Aiven documents requiring this flag; managed MySQL
+ *   generally) otherwise writes a statement only a superuser can replay, so
+ *   the restore fails on the target.
+ * - `--single-transaction` takes the dump inside one consistent InnoDB
+ *   snapshot instead of locking the source tables while it reads them.
+ *
+ * `--set-gtid-purged` is mysqldump-only: mariadb-dump rejects it outright, so
+ * MariaDB builds its own arguments in `engines/mariadb/index.ts` and must
+ * never reuse this builder.
+ */
+export function buildMysqlRemoteDumpArgs(options: {
+  host: string
+  port: string
+  user: string
+  database: string
+  outputPath: string
+  excludeTables?: string[]
+}): string[] {
+  const { host, port, user, database, outputPath, excludeTables } = options
+
+  return [
+    '-h',
+    host,
+    '-P',
+    port,
+    '-u',
+    user,
+    '--single-transaction', // Consistent snapshot without locking the source
+    '--set-gtid-purged=OFF', // Allows restoring to different MySQL instances
+    '--result-file',
+    outputPath,
+    // mysqldump requires db-qualified names; qualify bare names with the
+    // database being dumped
+    ...(excludeTables ?? []).map(
+      (table) =>
+        `--ignore-table=${table.includes('.') ? table : `${database}.${table}`}`,
+    ),
+    database,
+  ]
+}
+
 export class MySQLEngine extends BaseEngine {
   name = ENGINE
   displayName = 'MySQL'
@@ -1056,23 +1105,14 @@ export class MySQLEngine extends BaseEngine {
     const { host, port, user, password, database } =
       parseConnectionString(connectionString)
 
-    const args = [
-      '-h',
+    const args = buildMysqlRemoteDumpArgs({
       host,
-      '-P',
       port,
-      '-u',
       user,
-      '--result-file',
-      outputPath,
-      // mysqldump requires db-qualified names; qualify bare names with the
-      // database being dumped
-      ...(options?.excludeTables ?? []).map(
-        (table) =>
-          `--ignore-table=${table.includes('.') ? table : `${database}.${table}`}`,
-      ),
       database,
-    ]
+      outputPath,
+      excludeTables: options?.excludeTables,
+    })
 
     const spawnOptions: SpawnOptions = {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/engines/redis/resp-client.ts
+++ b/engines/redis/resp-client.ts
@@ -102,6 +102,27 @@ export type RespConnectOptions = {
   connectTimeoutMs?: number
 }
 
+// Usernames that name no real ACL user, so AUTH must be sent in its
+// one-argument form (`AUTH <password>`) instead of `AUTH <user> <password>`.
+//
+// - `default` is Redis's implicit ACL user, which `requirepass`-only servers
+//   reject when it is passed explicitly.
+// - `h` is Heroku's legacy convention: the classic Redis add-on minted URLs
+//   like `rediss://h:<password>@host:port` where `h` is a dummy placeholder,
+//   not an account. (Modern Heroku Key-Value URLs leave the username empty.)
+//   Sending `AUTH h <password>` to those servers fails with WRONGPASS.
+const IMPLICIT_RESP_USERNAMES = new Set(['default', 'h'])
+
+// Build the AUTH command for a connection. Exported for unit testing.
+export function buildRespAuthArgs(
+  password: string,
+  username?: string,
+): string[] {
+  return username && !IMPLICIT_RESP_USERNAMES.has(username)
+    ? ['AUTH', username, password]
+    : ['AUTH', password]
+}
+
 export class RespClient {
   private socket: Socket
   private inbox: Buffer = Buffer.alloc(0)
@@ -198,11 +219,7 @@ export class RespClient {
 
     const client = new RespClient(socket)
     if (opts.password) {
-      const authArgs =
-        opts.username && opts.username !== 'default'
-          ? ['AUTH', opts.username, opts.password]
-          : ['AUTH', opts.password]
-      await client.command(authArgs)
+      await client.command(buildRespAuthArgs(opts.password, opts.username))
     }
     if (opts.database && opts.database > 0) {
       await client.command(['SELECT', String(opts.database)])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spindb",
-  "version": "0.68.3",
+  "version": "0.68.4",
   "author": "Bob Bass <bob@bbass.co>",
   "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Zero-config Docker-free local database containers. Create, backup, and clone a variety of popular databases.",

--- a/tests/unit/mysql-remote-dump-args.test.ts
+++ b/tests/unit/mysql-remote-dump-args.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test'
+import { buildMysqlRemoteDumpArgs } from '../../engines/mysql/index'
+import { assert, assertDeepEqual, assertEqual } from '../utils/assertions'
+
+const baseOptions = {
+  host: 'mysql.example.com',
+  port: '3306',
+  user: 'avnadmin',
+  database: 'appdb',
+  outputPath: '/tmp/appdb.sql',
+}
+
+describe('MySQL remote dump args', () => {
+  it('disables GTID_PURGED so a managed source restores elsewhere', () => {
+    const args = buildMysqlRemoteDumpArgs(baseOptions)
+
+    assert(
+      args.includes('--set-gtid-purged=OFF'),
+      'remote dumps must suppress SET @@GLOBAL.GTID_PURGED, which only a superuser can replay',
+    )
+  })
+
+  it('takes the dump in a single transaction', () => {
+    const args = buildMysqlRemoteDumpArgs(baseOptions)
+
+    assert(
+      args.includes('--single-transaction'),
+      'remote dumps must use a consistent snapshot instead of locking the source',
+    )
+  })
+
+  it('builds the full argument list in order', () => {
+    assertDeepEqual(
+      buildMysqlRemoteDumpArgs(baseOptions),
+      [
+        '-h',
+        'mysql.example.com',
+        '-P',
+        '3306',
+        '-u',
+        'avnadmin',
+        '--single-transaction',
+        '--set-gtid-purged=OFF',
+        '--result-file',
+        '/tmp/appdb.sql',
+        'appdb',
+      ],
+      'remote dump args should match the expected mysqldump invocation',
+    )
+  })
+
+  it('qualifies bare excluded table names with the dumped database', () => {
+    const args = buildMysqlRemoteDumpArgs({
+      ...baseOptions,
+      excludeTables: ['sessions', 'other.audit_log'],
+    })
+
+    assert(
+      args.includes('--ignore-table=appdb.sessions'),
+      'bare table names should be qualified with the database being dumped',
+    )
+    assert(
+      args.includes('--ignore-table=other.audit_log'),
+      'already-qualified table names should be passed through unchanged',
+    )
+    assertEqual(
+      args[args.length - 1],
+      'appdb',
+      'the database must stay the final positional argument',
+    )
+  })
+})

--- a/tests/unit/redis-resp-auth.test.ts
+++ b/tests/unit/redis-resp-auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import { buildRespAuthArgs } from '../../engines/redis/resp-client'
+import { assertDeepEqual } from '../utils/assertions'
+
+describe('RESP AUTH args', () => {
+  it('sends a one-argument AUTH for Heroku legacy dummy usernames', () => {
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret', 'h'),
+      ['AUTH', 's3cret'],
+      'Heroku classic URLs carry a placeholder "h" username that is not an ACL user',
+    )
+  })
+
+  it('sends a one-argument AUTH for the implicit default user', () => {
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret', 'default'),
+      ['AUTH', 's3cret'],
+      'requirepass-only servers reject an explicit default user',
+    )
+  })
+
+  it('sends a one-argument AUTH when no username is present', () => {
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret'),
+      ['AUTH', 's3cret'],
+      'a missing username should not be invented',
+    )
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret', ''),
+      ['AUTH', 's3cret'],
+      'an empty username should not be invented',
+    )
+  })
+
+  it('sends a two-argument AUTH for real ACL users', () => {
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret', 'appuser'),
+      ['AUTH', 'appuser', 's3cret'],
+      'explicit ACL users must still be authenticated by name',
+    )
+  })
+
+  it('keeps usernames that merely start with h', () => {
+    assertDeepEqual(
+      buildRespAuthArgs('s3cret', 'hasura'),
+      ['AUTH', 'hasura', 's3cret'],
+      'only a lone "h" is the Heroku placeholder',
+    )
+  })
+})


### PR DESCRIPTION
Release `0.68.4`. Merging this to `main` triggers the npm OIDC publish.

Two hardening fixes, both shipped via #303 (CI Fast green: lint, unit, docker-export).

### Fixed

- **MySQL remote dumps from a GTID-enabled source.** `dumpFromConnectionString` built its `mysqldump` args without `--set-gtid-purged=OFF`, so a dump from a managed MySQL running with GTIDs on embedded `SET @@GLOBAL.GTID_PURGED` and the restore failed for any non-superuser. The local backup path in `engines/mysql/backup.ts` has always passed the flag. `--single-transaction` was added at the same time so a remote dump reads from a consistent InnoDB snapshot instead of locking the source. Both are mysqldump-only; MariaDB builds its own args and is untouched.
- **Heroku's legacy `h` Redis username.** The RESP client sent `AUTH h <password>` for classic Heroku URLs (`rediss://h:<password>@host`), where `h` is a placeholder rather than an ACL user, so those connections failed with `WRONGPASS`. A lone `h` now uses the one-argument `AUTH`. Modern Heroku Key-Value URLs leave the username empty and were never affected.

New unit coverage: `tests/unit/mysql-remote-dump-args.test.ts`, `tests/unit/redis-resp-auth.test.ts`. Full unit suite 1769 passing; `pnpm test:engine mysql` and `pnpm test:engine redis` green locally against real binaries.

Downstream after publish: `layerbase-cloud` (`package.json` `"spindb"`, `images/Dockerfile.base` `ARG SPINDB_VERSION`) and `layerbase-desktop` (`package.json` `"spindb"`) both still pin `0.68.2` and need their own bump PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remote MySQL backups now restore reliably from GTID-enabled sources.
  - Backups use consistent snapshots without holding read locks on source tables.
  - Redis connections using Heroku’s legacy credentials now authenticate successfully.
  - Explicit Redis ACL usernames remain supported.

- **Documentation**
  - Added guidance for troubleshooting legacy Redis authentication behavior.

- **Release**
  - Updated the application version to 0.68.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->